### PR TITLE
Cumulus RunCmd usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "astar-collator"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "astar-runtime",
  "async-trait",
@@ -239,7 +239,7 @@ dependencies = [
 
 [[package]]
 name = "astar-runtime"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -4599,7 +4599,7 @@ checksum = "a261afc61b7a5e323933b402ca6a1765183687c614789b1e4db7762ed4230bca"
 
 [[package]]
 name = "local-runtime"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "fp-rpc",
  "fp-self-contained",
@@ -10212,7 +10212,7 @@ dependencies = [
 
 [[package]]
 name = "shibuya-runtime"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -10285,7 +10285,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ $ ./target/release/astar-collator \
   --rpc-port 9933 \
   --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
   --rpc-cors all \
-  --validator
+  --collator
 ```
 
 Now, you can obtain the node's session key by sending the following RPC payload.

--- a/bin/collator/Cargo.toml
+++ b/bin/collator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-collator"
-version = "3.11.2"
+version = "3.11.3"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Astar collator implementation in Rust."
 build = "build.rs"

--- a/bin/collator/src/cli.rs
+++ b/bin/collator/src/cli.rs
@@ -116,7 +116,7 @@ pub struct ExportGenesisWasmCommand {
 pub struct RunCmd {
     #[allow(missing_docs)]
     #[clap(flatten)]
-    pub base: sc_cli::RunCmd,
+    pub base: cumulus_client_cli::RunCmd,
 
     /// Id of the parachain this collator collates for.
     ///
@@ -126,7 +126,7 @@ pub struct RunCmd {
 }
 
 impl std::ops::Deref for RunCmd {
-    type Target = sc_cli::RunCmd;
+    type Target = cumulus_client_cli::RunCmd;
 
     fn deref(&self) -> &Self::Target {
         &self.base

--- a/bin/collator/src/command.rs
+++ b/bin/collator/src/command.rs
@@ -551,7 +551,7 @@ pub fn run() -> Result<()> {
             }
         }
         None => {
-            let runner = cli.create_runner(&*cli.run)?;
+            let runner = cli.create_runner(&cli.run.normalize())?;
 
             runner.run_node_until_exit(|config| async move {
                 if config.chain_spec.is_dev() {

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-runtime"
-version = "3.11.2"
+version = "3.11.3"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 build = "build.rs"

--- a/runtime/local/Cargo.toml
+++ b/runtime/local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-runtime"
-version = "3.11.2"
+version = "3.11.3"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 build = "build.rs"

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "3.11.2"
+version = "3.11.3"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 build = "build.rs"

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "3.11.2"
+version = "3.11.3"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 build = "build.rs"


### PR DESCRIPTION
**Pull Request Summary**

Use `RunCmd` struct from cumulus CLI instead of legacy substrate.
This makes us more consistent with other chains and allows us to use tools like `polkadot-launch`
without the need to modify them prior to usage.

**TODO**
- [x] test
- [x] uplift versions 
- [ ] update documentation

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [ ] modifies existing feature (bug fix or improvements)
- [ ] updated spec version
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tests and/or benchmarks are included
- [ ] changed API client type definition or chain metadata

**This pull request makes the following changes:**

**Adds**
- (ex: Add feature A)

**Fixes**
- (ex: Fix validation function)

**Changes**
- (ex: Change document B)

**To-dos**
> *Feel free to remove this section if it's not applicable

- [ ] (ex: add user list)
