### PR TITLE
RPC tests for dapp staking

### DIFF
--- a/rpc-tests/tests/test-rpc.js
+++ b/rpc-tests/tests/test-rpc.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import BN from 'bn.js';
 import {
     capitalize,
     describeWithNetwork,
@@ -71,5 +72,93 @@ describeWithNetwork(network, `${network} RPC`, function(context) {
 
         expect(finalised).to.be.true;
         expect(newBalance.data.free.sub(originalBalance.data.free).toNumber()).to.equal(200);
+    });
+
+    it('should be able to Bond & stake minimum staking amount on registered contract using Bob account', async () => {
+        const staked = new BN("5000000000000000000");
+        const finalised = await sendTransaction(
+            context.api.tx.dappsStaking.bondAndStake(getAddressEnum(CONTRACT), staked),
+            context.bob
+        );
+        const stakerInfo = await context.api.query.dappsStaking.generalStakerInfo(BOB, getAddressEnum(CONTRACT));
+
+        expect(finalised).to.be.true;
+        expect(stakerInfo.stakes[0].staked).to.equals(staked);
+    });
+
+    it('should be able to Bond & stake an additional 500 tokens on the same contract using Bob account', async () => {
+        const staked = new BN("500000000000000000000");
+        const finalised = await sendTransaction(
+            context.api.tx.dappsStaking.bondAndStake(getAddressEnum(CONTRACT), staked),
+            context.bob
+        );
+        const stakerInfo = await context.api.query.dappsStaking.generalStakerInfo(BOB, getAddressEnum(CONTRACT));
+
+        expect(finalised).to.be.true;
+        expect(stakerInfo.stakes[0].staked).to.equals(staked);
+    });
+
+    it('should be able to Bond & stake an additional 500 tokens on the same contract using Bob account', async () => {
+        const staked = new BN("505000000000000000000");
+        const unbond = new BN("250000000000000000000");
+        const finalised = await sendTransaction(
+            context.api.tx.dappsStaking.unbondAndUnstake(getAddressEnum(CONTRACT), unbond),
+            context.bob
+        );
+        const stakerInfo = await context.api.query.dappsStaking.generalStakerInfo(BOB, getAddressEnum(CONTRACT));
+
+        expect(finalised).to.be.true;
+        expect(stakerInfo.stakes[0].staked).to.equals(staked.sub(unbond));
+    });
+
+    it('should be able to Unbond 250 tokens', async () => {
+        const staked = new BN("505000000000000000000");
+        const unbond = new BN("250000000000000000000");
+        const finalised = await sendTransaction(
+            context.api.tx.dappsStaking.unbondAndUnstake(getAddressEnum(CONTRACT), unbond),
+            context.bob
+        );
+        const stakerInfo = await context.api.query.dappsStaking.generalStakerInfo(BOB, getAddressEnum(CONTRACT));
+
+        expect(finalised).to.be.true;
+        expect(stakerInfo.stakes[0].staked).to.equals(staked.sub(unbond));
+    });
+
+    it('Forcing a new era using a sudo call.', async () => {
+        const finalised = await sendTransaction(
+            context.api.tx.dappsStaking.forceNewEra(),
+            context.bob
+        );
+
+        expect(finalised).to.be.true;
+    });
+
+    it('should be able to Claim dapp rewards for registered contract', async () => {
+        const currentEra = await context.api.query.dappsStaking.currentEra();
+        const finalised = await sendTransaction(
+            context.api.tx.dappsStaking.claimDapp(getAddressEnum(CONTRACT), currentEra),
+            context.bob
+        );
+
+        expect(finalised).to.be.true;
+    });
+
+    it('should be able to Claim Claim staker rewards for registered contract', async () => {
+        const finalised = await sendTransaction(
+            context.api.tx.dappsStaking.claimStaker(getAddressEnum(CONTRACT)),
+            context.bob
+        );
+
+        expect(finalised).to.be.true;
+    });
+
+    it('should be able to Unbond 250 tokens', async () => {
+        const unbond = new BN("250000000000000000000");
+        const finalised = await sendTransaction(
+            context.api.tx.dappsStaking.unbondAndUnstake(getAddressEnum(CONTRACT), unbond),
+            context.bob
+        );
+
+        expect(finalised).to.be.true;
     });
 });


### PR DESCRIPTION
**Pull Request Summary**

Added tests for:

1. Register contract on H160 address **`0x1`** using **Alice** account.
2. Bond & stake minimum staking amount on registered contract using **Bob** account.
3. Bond & stake an additional **500** tokens on the same contract using **Bob** account.
4. Unbond **250** tokens.
5. Ensure that at least a few blocks occur after step 3 (2 blocks should be enough).
6. Force a new era using a **sudo** call.
7. Claim dapp rewards for registered contract
8. Claim staker rewards for registered contract
9. Unbond **250** tokens.
10. Advance for **`UnbondingPeriod`** amount of eras until the first unbonding chunk can be withdrawn
11. Withdraw unbonded funds
12. Advance **ONE** era using **sudo** call
13. Withdraw the remaining unbonded chunk


**Check list**
- [x] added or updated unit tests
- [ ] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [ ] updated spec version
- [ ] updated semver
