### PR TITLE
Remove collator selection upgrade hook from Astar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "astar-collator"
-version = "4.16.0"
+version = "4.16.1"
 dependencies = [
  "astar-runtime",
  "async-trait",
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "astar-runtime"
-version = "4.15.0"
+version = "4.16.1"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -4732,7 +4732,7 @@ checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "local-runtime"
-version = "4.16.0"
+version = "4.16.1"
 dependencies = [
  "fp-rpc",
  "fp-self-contained",
@@ -10411,7 +10411,7 @@ dependencies = [
 
 [[package]]
 name = "shibuya-runtime"
-version = "4.16.0"
+version = "4.16.1"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -10502,7 +10502,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "4.16.0"
+version = "4.16.1"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",

--- a/bin/collator/Cargo.toml
+++ b/bin/collator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-collator"
-version = "4.16.0"
+version = "4.16.1"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Astar collator implementation in Rust."
 build = "build.rs"

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-runtime"
-version = "4.15.0"
+version = "4.16.1"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -95,7 +95,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("astar"),
     impl_name: create_runtime_str!("astar"),
     authoring_version: 1,
-    spec_version: 30,
+    spec_version: 31,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -7,7 +7,7 @@
 use codec::{Decode, Encode};
 use frame_support::{
     construct_runtime, parameter_types,
-    traits::{Contains, Currency, FindAuthor, Get, Imbalance, OnRuntimeUpgrade, OnUnbalanced},
+    traits::{Contains, Currency, FindAuthor, Get, Imbalance, OnUnbalanced},
     weights::{
         constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
         ConstantMultiplier, DispatchClass, Weight, WeightToFeeCoefficient, WeightToFeeCoefficients,
@@ -846,67 +846,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
-    (CollatorListCleanup,),
 >;
-
-pub struct CollatorListCleanup;
-impl OnRuntimeUpgrade for CollatorListCleanup {
-    fn on_runtime_upgrade() -> Weight {
-        use frame_support::traits::{LockIdentifier, LockableCurrency};
-        use pallet_collator_selection::{Candidates, LastAuthoredBlock};
-
-        const COLLATOR_STAKING_ID: LockIdentifier = *b"colstake";
-
-        let mut counter = 0_u64;
-
-        Candidates::<Runtime>::take()
-            .into_iter()
-            .for_each(|candidate| {
-                Balances::remove_lock(COLLATOR_STAKING_ID, &candidate.who);
-                LastAuthoredBlock::<Runtime>::remove(&candidate.who);
-
-                counter += 1;
-            });
-
-        <Runtime as frame_system::Config>::DbWeight::get()
-            .reads_writes(1 + counter * 3, 1 + counter * 4)
-    }
-
-    #[cfg(feature = "try-runtime")]
-    fn pre_upgrade() -> Result<(), &'static str> {
-        use frame_support::traits::OnRuntimeUpgradeHelpersExt;
-        use pallet_collator_selection::Candidates;
-
-        let candidates = Candidates::<Runtime>::get();
-        Self::set_temp_storage(candidates, "candidates");
-        Ok(())
-    }
-
-    #[cfg(feature = "try-runtime")]
-    fn post_upgrade() -> Result<(), &'static str> {
-        use frame_support::traits::LockIdentifier;
-        use frame_support::traits::OnRuntimeUpgradeHelpersExt;
-        use pallet_balances::Locks;
-        use pallet_collator_selection::{CandidateInfo, Candidates, LastAuthoredBlock};
-
-        const COLLATOR_STAKING_ID: LockIdentifier = *b"colstake";
-
-        //  No old candidates should remain
-        assert!(Candidates::<Runtime>::get().is_empty());
-
-        // Ensure there's no prior info about last authored block and that collator selection lock was released
-        let old_candidates =
-            Self::get_temp_storage::<Vec<CandidateInfo<AccountId, Balance>>>("candidates").unwrap();
-        old_candidates.iter().for_each(|candidate| {
-            assert!(!LastAuthoredBlock::<Runtime>::contains_key(&candidate.who));
-            assert!(!Locks::<Runtime>::get(&candidate.who)
-                .iter()
-                .any(|x| x.id == COLLATOR_STAKING_ID));
-        });
-
-        Ok(())
-    }
-}
 
 impl fp_self_contained::SelfContainedCall for Call {
     type SignedInfo = H160;

--- a/runtime/local/Cargo.toml
+++ b/runtime/local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-runtime"
-version = "4.16.0"
+version = "4.16.1"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "4.16.0"
+version = "4.16.1"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "4.16.0"
+version = "4.16.1"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"


### PR DESCRIPTION
**Pull Request Summary**

Removes OnRuntimeUpgrade logic used to migrate collator-selection pallet from Astar runtime.

**Check list**
- [x] updated spec version
- [x] updated semver
