### PR TITLE
Fix for zero era problem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5455,7 +5455,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-dapps-staking"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9658,7 +9658,7 @@ dependencies = [
 
 [[package]]
 name = "shibuya-runtime"
-version = "2.6.6"
+version = "2.6.7"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -9726,7 +9726,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "2.6.6"
+version = "2.6.7"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/frame/dapps-staking/Cargo.toml
+++ b/frame/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-dapps-staking"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 homepage = "https://astar.network/"

--- a/frame/dapps-staking/src/mock.rs
+++ b/frame/dapps-staking/src/mock.rs
@@ -31,6 +31,7 @@ pub(crate) const MINIMUM_STAKING_AMOUNT: Balance = 10;
 pub(crate) const DEVELOPER_REWARD_PERCENTAGE: u32 = 80;
 pub(crate) const HISTORY_DEPTH: u32 = 30;
 
+// Do note that this needs to at least be 3 for tests to be valid. It can be greater but not smaller.
 pub(crate) const BLOCKS_PER_ERA: BlockNumber = 3;
 
 pub(crate) const REGISTER_DEPOSIT: Balance = 10;

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -235,15 +235,18 @@ pub mod pallet {
         fn on_initialize(now: BlockNumberFor<T>) -> Weight {
             let force_new_era = Self::force_era().eq(&Forcing::ForceNew);
             let blocks_per_era = T::BlockPerEra::get();
+            let previous_era = Self::current_era();
 
             // Value is compared to 1 since genesis block is ignored
-            if now % blocks_per_era == 1u32.into() || force_new_era {
-                let era = Self::current_era();
-                let next_era = era + 1;
+            if now % blocks_per_era == BlockNumberFor::<T>::from(1u32)
+                || force_new_era
+                || previous_era.is_zero()
+            {
+                let next_era = previous_era + 1;
                 CurrentEra::<T>::put(next_era);
 
                 let reward = BlockRewardAccumulator::<T>::take();
-                Self::reward_balance_snapshoot(era, reward);
+                Self::reward_balance_snapshoot(previous_era, reward);
 
                 if force_new_era {
                     ForceEra::<T>::put(Forcing::ForceNone);

--- a/frame/dapps-staking/src/tests.rs
+++ b/frame/dapps-staking/src/tests.rs
@@ -391,6 +391,22 @@ fn unregister_stake_and_unstake_is_not_ok() {
 }
 
 #[test]
+fn on_initialize_when_dapp_staking_enabled_in_mid_of_an_era_is_ok() {
+    ExternalityBuilder::build().execute_with(|| {
+        // Set a block number in mid of an era
+        System::set_block_number(2);
+
+        // Verify that current era is 0 since dapps staking hasn't been initialized yet
+        assert_eq!(0u32, DappsStaking::current_era());
+
+        // Call on initialize in the mid of an era (according to block number calculation)
+        // but since no era was initialized before, it will trigger a new era init.
+        DappsStaking::on_initialize(System::block_number());
+        assert_eq!(1u32, DappsStaking::current_era());
+    })
+}
+
+#[test]
 fn bond_and_stake_different_eras_is_ok() {
     ExternalityBuilder::build().execute_with(|| {
         initialize_first_block();

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "2.6.6"
+version = "2.6.7"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 build = "build.rs"

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -93,7 +93,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shibuya"),
     impl_name: create_runtime_str!("shibuya"),
     authoring_version: 1,
-    spec_version: 13,
+    spec_version: 14,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "2.6.6"
+version = "2.6.7"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 build = "build.rs"

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -92,7 +92,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shiden"),
     impl_name: create_runtime_str!("shiden"),
     authoring_version: 1,
-    spec_version: 22,
+    spec_version: 23,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./.github/CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] all tests passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] changed API client type definition or chain metadata

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

## Affected core subsystem(s)
Dapps staking

## Description of change
Fixed an issue where 1st era wouldn't be triggered if dapps staking
is enabled in mid of what would numerically be an era.

This caused some storage to remain uninitialized which caused dapps staking not to work properly.

* * *
