### PR TITLE
Shiden upgrade - block reward v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "astar-collator"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "astar-runtime",
  "async-trait",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "astar-runtime"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -4600,7 +4600,7 @@ checksum = "a261afc61b7a5e323933b402ca6a1765183687c614789b1e4db7762ed4230bca"
 
 [[package]]
 name = "local-runtime"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "fp-rpc",
  "fp-self-contained",
@@ -4630,7 +4630,7 @@ dependencies = [
  "pallet-evm-precompile-simple",
  "pallet-evm-precompile-sr25519",
  "pallet-grandpa",
- "pallet-precompile-dapps-staking 3.2.0",
+ "pallet-precompile-dapps-staking",
  "pallet-randomness-collective-flip",
  "pallet-sudo",
  "pallet-timestamp",
@@ -5808,29 +5808,6 @@ dependencies = [
 
 [[package]]
 name = "pallet-dapps-staking"
-version = "3.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?tag=pallet-dapps-staking-3.1.0/polkadot-v0.9.17#162d8fcde709d0140bc8da9f7df5ac165c0c43a7"
-dependencies = [
- "frame-benchmarking",
- "frame-support",
- "frame-system",
- "num-traits",
- "pallet-balances",
- "pallet-session",
- "pallet-timestamp",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-staking",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-dapps-staking"
 version = "3.2.0"
 source = "git+https://github.com/AstarNetwork/astar-frame?tag=pallet-dapps-staking-3.2.0/polkadot-v0.9.17#33e48c2e54109bb5980f8117336c9489f9c20d06"
 dependencies = [
@@ -6253,26 +6230,6 @@ dependencies = [
  "scale-info",
  "sp-runtime",
  "sp-staking",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-precompile-dapps-staking"
-version = "3.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?tag=pallet-dapps-staking-3.1.0/polkadot-v0.9.17#162d8fcde709d0140bc8da9f7df5ac165c0c43a7"
-dependencies = [
- "fp-evm",
- "frame-support",
- "frame-system",
- "log",
- "num_enum",
- "pallet-dapps-staking 3.1.0",
- "pallet-evm",
- "parity-scale-codec",
- "precompile-utils 0.1.0 (git+https://github.com/AstarNetwork/astar-frame?tag=pallet-dapps-staking-3.1.0/polkadot-v0.9.17)",
- "scale-info",
- "sp-core",
- "sp-runtime",
  "sp-std",
 ]
 
@@ -8186,26 +8143,6 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?tag=pallet-dapps-staking-3.1.0/polkadot-v0.9.17#162d8fcde709d0140bc8da9f7df5ac165c0c43a7"
-dependencies = [
- "fp-evm",
- "frame-support",
- "frame-system",
- "log",
- "num_enum",
- "pallet-evm",
- "parity-scale-codec",
- "precompile-utils-macro 0.1.0 (git+https://github.com/AstarNetwork/astar-frame?tag=pallet-dapps-staking-3.1.0/polkadot-v0.9.17)",
- "sha3 0.9.1",
- "sp-core",
- "sp-io",
- "sp-std",
- "xcm",
-]
-
-[[package]]
-name = "precompile-utils"
-version = "0.1.0"
 source = "git+https://github.com/AstarNetwork/astar-frame?tag=pallet-dapps-staking-3.2.0/polkadot-v0.9.17#33e48c2e54109bb5980f8117336c9489f9c20d06"
 dependencies = [
  "fp-evm",
@@ -8241,18 +8178,6 @@ dependencies = [
  "sp-io",
  "sp-std",
  "xcm",
-]
-
-[[package]]
-name = "precompile-utils-macro"
-version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?tag=pallet-dapps-staking-3.1.0/polkadot-v0.9.17#162d8fcde709d0140bc8da9f7df5ac165c0c43a7"
-dependencies = [
- "num_enum",
- "proc-macro2",
- "quote",
- "sha3 0.8.2",
- "syn",
 ]
 
 [[package]]
@@ -10335,7 +10260,7 @@ dependencies = [
  "pallet-evm-precompile-sr25519",
  "pallet-identity",
  "pallet-multisig",
- "pallet-precompile-dapps-staking 3.2.0",
+ "pallet-precompile-dapps-staking",
  "pallet-randomness-collective-flip",
  "pallet-session",
  "pallet-sudo",
@@ -10369,7 +10294,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "3.15.0"
+version = "3.16.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",
@@ -10390,11 +10315,11 @@ dependencies = [
  "pallet-authorship",
  "pallet-balances",
  "pallet-base-fee",
- "pallet-block-reward 0.2.0",
+ "pallet-block-reward 2.0.0",
  "pallet-collator-selection 3.0.0 (git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.17)",
  "pallet-collective",
  "pallet-custom-signatures",
- "pallet-dapps-staking 3.1.0",
+ "pallet-dapps-staking 3.2.0",
  "pallet-ethereum",
  "pallet-evm",
  "pallet-evm-precompile-bn128",
@@ -10405,7 +10330,7 @@ dependencies = [
  "pallet-evm-precompile-sr25519",
  "pallet-identity",
  "pallet-multisig",
- "pallet-precompile-dapps-staking 3.1.0",
+ "pallet-precompile-dapps-staking",
  "pallet-session",
  "pallet-sudo",
  "pallet-timestamp",

--- a/bin/collator/Cargo.toml
+++ b/bin/collator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-collator"
-version = "3.15.0"
+version = "3.16.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Astar collator implementation in Rust."
 build = "build.rs"

--- a/bin/collator/src/parachain/chain_spec/shiden.rs
+++ b/bin/collator/src/parachain/chain_spec/shiden.rs
@@ -3,12 +3,15 @@
 use cumulus_primitives_core::ParaId;
 use sc_service::ChainType;
 use shiden_runtime::{
-    wasm_binary_unwrap, AccountId, AuraId, Balance, BaseFeeConfig, EVMConfig, ParachainInfoConfig,
-    Precompiles, Signature, SystemConfig, SDN,
+    wasm_binary_unwrap, AccountId, AuraId, Balance, BaseFeeConfig, BlockRewardConfig, EVMConfig,
+    ParachainInfoConfig, Precompiles, Signature, SystemConfig, SDN,
 };
 use sp_core::{sr25519, Pair, Public};
 
-use sp_runtime::traits::{IdentifyAccount, Verify};
+use sp_runtime::{
+    traits::{IdentifyAccount, Verify},
+    Perbill,
+};
 
 use super::{get_from_seed, Extensions};
 
@@ -81,6 +84,17 @@ fn make_genesis(
         },
         parachain_info: ParachainInfoConfig { parachain_id },
         balances: shiden_runtime::BalancesConfig { balances },
+        block_reward: BlockRewardConfig {
+            // Make sure sum is 100
+            reward_config: pallet_block_reward::RewardDistributionConfig {
+                base_treasury_percent: Perbill::from_percent(40),
+                base_staker_percent: Perbill::from_percent(25),
+                dapps_percent: Perbill::from_percent(25),
+                collators_percent: Perbill::from_percent(10),
+                adjustable_percent: Perbill::from_percent(0),
+                ideal_dapps_staking_tvl: Perbill::from_percent(0),
+            },
+        },
         vesting: shiden_runtime::VestingConfig { vesting: vec![] },
         session: shiden_runtime::SessionConfig {
             keys: authorities

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-runtime"
-version = "3.15.0"
+version = "3.16.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 build = "build.rs"

--- a/runtime/local/Cargo.toml
+++ b/runtime/local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-runtime"
-version = "3.15.0"
+version = "3.16.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 build = "build.rs"

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "3.15.0"
+version = "3.16.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 build = "build.rs"

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "3.15.0"
+version = "3.16.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2018"
 build = "build.rs"
@@ -78,10 +78,10 @@ frame-try-runtime = { git = "https://github.com/paritytech/substrate", branch = 
 try-runtime-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17", default-features = false, optional = true }
 
 # Astar pallets
-pallet-block-reward = { git = "https://github.com/AstarNetwork/astar-frame", tag = "pallet-block-reward-0.2.0/polkadot-v0.9.17", default-features = false }
+pallet-block-reward = { git = "https://github.com/AstarNetwork/astar-frame", tag = "pallet-block-reward-2.0.0/polkadot-v0.9.17", default-features = false }
 pallet-custom-signatures = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.17", default-features = false }
-pallet-dapps-staking = { git = "https://github.com/AstarNetwork/astar-frame", tag = "pallet-dapps-staking-3.1.0/polkadot-v0.9.17", default-features = false }
-pallet-precompile-dapps-staking = { git = "https://github.com/AstarNetwork/astar-frame", tag = "pallet-dapps-staking-3.1.0/polkadot-v0.9.17", default-features = false }
+pallet-dapps-staking = { git = "https://github.com/AstarNetwork/astar-frame", tag = "pallet-dapps-staking-3.2.0/polkadot-v0.9.17", default-features = false }
+pallet-precompile-dapps-staking = { git = "https://github.com/AstarNetwork/astar-frame", tag = "pallet-dapps-staking-3.2.0/polkadot-v0.9.17", default-features = false }
 pallet-evm-precompile-sr25519 = { git = "https://github.com/AstarNetwork/astar-frame", tag = "pallet-evm-precompile-sr25519-1.0.0/polkadot-v0.9.17", default-features = false }
 
 [build-dependencies]
@@ -156,6 +156,7 @@ runtime-benchmarks = [
     "sp-runtime/runtime-benchmarks",
     "pallet-balances/runtime-benchmarks",
     "pallet-dapps-staking/runtime-benchmarks",
+    "pallet-block-reward/runtime-benchmarks",
     "pallet-timestamp/runtime-benchmarks",
     "pallet-collective/runtime-benchmarks",
     "pallet-ethereum/runtime-benchmarks",

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -759,9 +759,7 @@ pub type Executive = frame_executive::Executive<
     (InitRewardConfigSettings,),
 >;
 
-// Migration for fixing era length in dapps staking.
 pub struct InitRewardConfigSettings;
-
 impl OnRuntimeUpgrade for InitRewardConfigSettings {
     fn on_runtime_upgrade() -> frame_support::weights::Weight {
         // TODO: discuss these params on sync & with community

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -7,7 +7,7 @@
 use codec::{Decode, Encode};
 use frame_support::{
     construct_runtime, parameter_types,
-    traits::{Contains, Currency, FindAuthor, Imbalance, OnRuntimeUpgrade, OnUnbalanced},
+    traits::{Contains, Currency, FindAuthor, Get, Imbalance, OnRuntimeUpgrade, OnUnbalanced},
     weights::{
         constants::{BlockExecutionWeight, ExtrinsicBaseWeight, WEIGHT_PER_SECOND},
         DispatchClass, Weight, WeightToFeeCoefficient, WeightToFeeCoefficients,
@@ -271,7 +271,6 @@ impl pallet_custom_signatures::Config for Runtime {
 parameter_types! {
     pub const BlockPerEra: BlockNumber = 1 * DAYS;
     pub const RegisterDeposit: Balance = 100 * SDN;
-    pub const DeveloperRewardPercentage: Perbill = Perbill::from_percent(50);
     pub const MaxNumberOfStakersPerContract: u32 = 1024;
     pub const MinimumStakingAmount: Balance = 50 * SDN;
     pub const MinimumRemainingAmount: Balance = 1 * SDN;
@@ -285,7 +284,6 @@ impl pallet_dapps_staking::Config for Runtime {
     type BlockPerEra = BlockPerEra;
     type SmartContract = SmartContract<AccountId>;
     type RegisterDeposit = RegisterDeposit;
-    type DeveloperRewardPercentage = DeveloperRewardPercentage;
     type Event = Event;
     type WeightInfo = weights::pallet_dapps_staking::WeightInfo<Runtime>;
     type MaxNumberOfStakersPerContract = MaxNumberOfStakersPerContract;
@@ -435,18 +433,25 @@ impl OnUnbalanced<NegativeImbalance> for ToStakingPot {
     }
 }
 
-pub struct OnBlockReward;
-impl OnUnbalanced<NegativeImbalance> for OnBlockReward {
-    fn on_nonzero_unbalanced(amount: NegativeImbalance) {
-        let (dapps, maintain) = amount.ration(50, 50);
-        // dapp staking block reward
-        DappsStaking::on_unbalanced(dapps);
+pub struct DappsStakingTvlProvider();
+impl Get<Balance> for DappsStakingTvlProvider {
+    fn get() -> Balance {
+        DappsStaking::tvl()
+    }
+}
 
-        let (treasury, collators) = maintain.ration(40, 10);
-        // treasury slice of block reward
-        Balances::resolve_creating(&TreasuryPalletId::get().into_account(), treasury);
-        // collators block reward
-        ToStakingPot::on_unbalanced(collators);
+pub struct BeneficiaryPayout();
+impl pallet_block_reward::BeneficiaryPayout<NegativeImbalance> for BeneficiaryPayout {
+    fn treasury(reward: NegativeImbalance) {
+        Balances::resolve_creating(&TreasuryPalletId::get().into_account(), reward);
+    }
+
+    fn collators(reward: NegativeImbalance) {
+        ToStakingPot::on_unbalanced(reward);
+    }
+
+    fn dapps_staking(stakers: NegativeImbalance, dapps: NegativeImbalance) {
+        DappsStaking::rewards(stakers, dapps)
     }
 }
 
@@ -456,8 +461,11 @@ parameter_types! {
 
 impl pallet_block_reward::Config for Runtime {
     type Currency = Balances;
-    type OnBlockReward = OnBlockReward;
+    type DappsStakingTvlProvider = DappsStakingTvlProvider;
+    type BeneficiaryPayout = BeneficiaryPayout;
     type RewardAmount = RewardAmount;
+    type Event = Event;
+    type WeightInfo = pallet_block_reward::weights::SubstrateWeight<Runtime>;
 }
 
 parameter_types! {
@@ -683,8 +691,8 @@ construct_runtime!(
         TransactionPayment: pallet_transaction_payment::{Pallet, Storage} = 30,
         Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>} = 31,
         Vesting: pallet_vesting::{Pallet, Call, Storage, Config<T>, Event<T>} = 32,
-        BlockReward: pallet_block_reward::{Pallet} = 33,
         DappsStaking: pallet_dapps_staking::{Pallet, Call, Storage, Event<T>} = 34,
+        BlockReward: pallet_block_reward::{Pallet, Call, Storage, Config, Event<T>} = 35,
 
         Authorship: pallet_authorship::{Pallet, Call, Storage, Inherent} = 40,
         CollatorSelection: pallet_collator_selection::{Pallet, Call, Storage, Event<T>, Config<T>} = 41,
@@ -748,32 +756,39 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
-    DappsStakingFixEraLength,
+    (InitRewardConfigSettings,),
 >;
 
 // Migration for fixing era length in dapps staking.
-pub struct DappsStakingFixEraLength;
+pub struct InitRewardConfigSettings;
 
-impl OnRuntimeUpgrade for DappsStakingFixEraLength {
+impl OnRuntimeUpgrade for InitRewardConfigSettings {
     fn on_runtime_upgrade() -> frame_support::weights::Weight {
-        use frame_system::pallet::Config;
-        use pallet_dapps_staking::{Config as DappStakingConfig, CurrentEra, NextEraStartingBlock};
-        use sp_runtime::SaturatedConversion;
+        // TODO: discuss these params on sync & with community
+        let mut reward_config = pallet_block_reward::RewardDistributionConfig {
+            base_treasury_percent: Perbill::from_percent(40),
+            base_staker_percent: Perbill::from_percent(25),
+            dapps_percent: Perbill::from_percent(25),
+            collators_percent: Perbill::from_percent(10),
+            adjustable_percent: Perbill::from_percent(0),
+            ideal_dapps_staking_tvl: Perbill::from_percent(0),
+        };
+        // This HAS to be tested prior to update - we need to ensure that config is consistent
+        #[cfg(feature = "try-runtime")]
+        assert!(reward_config.is_consistent());
 
-        let dapps_staking_block_offset: u32 = 489600; // calculated 2022/03/29
-                                                      // Shiden: 1384490 - (1384490 % 7200) - (124 * 7200)
+        // This should never execute but we need to have code in place that ensures config is consistent
+        if !reward_config.is_consistent() {
+            reward_config = Default::default();
+        }
+        pallet_block_reward::RewardDistributionConfigStorage::<Runtime>::put(reward_config);
 
-        let blocks_per_era =
-            <Runtime as DappStakingConfig>::BlockPerEra::get().saturated_into::<u32>();
-        let current_era = CurrentEra::<Runtime>::get();
+        // Do some storage cleanup for dapps-staking so we can remove these DB entries in the future
+        pallet_dapps_staking::MigrationStateV2::<Runtime>::kill();
+        pallet_dapps_staking::MigrationStateV3::<Runtime>::kill();
+        pallet_dapps_staking::MigrationUndergoingUnbonding::<Runtime>::kill();
 
-        let next_era_starting_block =
-            dapps_staking_block_offset + ((current_era + 1) * blocks_per_era);
-
-        NextEraStartingBlock::<Runtime>::put(
-            next_era_starting_block.saturated_into::<<Runtime as Config>::BlockNumber>(),
-        );
-        <Runtime as Config>::DbWeight::get().reads_writes(1, 1)
+        <Runtime as frame_system::pallet::Config>::DbWeight::get().writes(4)
     }
 }
 
@@ -1085,6 +1100,7 @@ impl_runtime_apis! {
             let mut list = Vec::<BenchmarkList>::new();
 
             list_benchmark!(list, extra, pallet_dapps_staking, DappsStaking);
+            list_benchmark!(list, extra, pallet_block_reward, BlockReward);
 
             let storage_info = AllPalletsWithSystem::storage_info();
 
@@ -1117,6 +1133,7 @@ impl_runtime_apis! {
             add_benchmark!(params, batches, pallet_balances, Balances);
             add_benchmark!(params, batches, pallet_timestamp, Timestamp);
             add_benchmark!(params, batches, pallet_dapps_staking, DappsStaking);
+            add_benchmark!(params, batches, pallet_block_reward, BlockReward);
 
             if batches.is_empty() { return Err("Benchmark not found for this pallet.".into()) }
             Ok(batches)


### PR DESCRIPTION
**Pull Request Summary**

Adds `block-reward-v2` pallet to Shiden.
Reward distribution parameters are set to mimic legacy so when upgrade is executed,
no change will be visible in the reward distribution.

After we discuss possible parameters with community, we can change reward distribution config
via extrinsic call.

**Check list**
- [ ] contains breaking changes
- [x] adds new feature
- [ ] modifies existing feature (bug fix or improvements)
- [x] updated spec version
- [ ] relies on other tasks
- [ ] documentation changes
- [ ] tests and/or benchmarks are included
- [ ] changed API client type definition or chain metadata
