### PR TITLE
Add contract and era to dapp staking Reward event

### DIFF
--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -193,7 +193,7 @@ pub mod pallet {
         /// The contract's reward have been claimed for era.
         ContractClaimed(T::SmartContract, EraIndex, BalanceOf<T>),
         /// Reward paid to staker.
-        Reward(T::AccountId, BalanceOf<T>),
+        Reward(T::SmartContract, EraIndex, T::AccountId, BalanceOf<T>),
     }
 
     #[pallet::error]
@@ -562,6 +562,8 @@ pub mod pallet {
                 reward_pool.split(T::DeveloperRewardPercentage::get() * contract_reward);
 
             Self::deposit_event(Event::<T>::Reward(
+                contract_id.clone(),
+                era,
                 developer.clone(),
                 developer_reward.peek(),
             ));
@@ -575,7 +577,12 @@ pub mod pallet {
                     stakers_reward.split(ratio * stakers_total_reward);
                 stakers_reward = new_stakers_reward;
 
-                Self::deposit_event(Event::<T>::Reward(staker.clone(), reward.peek()));
+                Self::deposit_event(Event::<T>::Reward(
+                    contract_id.clone(),
+                    era,
+                    staker.clone(),
+                    reward.peek(),
+                ));
                 T::Currency::resolve_creating(staker, reward);
             }
 


### PR DESCRIPTION
**Pull Request Summary**
Closes https://github.com/PlasmNetwork/Astar/issues/491.

> I want `T::SmartContract` and `EraIndex` on `Reward(T::AccountId, BalanceOf<T>)` event of the dApp staking pallet. It makes tracking reward claims easier for me. Without them, we can't find out what the reward belongs to with the event itself.

I hope https://github.com/PlasmNetwork/Astar/pull/480 is not deployed yet.

**Check list**
- [x] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] updated spec version
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tests and/or benchmarks are included
- [ ] changed API client type definition or chain metadata

**This pull request makes the following changes:**

**Changes**
- Change Reward event
