### PR TITLE
For rpc tests checking parachain is producing blocks before testing

### DIFF
--- a/rpc-tests/tests/test-rpc.js
+++ b/rpc-tests/tests/test-rpc.js
@@ -1,14 +1,17 @@
 import { expect } from 'chai';
+import { BN } from 'bn.js';
+import { formatBalance } from '@polkadot/util';
 import {
     capitalize,
     describeWithNetwork,
     sendTransaction
 } from './util.js';
-import { Keyring } from '@polkadot/api';
 
 const CONTRACT = '0x0000000000000000000000000000000000000001'; //0x01
 const ALICE = 'ajYMsCKsEAhEvHpeA4XqsfiA9v1CdzZPrCfS6pEfeGHW9j8';
 const BOB = 'ZAP5o2BjWAo5uoKDE6b6Xkk4Ju7k6bDu24LNjgZbfM3iyiR';
+const CHARLIE = 'ZD39yAE4W4RiXCyk1gv6CD2tSaVjQU5KoKfujyft4Xa2GAz';
+const DAVE = 'X2mE9hCGX771c3zzV6tPa8U2cDz4U4zkqUdmBrQn83M3cm7';
 
 export const getAddressEnum = (address) => ({ Evm: address });
 
@@ -32,73 +35,46 @@ describeWithNetwork(network, `${network} RPC`, function(context) {
 	});
 
 	it('should be able to Register contract on H160 address 0x01 using Alice account', async () => {
-        const events = await sendTransaction(
+        const finalised = await sendTransaction(
             context.api,
             context.api.tx.dappsStaking.register(getAddressEnum(CONTRACT)),
-            context.alice,
-            'dappsStaking',
-            'NewContract'
+            context.alice
         );
 
-        expect(events.length).to.equal(1);
-        expect(events[0].event.section).to.equal('dappsStaking');
-        expect(events[0].event.method).to.equal('NewContract');
-        expect(events[0].event.data[0].toString()).to.equal(ALICE);
+        const dappInfoOpt = await context.api.query.dappsStaking.registeredDapps(getAddressEnum(CONTRACT));
+
+        expect(finalised).to.be.true;
+        expect(dappInfoOpt.isSome).to.be.true;
+
+        const dappInfo = dappInfoOpt.unwrap();
+
+        expect(dappInfo.developer.toString()).to.equals(ALICE);
+        expect(dappInfo.state.toString()).to.equals('Registered');
     });
 
-	it('should be able to transfer tokens from alice to bob', async () => {
-        const events = await sendTransaction(
+	it('should be able to transfer tokens from alice to charlie', async () => {
+        const originalBalance = await context.api.query.system.account(CHARLIE);
+        const finalised = await sendTransaction(
             context.api,
-            context.api.tx.balances.transfer(BOB, 100),
-            context.alice,
-            'balances',
-            'Transfer'
+            context.api.tx.balances.transfer({ Id: CHARLIE }, 100),
+            context.alice
         );
+        const newBalance = await context.api.query.system.account(CHARLIE);
 
-
-        const filtered = events.filter((eventObj) => {
-            const { event: { method, section, data } } = eventObj;
-
-            return (
-                section === 'balances' &&
-                method === 'Transfer' &&
-                data[0].toString() === ALICE &&
-                data[1].toString() === BOB &&
-                data[2].toString() === '100'
-            );
-        });
-
-        // Check filtered event
-        expect(filtered.length).to.equal(1);
-        expect(filtered[0].event.section).to.equal('balances');
-        expect(filtered[0].event.method).to.equal('Transfer');
+        expect(finalised).to.be.true;
+        expect(newBalance.data.free.sub(originalBalance.data.free).toNumber()).to.equal(100);
     });
 
-    it('should be able to transfer tokens from bob to alice', async () => {
-        const events = await sendTransaction(
+    it('should be able to transfer tokens from bob to dave', async () => {
+        const originalBalance = await context.api.query.system.account(DAVE);
+        const finalised = await sendTransaction(
             context.api,
-            context.api.tx.balances.transfer(ALICE, 200),
-            context.bob,
-            'balances',
-            'Transfer'
+            context.api.tx.balances.transfer({ Id: DAVE }, 200),
+            context.bob
         );
+        const newBalance = await context.api.query.system.account(DAVE);
 
-
-        const filtered = events.filter((eventObj) => {
-            const { event: { method, section, data } } = eventObj;
-
-            return (
-                section === 'balances' &&
-                method === 'Transfer' &&
-                data[0].toString() === BOB &&
-                data[1].toString() === ALICE &&
-                data[2].toString() === '200'
-            );
-        });
-
-        // Check filtered event
-        expect(filtered.length).to.equal(1);
-        expect(filtered[0].event.section).to.equal('balances');
-        expect(filtered[0].event.method).to.equal('Transfer');
+        expect(finalised).to.be.true;
+        expect(newBalance.data.free.sub(originalBalance.data.free).toNumber()).to.equal(200);
     });
 });

--- a/rpc-tests/tests/test-rpc.js
+++ b/rpc-tests/tests/test-rpc.js
@@ -1,5 +1,9 @@
 import { expect } from 'chai';
-import { describeWithNetwork, capitalize } from './util.js';
+import {
+    capitalize,
+    describeWithNetwork,
+    sendTransaction
+} from './util.js';
 import { Keyring } from '@polkadot/api';
 
 const CONTRACT = '0x0000000000000000000000000000000000000001'; //0x01
@@ -21,170 +25,80 @@ describeWithNetwork(network, `${network} RPC`, function(context) {
 		expect(chain.toString()).to.equal(`${capitalize(network)} Testnet`);
 	});
 
-	it('should fetch chain name from rpc node', async function () {
+	it('should fetch chain name from rpc node', async () => {
 		const name = await context.api.rpc.system.name();
 
 		expect(name.toString()).to.equal('Astar Collator');
 	});
 
-	it('should be able to Register contract on H160 address 0x01 using Alice account', function (done) {
-        const api = context.api;
+	it('should be able to Register contract on H160 address 0x01 using Alice account', async () => {
+        const events = await sendTransaction(
+            context.api,
+            context.api.tx.dappsStaking.register(getAddressEnum(CONTRACT)),
+            context.alice,
+            'dappsStaking',
+            'NewContract'
+        );
 
-        // Construct the keyring after the API (crypto has an async init)
-        const keyring = new Keyring({ type: 'sr25519' });
-
-        // Add Alice to our keyring with a hard-derivation path (empty phrase, so uses dev)
-        const alice = keyring.addFromUri('//Alice');
-
-        let unsubscribe;
-
-        // Create a extrinsic, transferring 200 units to alice
-        api.tx.dappsStaking
-            .register(getAddressEnum(CONTRACT))
-            .signAndSend(alice, async (result) => {
-                console.log(`Current status is ${result?.status}`);
-
-                if (result?.status?.isInBlock) {
-                    if (unsubscribe) {
-                        unsubscribe();
-                    }
-
-                    const blockHash = result?.status?.asInBlock;
-
-                    const apiAt = await api.at(blockHash);
-
-                    const events = await apiAt.query.system.events();
-
-                    events.forEach(f => console.log(f.toHuman()));
-
-                    const filtered = events.filter((eventObj) => {
-                        const { event: { method, section, data } } = eventObj;
-
-                        return (
-                            section === 'dappsStaking' &&
-                            method === 'NewContract'
-                        );
-                    });
-
-                    expect(result?.status?.isInBlock).to.be.true;
-
-                    // Check event is in block for transfer
-                    expect(filtered.length).to.equal(1);
-                    expect(filtered[0].event.section).to.equal('dappsStaking');
-                    expect(filtered[0].event.method).to.equal('NewContract');
-                    done();
-                }
-            })
-            .then(unsub => {
-                unsubscribe = unsub;
-            });
+        expect(events.length).to.equal(1);
+        expect(events[0].event.section).to.equal('dappsStaking');
+        expect(events[0].event.method).to.equal('NewContract');
+        expect(events[0].event.data[0].toString()).to.equal(ALICE);
     });
 
-	it('should be able to transfer tokens from alice to bob', function (done) {
-        const api = context.api;
+	it('should be able to transfer tokens from alice to bob', async () => {
+        const events = await sendTransaction(
+            context.api,
+            context.api.tx.balances.transfer(BOB, 100),
+            context.alice,
+            'balances',
+            'Transfer'
+        );
 
-        // Construct the keyring after the API (crypto has an async init)
-        const keyring = new Keyring({ type: 'sr25519' });
 
-        // Add Alice to our keyring with a hard-derivation path (empty phrase, so uses dev)
-        const alice = keyring.addFromUri('//Alice');
+        const filtered = events.filter((eventObj) => {
+            const { event: { method, section, data } } = eventObj;
 
-        let unsubscribe;
+            return (
+                section === 'balances' &&
+                method === 'Transfer' &&
+                data[0].toString() === ALICE &&
+                data[1].toString() === BOB &&
+                data[2].toString() === '100'
+            );
+        });
 
-        // Create a extrinsic, transferring 100 units to Bob
-        api.tx.balances
-            .transfer(BOB, 100)
-            .signAndSend(alice, async (result) => {
-                console.log(`Current status is ${result?.status}`);
-
-                if (result?.status?.isInBlock) {
-                    if (unsubscribe) {
-                        unsubscribe();
-                    }
-
-                    const blockHash = result?.status?.asInBlock;
-
-                    const apiAt = await api.at(blockHash);
-
-                    const events = await apiAt.query.system.events();
-
-                    const filtered = events.filter((eventObj) => {
-                        const { event: { method, section, data } } = eventObj;
-
-                        return (
-                            section === 'balances' &&
-                            method === 'Transfer' &&
-                            data[0].toString() === ALICE &&
-                            data[1].toString() === BOB &&
-                            data[2].toString() === '100'
-                        );
-                    });
-
-                    expect(result?.status?.isInBlock).to.be.true;
-
-                    // Check event is in block for transfer
-                    expect(filtered.length).to.equal(1);
-                    expect(filtered[0].event.section).to.equal('balances');
-                    expect(filtered[0].event.method).to.equal('Transfer');
-                    done();
-                }
-            })
-            .then(unsub => {
-                unsubscribe = unsub;
-            });
+        // Check filtered event
+        expect(filtered.length).to.equal(1);
+        expect(filtered[0].event.section).to.equal('balances');
+        expect(filtered[0].event.method).to.equal('Transfer');
     });
 
-    it('should be able to transfer tokens from bob to alice', function (done) {
-        const api = context.api;
+    it('should be able to transfer tokens from bob to alice', async () => {
+        const events = await sendTransaction(
+            context.api,
+            context.api.tx.balances.transfer(ALICE, 200),
+            context.bob,
+            'balances',
+            'Transfer'
+        );
 
-        // Construct the keyring after the API (crypto has an async init)
-        const keyring = new Keyring({ type: 'sr25519' });
 
-        // Add Alice to our keyring with a hard-derivation path (empty phrase, so uses dev)
-        const bob = keyring.addFromUri('//Bob');
+        const filtered = events.filter((eventObj) => {
+            const { event: { method, section, data } } = eventObj;
 
-        let unsubscribe;
+            return (
+                section === 'balances' &&
+                method === 'Transfer' &&
+                data[0].toString() === BOB &&
+                data[1].toString() === ALICE &&
+                data[2].toString() === '200'
+            );
+        });
 
-        // Create a extrinsic, transferring 200 units to alice
-        api.tx.balances
-            .transfer(ALICE, 200)
-            .signAndSend(bob, async (result) => {
-                console.log(`Current status is ${result?.status}`);
-
-                if (result?.status?.isInBlock) {
-                    if (unsubscribe) {
-                        unsubscribe();
-                    }
-
-                    const blockHash = result?.status?.asInBlock;
-
-                    const apiAt = await api.at(blockHash);
-
-                    const events = await apiAt.query.system.events();
-
-                    const filtered = events.filter((eventObj) => {
-                        const { event: { method, section, data } } = eventObj;
-
-                        return (
-                            section === 'balances' &&
-                            method === 'Transfer' &&
-                            data[0].toString() === BOB &&
-                            data[1].toString() === ALICE &&
-                            data[2].toString() === '200'
-                        );
-                    });
-
-                    expect(result?.status?.isInBlock).to.be.true;
-
-                    // Check event is in block for transfer
-                    expect(filtered.length).to.equal(1);
-                    expect(filtered[0].event.section).to.equal('balances');
-                    expect(filtered[0].event.method).to.equal('Transfer');
-                    done();
-                }
-            })
-            .then(unsub => {
-                unsubscribe = unsub;
-            });
+        // Check filtered event
+        expect(filtered.length).to.equal(1);
+        expect(filtered[0].event.section).to.equal('balances');
+        expect(filtered[0].event.method).to.equal('Transfer');
     });
 });

--- a/rpc-tests/tests/test-rpc.js
+++ b/rpc-tests/tests/test-rpc.js
@@ -1,6 +1,4 @@
 import { expect } from 'chai';
-import { BN } from 'bn.js';
-import { formatBalance } from '@polkadot/util';
 import {
     capitalize,
     describeWithNetwork,
@@ -36,7 +34,6 @@ describeWithNetwork(network, `${network} RPC`, function(context) {
 
 	it('should be able to Register contract on H160 address 0x01 using Alice account', async () => {
         const finalised = await sendTransaction(
-            context.api,
             context.api.tx.dappsStaking.register(getAddressEnum(CONTRACT)),
             context.alice
         );
@@ -55,7 +52,6 @@ describeWithNetwork(network, `${network} RPC`, function(context) {
 	it('should be able to transfer tokens from alice to charlie', async () => {
         const originalBalance = await context.api.query.system.account(CHARLIE);
         const finalised = await sendTransaction(
-            context.api,
             context.api.tx.balances.transfer({ Id: CHARLIE }, 100),
             context.alice
         );
@@ -68,7 +64,6 @@ describeWithNetwork(network, `${network} RPC`, function(context) {
     it('should be able to transfer tokens from bob to dave', async () => {
         const originalBalance = await context.api.query.system.account(DAVE);
         const finalised = await sendTransaction(
-            context.api,
             context.api.tx.balances.transfer({ Id: DAVE }, 200),
             context.bob
         );

--- a/rpc-tests/tests/test-rpc.js
+++ b/rpc-tests/tests/test-rpc.js
@@ -27,47 +27,69 @@ describeWithNetwork(network, `${network} RPC`, function(context) {
 		expect(name.toString()).to.equal('Astar Collator');
 	});
 
-	it('should be able to Register contract on H160 address 0x01 using Alice account', async function () {
+	it('should be able to Register contract on H160 address 0x01 using Alice account', function (done) {
         const api = context.api;
 
         // Construct the keyring after the API (crypto has an async init)
         const keyring = new Keyring({ type: 'sr25519' });
-      
+
         // Add Alice to our keyring with a hard-derivation path (empty phrase, so uses dev)
         const alice = keyring.addFromUri('//Alice');
 
-        // Create a extrinsic, transferring 100 units to Bob
-        const transfer = api.tx.dappsStaking.register(getAddressEnum(CONTRACT));
-      
-        // Sign and send the transaction using our account
-        const hash = await transfer.signAndSend(alice, { nonce: -1 });
+        let unsubscribe;
 
-        console.log('Transfer sent with hash', hash.toHex());
+        // Create a extrinsic, transferring 200 units to alice
+        api.tx.dappsStaking
+            .register(getAddressEnum(CONTRACT))
+            .signAndSend(alice, (result) => {
+                console.log(`Current status is ${result?.status}`);
 
-        expect(hash).to.exist;
+                if (result?.status?.isInBlock) {
+                    if (unsubscribe) {
+                        unsubscribe();
+                    }
+
+                    expect(result?.status?.isInBlock).to.be.true;
+                    done();
+                }
+            })
+            .then(unsub => {
+                unsubscribe = unsub;
+            });
     });
 
-	it('should be able to transfer tokens from alice to bob', async function () {
+	it('should be able to transfer tokens from alice to bob', function (done) {
         const api = context.api;
 
         // Construct the keyring after the API (crypto has an async init)
         const keyring = new Keyring({ type: 'sr25519' });
-      
+
         // Add Alice to our keyring with a hard-derivation path (empty phrase, so uses dev)
         const alice = keyring.addFromUri('//Alice');
 
+        let unsubscribe;
+
         // Create a extrinsic, transferring 100 units to Bob
-        const transfer = api.tx.balances.transfer(BOB, 100);
-      
-        // Sign and send the transaction using our account
-        const hash = await transfer.signAndSend(alice, { nonce: -1 });
+        api.tx.balances
+            .transfer(BOB, 100)
+            .signAndSend(alice, (result) => {
+                console.log(`Current status is ${result?.status}`);
 
-        console.log('Transfer sent with hash', hash.toHex());
+                if (result?.status?.isInBlock) {
+                    if (unsubscribe) {
+                        unsubscribe();
+                    }
 
-        expect(hash).to.exist;
+                    expect(result?.status?.isInBlock).to.be.true;
+                    done();
+                }
+            })
+            .then(unsub => {
+                unsubscribe = unsub;
+            });
     });
 
-    it('should be able to transfer tokens from bob to alice', async function () {
+    it('should be able to transfer tokens from bob to alice', function (done) {
         const api = context.api;
 
         // Construct the keyring after the API (crypto has an async init)
@@ -76,14 +98,25 @@ describeWithNetwork(network, `${network} RPC`, function(context) {
         // Add Alice to our keyring with a hard-derivation path (empty phrase, so uses dev)
         const bob = keyring.addFromUri('//Bob');
 
-        // Create a extrinsic, transferring 100 units to Bob
-        const transfer = api.tx.balances.transfer(ALICE, 200);
+        let unsubscribe;
 
-        // Sign and send the transaction using our account
-        const hash = await transfer.signAndSend(bob, { nonce: -1 });
+        // Create a extrinsic, transferring 200 units to alice
+        api.tx.balances
+            .transfer(ALICE, 200)
+            .signAndSend(bob, (result) => {
+                console.log(`Current status is ${result?.status}`);
 
-        console.log('Transfer sent with hash', hash.toHex());
+                if (result?.status?.isInBlock) {
+                    if (unsubscribe) {
+                        unsubscribe();
+                    }
 
-        expect(hash).to.exist;
+                    expect(result?.status?.isInBlock).to.be.true;
+                    done();
+                }
+            })
+            .then(unsub => {
+                unsubscribe = unsub;
+            });
     });
 });

--- a/rpc-tests/tests/util.js
+++ b/rpc-tests/tests/util.js
@@ -34,13 +34,12 @@ export async function wait (milliseconds = 0) {
 /**
  * sendTransaction: sign and send transaction from sender accounts.
  *
- * @param {*} api ApiPromise from polkadot.js api
  * @param {*} transaction polkadot js api transaction
  * @param {*} sender account from which transaction needs to be sent
  *
  * @returns true when transaction is finalised
  */
-export async function sendTransaction(api, transaction, sender) {
+export async function sendTransaction(transaction, sender) {
 	return new Promise((resolve, reject) => {
 		let unsubscribe;
 		let timeout;


### PR DESCRIPTION
**Pull Request Summary**
RPC tests cannot be verified before parachain start producing blocks. It starts after relaychain has produced 10 blocks. This PR have added wait for test suite to start when parachain start producing blocks. Test suite starts after parachain has produced at least 2 blocks.

**Check list**
- [ ] added or updated unit tests
- [ ] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [ ] updated spec version
- [ ] updated semver
