### PR TITLE
Swap nix build with check

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -114,55 +114,17 @@ jobs:
     - name: Check all features compilation
       run: cargo check --verbose --all-features
 
-  # runtime-benchmarks:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: hecrj/setup-rust-action@v1
-  #     with:
-  #       rust-version: ${{ env.RUST_VERSION }}
-  #       targets: 'wasm32-unknown-unknown'
-  #
-  #   - name: Checkout the source code
-  #     uses: actions/checkout@master
-  #     with:
-  #       submodules: true
-  #
-  #   - name: Check targets are installed correctly
-  #     run: rustup target list --installed
-  #
-  #   - name: Check runtime-benchmarks compilation
-  #     run: cargo check --verbose --features runtime-benchmarks
-
-  # try-runtime:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: hecrj/setup-rust-action@v1
-  #     with:
-  #       rust-version: ${{ env.RUST_VERSION }}
-  #       targets: 'wasm32-unknown-unknown'
-  #
-  #   - name: Checkout the source code
-  #     uses: actions/checkout@master
-  #     with:
-  #       submodules: true
-  #
-  #   - name: Check targets are installed correctly
-  #     run: rustup target list --installed
-  #
-  #   - name: Check try-runtime compilation
-  #     run: cargo check --verbose --features try-runtime
-
-  # nix:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - name: Checkout the source code
-  #     uses: actions/checkout@v2
-  #     with:
-  #       submodules: true
-  #   - uses: cachix/install-nix-action@v12
-  #     with:
-  #       nix_path: nixpkgs=channel:nixos-21.11
-  #   - run: nix-shell third-party/nix/shell.nix --run "cargo build --release"
+  nix:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixos-21.11
+    - run: nix-shell third-party/nix/shell.nix --run "cargo check --all-features"
 
   docker:
     needs: test


### PR DESCRIPTION
**Pull Request Summary**

Nix build has been failing for quite some time due to timeout.
Since we don't store or use the built binary, `build` is swapped with `check`.

**Check list**
- [ ] contains breaking changes
- [ ] adds new feature
- [x] modifies existing feature (bug fix or improvements)
- [ ] updated spec version
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tests and/or benchmarks are included
- [ ] changed API client type definition or chain metadata

**This pull request makes the following changes:**

**Adds**
- (ex: Add feature A)

**Fixes**
- (ex: Fix validation function)

**Changes**
- (ex: Change document B)

**To-dos**
> *Feel free to remove this section if it's not applicable

- [ ] (ex: add user list)
