### PR TITLE
Proxy on Shibuya/local

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "astar-collator"
-version = "4.19.0"
+version = "4.20.0"
 dependencies = [
  "astar-runtime",
  "async-trait",
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "astar-runtime"
-version = "4.19.0"
+version = "4.20.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -4809,7 +4809,7 @@ checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "local-runtime"
-version = "4.19.0"
+version = "4.20.0"
 dependencies = [
  "chain-extension-trait",
  "dapps-staking-chain-extension",
@@ -4849,6 +4849,7 @@ dependencies = [
  "pallet-evm-precompile-substrate-ecdsa",
  "pallet-grandpa",
  "pallet-precompile-dapps-staking",
+ "pallet-proxy",
  "pallet-randomness-collective-flip",
  "pallet-scheduler",
  "pallet-sudo",
@@ -10508,7 +10509,7 @@ dependencies = [
 
 [[package]]
 name = "shibuya-runtime"
-version = "4.19.0"
+version = "4.20.0"
 dependencies = [
  "chain-extension-trait",
  "cumulus-pallet-aura-ext",
@@ -10560,6 +10561,7 @@ dependencies = [
  "pallet-identity",
  "pallet-multisig",
  "pallet-precompile-dapps-staking",
+ "pallet-proxy",
  "pallet-randomness-collective-flip",
  "pallet-scheduler",
  "pallet-session",
@@ -10601,7 +10603,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "4.19.0"
+version = "4.20.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",

--- a/bin/collator/Cargo.toml
+++ b/bin/collator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-collator"
-version = "4.19.0"
+version = "4.20.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Astar collator implementation in Rust."
 build = "build.rs"

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-runtime"
-version = "4.19.0"
+version = "4.20.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/local/Cargo.toml
+++ b/runtime/local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-runtime"
-version = "4.19.0"
+version = "4.20.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"
@@ -33,6 +33,7 @@ pallet-evm-precompile-modexp = { git = "https://github.com/AstarNetwork/frontier
 pallet-evm-precompile-sha3fips = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.28", default-features = false }
 pallet-evm-precompile-simple = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.28", default-features = false }
 pallet-grandpa = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
+pallet-proxy = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
 pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
 pallet-scheduler = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
 pallet-sudo = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
@@ -121,6 +122,7 @@ std = [
 	"pallet-transaction-payment/std",
 	"pallet-utility/std",
 	"pallet-vesting/std",
+	"pallet-proxy/std",
 	"sp-api/std",
 	"sp-block-builder/std",
 	"sp-consensus-aura/std",

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "4.19.0"
+version = "4.20.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"
@@ -54,6 +54,7 @@ pallet-evm-precompile-sha3fips = { git = "https://github.com/AstarNetwork/fronti
 pallet-evm-precompile-simple = { git = "https://github.com/AstarNetwork/frontier", branch = "polkadot-v0.9.28", default-features = false }
 pallet-identity = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
 pallet-multisig = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
+pallet-proxy = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
 pallet-randomness-collective-flip = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
 pallet-scheduler = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
 pallet-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28", default-features = false }
@@ -166,6 +167,7 @@ std = [
 	"pallet-utility/std",
 	"pallet-timestamp/std",
 	"pallet-vesting/std",
+	"pallet-proxy/std",
 	"sp-offchain/std",
 	"sp-session/std",
 	"pallet-sudo/std",

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -4,13 +4,13 @@
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
 
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, MaxEncodedLen};
 use cumulus_pallet_parachain_system::AnyRelayNumber;
 use frame_support::{
     construct_runtime, parameter_types,
     traits::{
-        ConstU32, Contains, Currency, EitherOfDiverse, EqualPrivilegeOnly, FindAuthor, Get,
-        Imbalance, Nothing, OnUnbalanced,
+        ConstU128, ConstU32, Contains, Currency, EitherOfDiverse, EqualPrivilegeOnly, FindAuthor,
+        Get, Imbalance, InstanceFilter, Nothing, OnUnbalanced,
     },
     weights::{
         constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
@@ -136,7 +136,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shibuya"),
     impl_name: create_runtime_str!("shibuya"),
     authoring_version: 1,
-    spec_version: 64,
+    spec_version: 65,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,
@@ -931,6 +931,56 @@ impl pallet_sudo::Config for Runtime {
     type Call = Call;
 }
 
+/// The type used to represent the kinds of proxying allowed.
+#[derive(
+    Copy,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Encode,
+    Decode,
+    RuntimeDebug,
+    MaxEncodedLen,
+    scale_info::TypeInfo,
+)]
+pub enum ProxyType {
+    Any,
+}
+
+impl Default for ProxyType {
+    fn default() -> Self {
+        Self::Any
+    }
+}
+impl InstanceFilter<Call> for ProxyType {
+    fn filter(&self, _c: &Call) -> bool {
+        match self {
+            ProxyType::Any => true,
+        }
+    }
+}
+
+impl pallet_proxy::Config for Runtime {
+    type Event = Event;
+    type Call = Call;
+    type Currency = Balances;
+    type ProxyType = ProxyType;
+    // One storage item; key size 32, value size 8; .
+    type ProxyDepositBase = ConstU128<{ SDN * 1 }>;
+    // Additional storage item size of 33 bytes.
+    type ProxyDepositFactor = ConstU128<{ MILLISDN * 330 }>;
+    type MaxProxies = ConstU32<32>;
+    type WeightInfo = pallet_proxy::weights::SubstrateWeight<Runtime>;
+    type MaxPending = ConstU32<32>;
+    type CallHasher = BlakeTwo256;
+    // Key size 32 + 1 item
+    type AnnouncementDepositBase = ConstU128<{ SDN * 1 }>;
+    // Acc Id + Hash + block number
+    type AnnouncementDepositFactor = ConstU128<{ MILLISDN * 660 }>;
+}
+
 pub struct EvmRevertCodeHandler;
 impl pallet_xc_asset_config::XcAssetChanged<Runtime> for EvmRevertCodeHandler {
     fn xc_asset_registered(asset_id: AssetId) {
@@ -965,6 +1015,7 @@ construct_runtime!(
         EthCall: pallet_custom_signatures = 15,
         RandomnessCollectiveFlip: pallet_randomness_collective_flip = 16,
         Scheduler: pallet_scheduler = 17,
+        Proxy: pallet_proxy = 18,
 
         ParachainSystem: cumulus_pallet_parachain_system = 20,
         ParachainInfo: parachain_info = 21,
@@ -1050,26 +1101,10 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
-    (ElasticityCleanup,),
 >;
 
-use frame_support::traits::OnRuntimeUpgrade;
-pub struct ElasticityCleanup;
-impl OnRuntimeUpgrade for ElasticityCleanup {
-    fn on_runtime_upgrade() -> Weight {
-        pallet_base_fee::Elasticity::<Runtime>::put(Permill::zero());
-        <Runtime as frame_system::Config>::DbWeight::get().writes(1)
-    }
-
-    #[cfg(feature = "try-runtime")]
-    fn post_upgrade() -> Result<(), &'static str> {
-        assert!(pallet_base_fee::Elasticity::<Runtime>::get().is_zero());
-        Ok(())
-    }
-}
 #[derive(Default)]
 pub struct DappsStakingChainExtension;
-
 impl RegisteredChainExtension<Runtime> for DappsStakingChainExtension {
     const ID: u16 = 00;
 }

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "4.19.0"
+version = "4.20.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -95,7 +95,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shiden"),
     impl_name: create_runtime_str!("shiden"),
     authoring_version: 1,
-    spec_version: 68,
+    spec_version: 69,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,
@@ -875,23 +875,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
-    (ElasticityCleanup,),
 >;
-
-use frame_support::traits::OnRuntimeUpgrade;
-pub struct ElasticityCleanup;
-impl OnRuntimeUpgrade for ElasticityCleanup {
-    fn on_runtime_upgrade() -> Weight {
-        pallet_base_fee::Elasticity::<Runtime>::put(Permill::zero());
-        <Runtime as frame_system::Config>::DbWeight::get().writes(1)
-    }
-
-    #[cfg(feature = "try-runtime")]
-    fn post_upgrade() -> Result<(), &'static str> {
-        assert!(pallet_base_fee::Elasticity::<Runtime>::get().is_zero());
-        Ok(())
-    }
-}
 
 impl fp_self_contained::SelfContainedCall for Call {
     type SignedInfo = H160;


### PR DESCRIPTION
**Pull Request Summary**

Adds `Proxy` pallet to `Shibuya` and `local` runtimes.

Also removes deprecated `OnRuntimeUpgrade` hooks for `Shibuya` and `Shiden`.
They are kept for `Astar` since upgrade is scheduled later this week.

**Check list**
- [x] updated spec version
- [x] updated semver
