### PR TITLE
update astar chain spec boot node dnsaddr

### DIFF
--- a/bin/collator/res/astar.json
+++ b/bin/collator/res/astar.json
@@ -3,7 +3,7 @@
   "id": "astar",
   "chainType": "Live",
   "bootNodes": [
-    "/dnsaddr/bootnode.astar.network/p2p/12D3KooWB4yB7QCZNFJ4rYrtkrBv6opFVt38RN1v8UoeLcv7nXru",
+    "/dnsaddr/bootnode.astar.network",
     "/ip4/20.40.136.125/tcp/30333/p2p/12D3KooWKZwcaofXPmXWHSSfnh34VFJ8zSRJScnNu9UA75x8kNXi",
     "/dns4/node-6877180792046243840-0.p2p.onfinality.io/tcp/19932/ws/p2p/12D3KooWARXaG1Ft65ZgCPK8isSg1UBLASQenrH9sJsjEYEDAvQf",
     "/dns4/node-6877173450521071616-0.p2p.onfinality.io/tcp/12708/ws/p2p/12D3KooWFPbDQjtCXhRjsvu1HCqTrSc6KEazEnETLPQMS4gDpoQq",

--- a/bin/collator/res/astar.raw.json
+++ b/bin/collator/res/astar.raw.json
@@ -3,7 +3,7 @@
   "id": "astar",
   "chainType": "Live",
   "bootNodes": [
-    "/dnsaddr/bootnode.astar.network/p2p/12D3KooWB4yB7QCZNFJ4rYrtkrBv6opFVt38RN1v8UoeLcv7nXru",
+    "/dnsaddr/bootnode.astar.network",
     "/ip4/20.40.136.125/tcp/30333/p2p/12D3KooWKZwcaofXPmXWHSSfnh34VFJ8zSRJScnNu9UA75x8kNXi",
     "/dns4/node-6877180792046243840-0.p2p.onfinality.io/tcp/19932/ws/p2p/12D3KooWARXaG1Ft65ZgCPK8isSg1UBLASQenrH9sJsjEYEDAvQf",
     "/dns4/node-6877173450521071616-0.p2p.onfinality.io/tcp/12708/ws/p2p/12D3KooWFPbDQjtCXhRjsvu1HCqTrSc6KEazEnETLPQMS4gDpoQq",


### PR DESCRIPTION
**Pull Request Summary**
Update astar boot node dnsaddr.
Because chain spec boot node section using libp2p `dnsaddr` (https://github.com/multiformats/multiaddr/blob/master/protocols/DNSADDR.md), there's no need to specify /p2p/{node identity}. It is defined in TXT record at DNS. It is also possible to register multiple node ipv4, ipv6 addresses and identity in TXT record.

You can check actual addresses by (libp2p-lookup)[https://github.com/mxinden/libp2p-lookup/blob/master/README.md]
```
libp2p-lookup direct --address /dnsaddr/bootnode.astar.network
```
