### PR TITLE
default parachain id

### DIFF
--- a/bin/collator/src/command.rs
+++ b/bin/collator/src/command.rs
@@ -11,7 +11,7 @@ use crate::{
 use codec::Encode;
 use cumulus_client_cli::generate_genesis_block;
 use cumulus_primitives_core::ParaId;
-use log::info;
+use log::{info, warn};
 use sc_cli::{
     ChainSpec, CliConfiguration, DefaultConfigurationValues, ImportParams, KeystoreParams,
     NetworkParams, Result, RuntimeVersion, SharedParams, SubstrateCli,
@@ -27,6 +27,8 @@ use std::net::SocketAddr;
 
 #[cfg(feature = "frame-benchmarking")]
 use frame_benchmarking_cli::{BenchmarkCmd, SUBSTRATE_REFERENCE_HARDWARE};
+
+const DEFAULT_PARACHAIN_ID: u32 = 2000;
 
 trait IdentifyChain {
     fn is_astar(&self) -> bool;
@@ -67,19 +69,13 @@ impl<T: sc_service::ChainSpec + 'static> IdentifyChain for T {
 
 fn load_spec(
     id: &str,
-    para_id: Option<u32>,
+    para_id: u32,
 ) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
     Ok(match id {
         "dev" => Box::new(development_config()),
-        "astar-dev" => Box::new(chain_spec::astar::get_chain_spec(
-            para_id.ok_or::<String>("parachain id is missing".into())?,
-        )),
-        "shibuya-dev" => Box::new(chain_spec::shibuya::get_chain_spec(
-            para_id.ok_or::<String>("parachain id is missing".into())?,
-        )),
-        "shiden-dev" => Box::new(chain_spec::shiden::get_chain_spec(
-            para_id.ok_or::<String>("parachain id is missing".into())?,
-        )),
+        "astar-dev" => Box::new(chain_spec::astar::get_chain_spec(para_id)),
+        "shibuya-dev" => Box::new(chain_spec::shibuya::get_chain_spec(para_id)),
+        "shiden-dev" => Box::new(chain_spec::shiden::get_chain_spec(para_id)),
         "astar" => Box::new(chain_spec::AstarChainSpec::from_json_bytes(
             &include_bytes!("../res/astar.raw.json")[..],
         )?),
@@ -134,7 +130,7 @@ impl SubstrateCli for Cli {
     }
 
     fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
-        load_spec(id, self.run.parachain_id)
+        load_spec(id, self.run.parachain_id.unwrap_or(DEFAULT_PARACHAIN_ID))
     }
 
     fn native_runtime_version(chain_spec: &Box<dyn ChainSpec>) -> &'static RuntimeVersion {
@@ -656,9 +652,21 @@ pub fn run() -> Result<()> {
                         .chain(cli.relaychain_args.iter()),
                 );
 
-                let extension = chain_spec::Extensions::try_get(&*config.chain_spec);
-				let para_id = extension.map(|e| e.para_id);
-				let id = ParaId::from(cli.run.parachain_id.clone().or(para_id).ok_or::<String>("parachain id is missing".into())?);
+                // Parachain id evaluation order
+                // para id passed by cli arg -> para id in chainspec
+                let cli_arg_para_id = cli.run.parachain_id;
+                let chain_spec_para_id = chain_spec::Extensions::try_get(&*config.chain_spec).map(|e| e.para_id);
+                let id = ParaId::from(match (cli_arg_para_id, chain_spec_para_id) {
+                    (Some(cli_arg_para_id), Some(chain_spec_para_id)) => {
+                        if cli_arg_para_id != chain_spec_para_id {
+                            warn!("Specified parachain id doesn't match the one defined in chainspec");
+                        }
+                        cli_arg_para_id
+                    },
+                    (Some(para_id), None) => para_id,
+                    (None, Some(para_id)) => para_id,
+                    _ => Err("Parachain id is missing")?,
+                });
 
                 let parachain_account =
                     AccountIdConversion::<polkadot_primitives::v2::AccountId>::into_account_truncating(&id);


### PR DESCRIPTION
**Pull Request Summary**
Default parachain id abolishment (raise error when parachain id not found in cli arg or chainspec) had a side effect on subcommands, since all subcommands load spec first and it cannot take `--parachain-id` cli arg. 
This PR recovers default parachain id functionality with a warning in case parachain id in cli arg mismatch one in the chainspec.

No semver updates since this PR is intended to be included in the next version release with other PR updates.

**Check list**
- [ ] added or updated unit tests
- [ ] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [ ] updated spec version
- [ ] updated semver
