### PR TITLE
Short retention for benchmarking binary.

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -59,7 +59,7 @@ jobs:
       with:
         name: astar-runtime-benchmarks
         path: target/release/astar-collator
-        retention-days: 7
+        retention-days: 1
 
   try-runtime:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -59,6 +59,7 @@ jobs:
       with:
         name: astar-runtime-benchmarks
         path: target/release/astar-collator
+        retention-days: 7
 
   try-runtime:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Pull Request Summary**

> Reduced retention for benchmarking binary

Reduced to 1 day. No need for it to take unnecessary space for more days.
This job is useful if you want to outsource binary building to the CI instead
of building it on your own machine.

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] updated spec version
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tests and/or benchmarks are included
- [ ] changed API client type definition or chain metadata
