### PR TITLE
Dev type chains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "astar-collator"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "astar-runtime",
  "async-trait",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "astar-runtime"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -4252,7 +4252,7 @@ dependencies = [
 
 [[package]]
 name = "local-runtime"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "evm",
  "fp-rpc",
@@ -9234,7 +9234,7 @@ dependencies = [
 
 [[package]]
 name = "shibuya-runtime"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -9302,7 +9302,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "3.2.2"
+version = "3.2.3"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/bin/collator/Cargo.toml
+++ b/bin/collator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-collator"
-version = "3.2.2"
+version = "3.2.3"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Astar collator implementation in Rust."
 build = "build.rs"

--- a/bin/collator/src/parachain/chain_spec/astar.rs
+++ b/bin/collator/src/parachain/chain_spec/astar.rs
@@ -76,7 +76,7 @@ pub fn get_chain_spec(para_id: u32) -> AstarChainSpec {
     AstarChainSpec::from_genesis(
         "Astar Testnet",
         "astar",
-        ChainType::DevelopmentDevelopment,
+        ChainType::Development,
         move || make_genesis(endowned.clone(), sudo_key.clone(), para_id.into()),
         vec![],
         None,

--- a/bin/collator/src/parachain/chain_spec/astar.rs
+++ b/bin/collator/src/parachain/chain_spec/astar.rs
@@ -76,7 +76,7 @@ pub fn get_chain_spec(para_id: u32) -> AstarChainSpec {
     AstarChainSpec::from_genesis(
         "Astar Testnet",
         "astar",
-        ChainType::Live,
+        ChainType::DevelopmentDevelopment,
         move || make_genesis(endowned.clone(), sudo_key.clone(), para_id.into()),
         vec![],
         None,

--- a/bin/collator/src/parachain/chain_spec/shibuya.rs
+++ b/bin/collator/src/parachain/chain_spec/shibuya.rs
@@ -35,7 +35,7 @@ pub fn get_chain_spec(para_id: u32) -> ShibuyaChainSpec {
     ShibuyaChainSpec::from_genesis(
         "Shibuya Testnet",
         "shibuya",
-        ChainType::Live,
+        ChainType::Development,
         move || make_genesis(endowned.clone(), sudo_key.clone(), para_id.into()),
         vec![],
         None,

--- a/bin/collator/src/parachain/chain_spec/shiden.rs
+++ b/bin/collator/src/parachain/chain_spec/shiden.rs
@@ -30,7 +30,7 @@ pub fn get_chain_spec(para_id: u32) -> ShidenChainSpec {
     ShidenChainSpec::from_genesis(
         "Shiden Testnet",
         "shiden",
-        ChainType::Live,
+        ChainType::Development,
         move || make_genesis(endowned.clone(), sudo_key.clone(), para_id.into()),
         vec![],
         None,

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-runtime"
-version = "3.2.2"
+version = "3.2.3"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 build = "build.rs"

--- a/runtime/local/Cargo.toml
+++ b/runtime/local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-runtime"
-version = "3.2.2"
+version = "3.2.3"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 build = "build.rs"

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "3.2.2"
+version = "3.2.3"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 build = "build.rs"

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "3.2.2"
+version = "3.2.3"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 build = "build.rs"

--- a/third-party/polkadot-launch/config.json
+++ b/third-party/polkadot-launch/config.json
@@ -30,7 +30,7 @@
 					"configuration": {
 						"config": {
 							"validation_upgrade_frequency": 1,
-							"validation_upgrade_delay": 1
+							"validation_upgrade_delay": 10
 						}
 					}
 				}
@@ -40,21 +40,21 @@
 	"parachains": [
 		{
 			"bin": "./bin/astar-collator",
-			"id": "200",
- 			"chain": "testnet",
+			"id": "2007",
+ 			"chain": "shibuya-dev",
 			"balance": "1000000000000000000000",
 			"nodes": [
 				{
 					"wsPort": 9988,
 					"port": 31200,
 					"name": "alice",
-					"flags": ["--force-authoring", "--unsafe-ws-external", "--unsafe-rpc-external", "--rpc-port=8545", "--rpc-cors=all", "--", "--execution=wasm"]
+					"flags": ["--unsafe-ws-external", "--unsafe-rpc-external", "--rpc-port=8545", "--rpc-cors=all", "--", "--execution=wasm"]
 				},
 				{
 					"wsPort": 9989,
 					"port": 31201,
 					"name": "bob",
-					"flags": ["--force-authoring", "--", "--execution=wasm"]
+					"flags": ["--", "--execution=wasm"]
 				}
 			]
 		}


### PR DESCRIPTION
**Pull Request Summary**

Changed dev chains to be of `Development` type.
This allows all accounts to be accessible directly via Polkadot.js
app.

This is required to work with polkadot-launch tool.
Additionally, following changes were needed to make it work:

- in polkadot-launch
  - modify `spawn.ts` file, function `startCollator` to exclude argument `--collator`
- when using template Astar/third-party/polkadot-launch/config.json
  - set chain to `shibuya-dev` if testing shibuya
  - set id to `2007` since that is the default parachain Id used by our binary (it's actually shiden id)
  - remove `--force-authoring` as argument because polkadot-launch will add it without prior check 

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] updated spec version
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tests and/or benchmarks are included
- [ ] changed API client type definition or chain metadata

