### PR TITLE
Update migration of Shiden and Shibuya bootnodes

### DIFF
--- a/bin/collator/res/shibuya.json
+++ b/bin/collator/res/shibuya.json
@@ -4,7 +4,7 @@
   "chainType": "Live",
   "bootNodes": [
     "/ip4/35.74.249.69/tcp/30333/p2p/12D3KooWEHWUJ3Rzf8RLRihohbgXafz3Y4LnnKSzFDeZ1sXnopJs",
-    "/ip4/52.195.13.44/tcp/30333/p2p/12D3KooWEft299vbURLUdCcqqTTrmGUnoCfF5z6ttGfrtoVWztFG"
+    "/ip4/20.40.146.211/tcp/30333/p2p/12D3KooWBVXQ1WgLjHhWMn8mVEdpwF6uepMT1sYkDvAhYAomZvvx"
   ],
   "telemetryEndpoints": null,
   "protocolId": "shibuya",

--- a/bin/collator/res/shibuya.raw.json
+++ b/bin/collator/res/shibuya.raw.json
@@ -4,7 +4,7 @@
   "chainType": "Live",
   "bootNodes": [
     "/ip4/35.74.249.69/tcp/30333/p2p/12D3KooWEHWUJ3Rzf8RLRihohbgXafz3Y4LnnKSzFDeZ1sXnopJs",
-    "/ip4/52.195.13.44/tcp/30333/p2p/12D3KooWEft299vbURLUdCcqqTTrmGUnoCfF5z6ttGfrtoVWztFG"
+    "/ip4/20.40.146.211/tcp/30333/p2p/12D3KooWBVXQ1WgLjHhWMn8mVEdpwF6uepMT1sYkDvAhYAomZvvx"
   ],
   "telemetryEndpoints": null,
   "protocolId": "shibuya",

--- a/bin/collator/res/shiden.json
+++ b/bin/collator/res/shiden.json
@@ -3,7 +3,7 @@
   "id": "shiden",
   "chainType": "Live",
   "bootNodes": [
-    "/ip4/54.238.76.198/tcp/30333/p2p/12D3KooWHjaW6mwpsDhdDv9CFmWSfgiT13kjDcpsUsTQGDVCyxV6",
+    "/ip4/54.64.145.3/tcp/30333/p2p/12D3KooWDYfspdMj1tQJZuiecmKKaQjGuSX2cy5rExtqcMqmiNrR",
     "/ip4/20.40.146.192/tcp/30333/p2p/12D3KooWEnYEZpxqD5ZvZ89nsTTqqvijtpCTfYgFchVQcbwA8rve"
   ],
   "telemetryEndpoints": null,

--- a/bin/collator/res/shiden.json
+++ b/bin/collator/res/shiden.json
@@ -4,7 +4,7 @@
   "chainType": "Live",
   "bootNodes": [
     "/ip4/54.238.76.198/tcp/30333/p2p/12D3KooWHjaW6mwpsDhdDv9CFmWSfgiT13kjDcpsUsTQGDVCyxV6",
-    "/ip4/52.69.166.77/tcp/30333/p2p/12D3KooWEQ4CW9Mbc2zdNrEbRm8epJC2Vj9FWrTob3TB76QLikvo"
+    "/ip4/20.40.146.192/tcp/30333/p2p/12D3KooWEnYEZpxqD5ZvZ89nsTTqqvijtpCTfYgFchVQcbwA8rve"
   ],
   "telemetryEndpoints": null,
   "protocolId": "shiden",

--- a/bin/collator/res/shiden.raw.json
+++ b/bin/collator/res/shiden.raw.json
@@ -3,7 +3,7 @@
   "id": "shiden",
   "chainType": "Live",
   "bootNodes": [
-    "/ip4/54.238.76.198/tcp/30333/p2p/12D3KooWHjaW6mwpsDhdDv9CFmWSfgiT13kjDcpsUsTQGDVCyxV6",
+    "/ip4/54.64.145.3/tcp/30333/p2p/12D3KooWDYfspdMj1tQJZuiecmKKaQjGuSX2cy5rExtqcMqmiNrR",
     "/ip4/20.40.146.192/tcp/30333/p2p/12D3KooWEnYEZpxqD5ZvZ89nsTTqqvijtpCTfYgFchVQcbwA8rve"
   ],
   "telemetryEndpoints": null,

--- a/bin/collator/res/shiden.raw.json
+++ b/bin/collator/res/shiden.raw.json
@@ -4,7 +4,7 @@
   "chainType": "Live",
   "bootNodes": [
     "/ip4/54.238.76.198/tcp/30333/p2p/12D3KooWHjaW6mwpsDhdDv9CFmWSfgiT13kjDcpsUsTQGDVCyxV6",
-    "/ip4/52.69.166.77/tcp/30333/p2p/12D3KooWEQ4CW9Mbc2zdNrEbRm8epJC2Vj9FWrTob3TB76QLikvo"
+    "/ip4/20.40.146.192/tcp/30333/p2p/12D3KooWEnYEZpxqD5ZvZ89nsTTqqvijtpCTfYgFchVQcbwA8rve"
   ],
   "telemetryEndpoints": null,
   "protocolId": "shiden",


### PR DESCRIPTION
**Pull Request Summary**

Update bootnode 1 IP and Key (same server)
Migrate bootnode 2 to EU

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [ ] modifies existing feature (bug fix or improvements)
- [x] updated spec version
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tests and/or benchmarks are included
- [ ] changed API client type definition or chain metadata

**This pull request makes the following changes:**

**Adds**
- (ex: Add feature A)

**Fixes**
- (ex: Fix validation function)

**Changes**
- (ex: Change document B)

**To-dos**
> *Feel free to remove this section if it's not applicable

- [ ] (ex: add user list)
