### PR TITLE
Stateful runtime upgrade

### DIFF
--- a/frame/dapps-staking/src/migrations.rs
+++ b/frame/dapps-staking/src/migrations.rs
@@ -5,10 +5,19 @@ use super::*;
 pub mod v2 {
 
     use super::*;
-    use frame_support::{traits::Get, weights::Weight};
+    use codec::{Decode, Encode, FullCodec};
+    use frame_support::{
+        storage::{
+            generator::{StorageDoubleMap, StorageMap},
+            unhashed,
+        },
+        traits::Get,
+        weights::Weight,
+    };
     use sp_std::collections::btree_map::BTreeMap;
+    use sp_std::fmt::Debug;
 
-    #[cfg(feature = "try-runtime")]
+    // #[cfg(feature = "try-runtime")]
     use frame_support::log;
     #[cfg(feature = "try-runtime")]
     use frame_support::traits::OnRuntimeUpgradeHelpersExt;
@@ -19,7 +28,7 @@ pub mod v2 {
     type OldLedger<T> = pallet::pallet::BalanceOf<T>;
 
     // The old struct used to sotre staking points. Contains unused `formed_staked_era` value.
-    #[derive(Clone, PartialEq, Encode, Decode)]
+    #[derive(Clone, PartialEq, Encode, Decode, RuntimeDebug)]
     struct OldEraStakingPoints<AccountId: Ord, Balance: HasCompact> {
         total: Balance,
         stakers: BTreeMap<AccountId, Balance>,
@@ -27,10 +36,54 @@ pub mod v2 {
         claimed_rewards: Balance,
     }
 
-    #[derive(PartialEq, Eq, Clone, Encode, Decode)]
+    #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug)]
     struct OldEraRewardAndStake<Balance> {
         rewards: Balance,
         staked: Balance,
+    }
+
+    /// Serves as migration state representation.
+    /// E.g. we might be migrating `Ledger` but need to stop since we've reached the predefined weight limit.
+    /// Therefore we use this enum to store migration state `MigrationState::Ledger(Some(last_processed_key))`.
+    #[derive(PartialEq, Eq, Clone, Encode, Decode, TypeInfo, RuntimeDebug)]
+    pub enum MigrationState {
+        NotStarted,
+        /// In the middle of `Ledger` migration.
+        Ledger(Option<Vec<u8>>),
+        /// In the middle of `StakingInfo` migration.
+        StakingInfo(Option<Vec<u8>>),
+        /// In the middle of `RewardsAndStakes` migration.
+        RewardsAndStakes(Option<Vec<u8>>),
+        Finished,
+    }
+
+    impl Default for MigrationState {
+        fn default() -> Self {
+            MigrationState::NotStarted
+        }
+    }
+
+    /// TODO: this should be part of `IterableStorageMap` and all other `Iterable` storage traits.
+    /// Translates a value from format `O` into format `V`.
+    /// If key is invalid, translation is ignored.
+    /// If translation function `F` fails (returns None), entry is removed from the underlying map.
+    fn translate<O: Decode + Debug, V: FullCodec + Debug, F: FnMut(O) -> Option<V>>(
+        key: &[u8],
+        mut f: F,
+    ) {
+        let value = match unhashed::get::<O>(key) {
+            Some(value) => value,
+            None => {
+                return;
+            }
+        };
+
+        match f(value) {
+            Some(new) => {
+                unhashed::put::<V>(key, &new);
+            }
+            None => unhashed::kill(key),
+        }
     }
 
     #[cfg(feature = "try-runtime")]
@@ -54,6 +107,163 @@ pub mod v2 {
         );
 
         Ok(().into())
+    }
+
+    pub fn stateful_migrate<T: Config>(weight_limit: Weight) -> Weight {
+        // Ensure this is a valid migration for this version
+        if StorageVersion::<T>::get() != Version::V1_0_0 {
+            return T::DbWeight::get().reads(1);
+        }
+
+        let mut migration_state = MigrationStateV2::<T>::get();
+        let mut consumed_weight = T::DbWeight::get().reads(2);
+
+        // The first storage we process is `Ledger` so we set the starting state if needed
+        if migration_state == MigrationState::NotStarted {
+            migration_state = MigrationState::Ledger(None);
+            PalletDisabled::<T>::put(true);
+            consumed_weight += T::DbWeight::get().writes(1);
+        }
+
+        log::info!(">>> Migration state is: {:?}", migration_state);
+
+        // Process ledger
+        if let MigrationState::Ledger(last_processed_key) = migration_state.clone() {
+            // First, get correct iterator.
+            let key_iter = if let Some(previous_key) = last_processed_key {
+                Ledger::<T>::iter_keys_from(previous_key)
+            } else {
+                Ledger::<T>::iter_keys()
+            };
+
+            for key in key_iter {
+                // TODO: need function from map that will only translate ONE value!
+                let key_as_vec = Ledger::<T>::storage_map_final_key(key);
+                translate(&key_as_vec, |value: OldLedger<T>| {
+                    Some(AccountLedger {
+                        locked: value,
+                        unbonding_info: Default::default(),
+                    })
+                });
+
+                // Increment total consumed weight.
+                consumed_weight += T::DbWeight::get().reads_writes(1, 1);
+
+                // Check if we've consumed enough weight already.
+                if consumed_weight >= weight_limit {
+                    log::info!(
+                        ">>> Ledger migration stopped after consuming {:?} weight.",
+                        consumed_weight
+                    );
+                    MigrationStateV2::<T>::put(MigrationState::Ledger(Some(key_as_vec)));
+                    consumed_weight += T::DbWeight::get().writes(1);
+
+                    // we want try-runtime to execute the entire migration
+                    if cfg!(feature = "try-runtime") {
+                        return stateful_migrate::<T>(weight_limit)
+                    } else {
+                        return consumed_weight;
+                    }
+                }
+            }
+
+            log::info!(">>> Ledger migration finished.");
+            // This means we're finished with migration of the Ledger. Hooray!
+            // Next step of the migration should be configured.
+            migration_state = MigrationState::StakingInfo(None);
+        }
+
+        if let MigrationState::StakingInfo(last_processed_key) = migration_state.clone() {
+            let key_iter = if let Some(previous_key) = last_processed_key {
+                ContractEraStake::<T>::iter_keys_from(previous_key)
+            } else {
+                ContractEraStake::<T>::iter_keys()
+            };
+
+            for (key1, key2) in key_iter {
+                let key_as_vec = ContractEraStake::<T>::storage_double_map_final_key(key1, key2);
+                translate(
+                    &key_as_vec,
+                    |value: OldEraStakingPoints<T::AccountId, BalanceOf<T>>| {
+                        Some(EraStakingPoints {
+                            total: value.total,
+                            stakers: value.stakers,
+                            claimed_rewards: value.claimed_rewards,
+                        })
+                    },
+                );
+
+                consumed_weight += T::DbWeight::get().reads_writes(1, 1);
+
+                if consumed_weight >= weight_limit {
+                    log::info!(
+                        ">>> EraStakingPoints migration stopped after consuming {:?} weight.",
+                        consumed_weight
+                    );
+                    MigrationStateV2::<T>::put(MigrationState::StakingInfo(Some(key_as_vec)));
+                    consumed_weight += T::DbWeight::get().writes(1);
+
+                    if cfg!(feature = "try-runtime") {
+                        return stateful_migrate::<T>(weight_limit)
+                    } else {
+                        return consumed_weight;
+                    }
+                }
+            }
+
+            log::info!(">>> EraStakingPoints migration finished.");
+
+            migration_state = MigrationState::RewardsAndStakes(None);
+        }
+
+        if let MigrationState::RewardsAndStakes(last_processed_key) = migration_state.clone() {
+            let key_iter = if let Some(previous_key) = last_processed_key {
+                EraRewardsAndStakes::<T>::iter_keys_from(previous_key)
+            } else {
+                EraRewardsAndStakes::<T>::iter_keys()
+            };
+
+            for key in key_iter {
+                let key_as_vec = EraRewardsAndStakes::<T>::storage_map_final_key(key);
+                translate(&key_as_vec, |value: OldEraRewardAndStake<BalanceOf<T>>| {
+                    Some(EraRewardAndStake {
+                        rewards: value.rewards,
+                        staked: value.staked,
+                    })
+                });
+
+                consumed_weight += T::DbWeight::get().reads_writes(1, 1);
+
+                if consumed_weight >= weight_limit {
+                    log::info!(
+                        ">>> EraRewardsAndStakes migration stopped after consuming {:?} weight.",
+                        consumed_weight
+                    );
+                    MigrationStateV2::<T>::put(MigrationState::RewardsAndStakes(Some(key_as_vec)));
+                    consumed_weight += T::DbWeight::get().writes(1);
+
+                    if cfg!(feature = "try-runtime") {
+                        return stateful_migrate::<T>(weight_limit)
+                    } else {
+                        return consumed_weight;
+                    }
+                }
+            }
+
+            log::info!(">>> EraRewardsAndStakes migration finished.");
+        }
+
+        MigrationStateV2::<T>::put(MigrationState::Finished);
+        consumed_weight += T::DbWeight::get().writes(1);
+        log::info!(">>> Migration finalized.");
+
+        StorageVersion::<T>::put(Version::V2_0_0);
+        consumed_weight += T::DbWeight::get().writes(1);
+
+        PalletDisabled::<T>::put(false);
+        consumed_weight += T::DbWeight::get().writes(1);
+
+        consumed_weight
     }
 
     pub fn migrate<T: Config>() -> Weight {

--- a/frame/dapps-staking/src/migrations.rs
+++ b/frame/dapps-staking/src/migrations.rs
@@ -124,7 +124,7 @@ pub mod v2 {
         if migration_state == MigrationState::NotStarted {
             migration_state = MigrationState::Ledger(None);
             PalletDisabled::<T>::put(true);
-            consumed_weight += T::DbWeight::get().writes(1);
+            consumed_weight = consumed_weight.saturating_add(T::DbWeight::get().writes(1));
 
             // If normal run, just exit here to avoid the risk of clogging the upgrade block.
             if !cfg!(feature = "try-runtime") {
@@ -153,7 +153,8 @@ pub mod v2 {
                 });
 
                 // Increment total consumed weight.
-                consumed_weight += T::DbWeight::get().reads_writes(1, 1);
+                consumed_weight =
+                    consumed_weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
 
                 // Check if we've consumed enough weight already.
                 if consumed_weight >= weight_limit {
@@ -162,7 +163,7 @@ pub mod v2 {
                         consumed_weight
                     );
                     MigrationStateV2::<T>::put(MigrationState::Ledger(Some(key_as_vec)));
-                    consumed_weight += T::DbWeight::get().writes(1);
+                    consumed_weight = consumed_weight.saturating_add(T::DbWeight::get().writes(1));
 
                     // we want try-runtime to execute the entire migration
                     if cfg!(feature = "try-runtime") {
@@ -199,7 +200,8 @@ pub mod v2 {
                     },
                 );
 
-                consumed_weight += T::DbWeight::get().reads_writes(1, 1);
+                consumed_weight =
+                    consumed_weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
 
                 if consumed_weight >= weight_limit {
                     log::info!(
@@ -207,7 +209,7 @@ pub mod v2 {
                         consumed_weight
                     );
                     MigrationStateV2::<T>::put(MigrationState::StakingInfo(Some(key_as_vec)));
-                    consumed_weight += T::DbWeight::get().writes(1);
+                    consumed_weight = consumed_weight.saturating_add(T::DbWeight::get().writes(1));
 
                     if cfg!(feature = "try-runtime") {
                         return stateful_migrate::<T>(weight_limit);
@@ -238,7 +240,8 @@ pub mod v2 {
                     })
                 });
 
-                consumed_weight += T::DbWeight::get().reads_writes(1, 1);
+                consumed_weight =
+                    consumed_weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
 
                 if consumed_weight >= weight_limit {
                     log::info!(
@@ -246,7 +249,7 @@ pub mod v2 {
                         consumed_weight
                     );
                     MigrationStateV2::<T>::put(MigrationState::RewardsAndStakes(Some(key_as_vec)));
-                    consumed_weight += T::DbWeight::get().writes(1);
+                    consumed_weight = consumed_weight.saturating_add(T::DbWeight::get().writes(1));
 
                     if cfg!(feature = "try-runtime") {
                         return stateful_migrate::<T>(weight_limit);
@@ -260,14 +263,14 @@ pub mod v2 {
         }
 
         MigrationStateV2::<T>::put(MigrationState::Finished);
-        consumed_weight += T::DbWeight::get().writes(1);
+        consumed_weight = consumed_weight.saturating_add(T::DbWeight::get().writes(1));
         log::info!(">>> Migration finalized.");
 
         StorageVersion::<T>::put(Version::V2_0_0);
-        consumed_weight += T::DbWeight::get().writes(1);
+        consumed_weight = consumed_weight.saturating_add(T::DbWeight::get().writes(1));
 
         PalletDisabled::<T>::put(false);
-        consumed_weight += T::DbWeight::get().writes(1);
+        consumed_weight = consumed_weight.saturating_add(T::DbWeight::get().writes(1));
 
         consumed_weight
     }

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -115,6 +115,15 @@ pub mod pallet {
         type WeightInfo: WeightInfo;
     }
 
+    #[pallet::storage]
+    #[pallet::getter(fn migration_state_v2)]
+    pub type MigrationStateV2<T: Config> =
+        StorageValue<_, migrations::v2::MigrationState, ValueQuery>;
+
+    #[pallet::storage]
+    #[pallet::getter(fn pallet_disabled)]
+    pub type PalletDisabled<T: Config> = StorageValue<_, bool, ValueQuery>;
+
     /// Bonded amount for the staker
     #[pallet::storage]
     #[pallet::getter(fn ledger)]
@@ -213,6 +222,8 @@ pub mod pallet {
 
     #[pallet::error]
     pub enum Error<T> {
+        /// Disabled
+        Disabled,
         /// Can not stake with zero value.
         StakingWithNoValue,
         /// Can not stake with value less than minimum staking value
@@ -283,6 +294,26 @@ pub mod pallet {
 
     #[pallet::call]
     impl<T: Config> Pallet<T> {
+        #[pallet::weight(weight_limit.unwrap_or(T::BlockWeights::get().max_block / 5 * 3))]
+        pub fn do_upgrade(
+            origin: OriginFor<T>,
+            weight_limit: Option<Weight>,
+        ) -> DispatchResultWithPostInfo {
+            ensure_root(origin)?;
+
+            // TODO: scale this down bellow 75%. It should probably be an argument that depends on the size of block
+            // dedicated to normal ops.
+            // Make this a constant?
+            let weight_limit = weight_limit.unwrap_or(T::BlockWeights::get().max_block / 5 * 3); // e.g. 60%
+
+            // TODO: do some hard-check on weight and terminate extrinsic if weight is too high?
+            // Otherwise we might get stuck again (same as when we upgraded Shibuya)
+
+            let consumed_weight = migrations::v2::stateful_migrate::<T>(weight_limit);
+
+            Ok(Some(consumed_weight).into())
+        }
+
         /// register contract into staking targets.
         /// contract_id should be ink! or evm contract.
         ///
@@ -293,6 +324,8 @@ pub mod pallet {
             origin: OriginFor<T>,
             contract_id: T::SmartContract,
         ) -> DispatchResultWithPostInfo {
+            ensure!(!Self::pallet_disabled(), Error::<T>::Disabled);
+
             let developer = ensure_signed(origin)?;
 
             ensure!(
@@ -332,6 +365,7 @@ pub mod pallet {
             origin: OriginFor<T>,
             contract_id: T::SmartContract,
         ) -> DispatchResultWithPostInfo {
+            ensure!(!Self::pallet_disabled(), Error::<T>::Disabled);
             let developer = ensure_signed(origin)?;
 
             let registered_contract =
@@ -394,6 +428,7 @@ pub mod pallet {
             contract_id: T::SmartContract,
             #[pallet::compact] value: BalanceOf<T>,
         ) -> DispatchResultWithPostInfo {
+            ensure!(!Self::pallet_disabled(), Error::<T>::Disabled);
             let staker = ensure_signed(origin)?;
 
             // Check that contract is ready for staking.
@@ -486,6 +521,7 @@ pub mod pallet {
             contract_id: T::SmartContract,
             #[pallet::compact] value: BalanceOf<T>,
         ) -> DispatchResultWithPostInfo {
+            ensure!(!Self::pallet_disabled(), Error::<T>::Disabled);
             let staker = ensure_signed(origin)?;
 
             ensure!(value > Zero::zero(), Error::<T>::UnstakingWithNoValue);
@@ -562,6 +598,7 @@ pub mod pallet {
         ///
         #[pallet::weight(T::WeightInfo::withdraw_unbonded())]
         pub fn withdraw_unbonded(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
+            ensure!(!Self::pallet_disabled(), Error::<T>::Disabled);
             let staker = ensure_signed(origin)?;
 
             let mut ledger = Self::ledger(&staker);
@@ -594,6 +631,7 @@ pub mod pallet {
             contract_id: T::SmartContract,
             #[pallet::compact] era: EraIndex,
         ) -> DispatchResultWithPostInfo {
+            ensure!(!Self::pallet_disabled(), Error::<T>::Disabled);
             let _ = ensure_signed(origin)?;
 
             let developer =
@@ -690,6 +728,7 @@ pub mod pallet {
         /// # </weight>
         #[pallet::weight(T::WeightInfo::force_new_era())]
         pub fn force_new_era(origin: OriginFor<T>) -> DispatchResult {
+            ensure!(!Self::pallet_disabled(), Error::<T>::Disabled);
             ensure_root(origin)?;
             ForceEra::<T>::put(Forcing::ForceNew);
             Ok(())
@@ -704,6 +743,7 @@ pub mod pallet {
             origin: OriginFor<T>,
             developer: T::AccountId,
         ) -> DispatchResultWithPostInfo {
+            ensure!(!Self::pallet_disabled(), Error::<T>::Disabled);
             ensure_root(origin)?;
 
             ensure!(
@@ -723,6 +763,7 @@ pub mod pallet {
             origin: OriginFor<T>,
             enabled: bool,
         ) -> DispatchResultWithPostInfo {
+            ensure!(!Self::pallet_disabled(), Error::<T>::Disabled);
             ensure_root(origin)?;
             PreApprovalIsEnabled::<T>::put(enabled);
             Ok(().into())

--- a/frame/dapps-staking/src/pallet/mod.rs
+++ b/frame/dapps-staking/src/pallet/mod.rs
@@ -316,7 +316,7 @@ pub mod pallet {
 
             // A sanity check to prevent too heavy upgrade
             ensure!(
-                weight_limit > T::BlockWeights::get().max_block / 4 * 3,
+                weight_limit < T::BlockWeights::get().max_block / 4 * 3,
                 Error::<T>::UpgradeTooHeavy
             );
 

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -753,7 +753,10 @@ pub struct DappsStakingMigrationV2;
 
 impl OnRuntimeUpgrade for DappsStakingMigrationV2 {
     fn on_runtime_upgrade() -> frame_support::weights::Weight {
-        pallet_dapps_staking::migrations::v2::migrate::<Runtime>()
+        // pallet_dapps_staking::migrations::v2::migrate::<Runtime>()
+        pallet_dapps_staking::migrations::v2::stateful_migrate::<Runtime>(
+            RuntimeBlockWeights::get().max_block / 5 * 3,
+        )
     }
 
     #[cfg(feature = "try-runtime")]

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -752,7 +752,10 @@ pub struct DappsStakingMigrationV2;
 
 impl OnRuntimeUpgrade for DappsStakingMigrationV2 {
     fn on_runtime_upgrade() -> frame_support::weights::Weight {
-        pallet_dapps_staking::migrations::v2::migrate::<Runtime>()
+        // pallet_dapps_staking::migrations::v2::migrate::<Runtime>()
+        pallet_dapps_staking::migrations::v2::stateful_migrate::<Runtime>(
+            RuntimeBlockWeights::get().max_block / 5 * 3,
+        )
     }
 
     #[cfg(feature = "try-runtime")]


### PR DESCRIPTION
**Pull Request Summary**

The purpose of this commit is to introduce a way for upgrading Shibuya.
Due to having huge amount of key-value pairs that require storage migration,
it's not possible to do it all in a single block. Therefore a concept of stateful runtime upgrade is introduced.

Basic idea is the following:

1. Do runtime_upgrade. Disable dApps Staking pallet extrinsic calls.
2. Manually call `do_upgrade` extrinsic call which will migrate storage until it consumes **W** weight.
    * each call that doesn't finish the migration will save the state where it left off
3. Repeat 2. until migration is finished.
4. Re-enable the pallet extrinsic calls.

Code is a bit dirty and some operations should be handled in substrate code.
Feel free to comment, criticize and suggest improvements!

Note that `try-runtime` has a bit different handling.
Each time one step of stateful migration is executed, it will recursively
call it again. This makes it possible to easily test the solution with `try-runtime` feature.


**Check list**
- [ ] contains breaking changes
- [x] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] updated spec version
- [x] relies on other tasks
- [ ] documentation changes
- [ ] tests and/or benchmarks are included
- [ ] changed API client type definition or chain metadata