### PR TITLE
10 times max weight for non-tx eth calls

### DIFF
--- a/bin/collator/src/rpc.rs
+++ b/bin/collator/src/rpc.rs
@@ -173,8 +173,8 @@ where
             block_data_cache.clone(),
             fee_history_cache,
             fee_history_limit,
-            // Unit multiplier for non-transactional - can be changed in the future
-            1,
+            // Allow 10x max allowed weight for non-transactional calls
+            10,
         )
         .into_rpc(),
     )?;


### PR DESCRIPTION
**Pull Request Summary**

Increases max allowed weight for non-transactional ETH calls 10 folds.

This can be useful for situations like with Graph where default settings don't work by default (e.g. 50_000_000 max gas).

Skipped updating semver since no changes were released yet.

Based on: https://github.com/paritytech/frontier/pull/799
