### PR TITLE
Node start selection change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "astar-collator"
-version = "4.21.1"
+version = "4.21.2"
 dependencies = [
  "astar-runtime",
  "async-trait",
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "astar-runtime"
-version = "4.21.1"
+version = "4.21.2"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -4760,7 +4760,7 @@ checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "local-runtime"
-version = "4.21.1"
+version = "4.21.2"
 dependencies = [
  "chain-extension-trait",
  "dapps-staking-chain-extension",
@@ -10503,7 +10503,7 @@ dependencies = [
 
 [[package]]
 name = "shibuya-runtime"
-version = "4.21.1"
+version = "4.21.2"
 dependencies = [
  "chain-extension-trait",
  "cumulus-pallet-aura-ext",
@@ -10600,7 +10600,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "4.21.1"
+version = "4.21.2"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",

--- a/bin/collator/Cargo.toml
+++ b/bin/collator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-collator"
-version = "4.21.1"
+version = "4.21.2"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Astar collator implementation in Rust."
 build = "build.rs"

--- a/bin/collator/src/command.rs
+++ b/bin/collator/src/command.rs
@@ -11,7 +11,7 @@ use crate::{
 use codec::Encode;
 use cumulus_client_cli::generate_genesis_block;
 use cumulus_primitives_core::ParaId;
-use log::{info, warn, error};
+use log::{error, info, warn};
 use sc_cli::{
     ChainSpec, CliConfiguration, DefaultConfigurationValues, ImportParams, KeystoreParams,
     NetworkParams, Result, RuntimeVersion, SharedParams, SubstrateCli,

--- a/bin/collator/src/command.rs
+++ b/bin/collator/src/command.rs
@@ -11,7 +11,7 @@ use crate::{
 use codec::Encode;
 use cumulus_client_cli::generate_genesis_block;
 use cumulus_primitives_core::ParaId;
-use log::{info, warn};
+use log::{info, warn, error};
 use sc_cli::{
     ChainSpec, CliConfiguration, DefaultConfigurationValues, ImportParams, KeystoreParams,
     NetworkParams, Result, RuntimeVersion, SharedParams, SubstrateCli,
@@ -79,7 +79,7 @@ fn load_spec(
         "astar" => Box::new(chain_spec::AstarChainSpec::from_json_bytes(
             &include_bytes!("../res/astar.raw.json")[..],
         )?),
-        "" | "shiden" => Box::new(chain_spec::ShidenChainSpec::from_json_bytes(
+        "shiden" => Box::new(chain_spec::ShidenChainSpec::from_json_bytes(
             &include_bytes!("../res/shiden.raw.json")[..],
         )?),
         "shibuya" => Box::new(chain_spec::ShibuyaChainSpec::from_json_bytes(
@@ -91,8 +91,10 @@ fn load_spec(
                 Box::new(chain_spec::AstarChainSpec::from_json_file(path.into())?)
             } else if chain_spec.is_shiden() {
                 Box::new(chain_spec::ShidenChainSpec::from_json_file(path.into())?)
-            } else {
+            } else if chain_spec.is_shibuya() {
                 Box::new(chain_spec)
+            } else {
+                Err("Unclear which chain spec to base this chain on. Name should start with astar, shiden or shibuya if custom name is used")?
             }
         }
     })
@@ -705,11 +707,15 @@ pub fn run() -> Result<()> {
                         .await
                         .map(|r| r.0)
                         .map_err(Into::into)
-                } else {
+                } else if config.chain_spec.is_shibuya() {
                     start_shibuya_node(config, polkadot_config, collator_options, id)
                         .await
                         .map(|r| r.0)
                         .map_err(Into::into)
+                } else {
+                    let err_msg = "Unrecognized chain spec - name should start with one of: astar or shiden or shibuya";
+                    error!("{}", err_msg);
+                    Err(err_msg.into())
                 }
             })
         }

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-runtime"
-version = "4.21.1"
+version = "4.21.2"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/local/Cargo.toml
+++ b/runtime/local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-runtime"
-version = "4.21.1"
+version = "4.21.2"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "4.21.1"
+version = "4.21.2"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "4.21.1"
+version = "4.21.2"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"


### PR DESCRIPTION
**Pull Request Summary**

Fixed an issue where inappropriate runtime would be selected for a chain-spec in case its name doesn't start with `astar`, `shiden` or `shibuya`.

Also removed the default chain to be `shiden`. 

**Check list**
- [x] updated semver
