### PR TITLE
ManagerOrigin for xc-asset-config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,7 +1032,7 @@ dependencies = [
 [[package]]
 name = "chain-extension-trait"
 version = "1.0.3"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#791b6d622f64ea454e3ef12037bcebc449954503"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
 dependencies = [
  "pallet-contracts",
  "sp-runtime",
@@ -1983,7 +1983,7 @@ dependencies = [
 [[package]]
 name = "dapps-staking-chain-extension"
 version = "1.0.4"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#791b6d622f64ea454e3ef12037bcebc449954503"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
 dependencies = [
  "chain-extension-trait",
  "dapps-staking-chain-extension-types",
@@ -2005,7 +2005,7 @@ dependencies = [
 [[package]]
 name = "dapps-staking-chain-extension-types"
 version = "1.0.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#791b6d622f64ea454e3ef12037bcebc449954503"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -2407,34 +2407,14 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "evm"
 version = "0.35.0"
-source = "git+https://github.com/rust-blockchain/evm?rev=01bcbd2205a212c34451d3b4fabc962793b057d3#01bcbd2205a212c34451d3b4fabc962793b057d3"
-dependencies = [
- "auto_impl",
- "environmental",
- "ethereum",
- "evm-core 0.35.0 (git+https://github.com/rust-blockchain/evm?rev=01bcbd2205a212c34451d3b4fabc962793b057d3)",
- "evm-gasometer 0.35.0 (git+https://github.com/rust-blockchain/evm?rev=01bcbd2205a212c34451d3b4fabc962793b057d3)",
- "evm-runtime 0.35.0 (git+https://github.com/rust-blockchain/evm?rev=01bcbd2205a212c34451d3b4fabc962793b057d3)",
- "log",
- "parity-scale-codec",
- "primitive-types",
- "rlp",
- "scale-info",
- "serde",
- "sha3 0.10.5",
-]
-
-[[package]]
-name = "evm"
-version = "0.35.0"
 source = "git+https://github.com/rust-blockchain/evm?rev=51b8c2ce3104265e1fd5bb0fe5cdfd2e0938239c#51b8c2ce3104265e1fd5bb0fe5cdfd2e0938239c"
 dependencies = [
  "auto_impl",
  "environmental",
  "ethereum",
- "evm-core 0.35.0 (git+https://github.com/rust-blockchain/evm?rev=51b8c2ce3104265e1fd5bb0fe5cdfd2e0938239c)",
- "evm-gasometer 0.35.0 (git+https://github.com/rust-blockchain/evm?rev=51b8c2ce3104265e1fd5bb0fe5cdfd2e0938239c)",
- "evm-runtime 0.35.0 (git+https://github.com/rust-blockchain/evm?rev=51b8c2ce3104265e1fd5bb0fe5cdfd2e0938239c)",
+ "evm-core",
+ "evm-gasometer",
+ "evm-runtime",
  "log",
  "parity-scale-codec",
  "primitive-types",
@@ -2442,17 +2422,6 @@ dependencies = [
  "scale-info",
  "serde",
  "sha3 0.10.5",
-]
-
-[[package]]
-name = "evm-core"
-version = "0.35.0"
-source = "git+https://github.com/rust-blockchain/evm?rev=01bcbd2205a212c34451d3b4fabc962793b057d3#01bcbd2205a212c34451d3b4fabc962793b057d3"
-dependencies = [
- "parity-scale-codec",
- "primitive-types",
- "scale-info",
- "serde",
 ]
 
 [[package]]
@@ -2469,35 +2438,12 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.35.0"
-source = "git+https://github.com/rust-blockchain/evm?rev=01bcbd2205a212c34451d3b4fabc962793b057d3#01bcbd2205a212c34451d3b4fabc962793b057d3"
-dependencies = [
- "environmental",
- "evm-core 0.35.0 (git+https://github.com/rust-blockchain/evm?rev=01bcbd2205a212c34451d3b4fabc962793b057d3)",
- "evm-runtime 0.35.0 (git+https://github.com/rust-blockchain/evm?rev=01bcbd2205a212c34451d3b4fabc962793b057d3)",
- "primitive-types",
-]
-
-[[package]]
-name = "evm-gasometer"
-version = "0.35.0"
 source = "git+https://github.com/rust-blockchain/evm?rev=51b8c2ce3104265e1fd5bb0fe5cdfd2e0938239c#51b8c2ce3104265e1fd5bb0fe5cdfd2e0938239c"
 dependencies = [
  "environmental",
- "evm-core 0.35.0 (git+https://github.com/rust-blockchain/evm?rev=51b8c2ce3104265e1fd5bb0fe5cdfd2e0938239c)",
- "evm-runtime 0.35.0 (git+https://github.com/rust-blockchain/evm?rev=51b8c2ce3104265e1fd5bb0fe5cdfd2e0938239c)",
+ "evm-core",
+ "evm-runtime",
  "primitive-types",
-]
-
-[[package]]
-name = "evm-runtime"
-version = "0.35.0"
-source = "git+https://github.com/rust-blockchain/evm?rev=01bcbd2205a212c34451d3b4fabc962793b057d3#01bcbd2205a212c34451d3b4fabc962793b057d3"
-dependencies = [
- "auto_impl",
- "environmental",
- "evm-core 0.35.0 (git+https://github.com/rust-blockchain/evm?rev=01bcbd2205a212c34451d3b4fabc962793b057d3)",
- "primitive-types",
- "sha3 0.10.5",
 ]
 
 [[package]]
@@ -2507,7 +2453,7 @@ source = "git+https://github.com/rust-blockchain/evm?rev=51b8c2ce3104265e1fd5bb0
 dependencies = [
  "auto_impl",
  "environmental",
- "evm-core 0.35.0 (git+https://github.com/rust-blockchain/evm?rev=51b8c2ce3104265e1fd5bb0fe5cdfd2e0938239c)",
+ "evm-core",
  "primitive-types",
  "sha3 0.10.5",
 ]
@@ -2657,7 +2603,7 @@ source = "git+https://github.com/AstarNetwork/frontier?branch=polkadot-v0.9.29#2
 dependencies = [
  "ethereum",
  "ethereum-types",
- "evm 0.35.0 (git+https://github.com/rust-blockchain/evm?rev=51b8c2ce3104265e1fd5bb0fe5cdfd2e0938239c)",
+ "evm",
  "fc-db",
  "fc-rpc-core",
  "fp-evm",
@@ -2846,7 +2792,7 @@ name = "fp-evm"
 version = "3.0.0-dev"
 source = "git+https://github.com/AstarNetwork/frontier?branch=polkadot-v0.9.29#28954b2040d26b5d204bb3eac4a70a65ca76a860"
 dependencies = [
- "evm 0.35.0 (git+https://github.com/rust-blockchain/evm?rev=51b8c2ce3104265e1fd5bb0fe5cdfd2e0938239c)",
+ "evm",
  "frame-support",
  "parity-scale-codec",
  "serde",
@@ -2897,7 +2843,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3027,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -3058,7 +3004,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3072,7 +3018,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -3084,7 +3030,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3094,7 +3040,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "frame-support",
  "log",
@@ -5608,7 +5554,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5654,7 +5600,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5713,7 +5659,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5782,7 +5728,7 @@ dependencies = [
 [[package]]
 name = "pallet-block-reward"
 version = "2.2.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#791b6d622f64ea454e3ef12037bcebc449954503"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5838,7 +5784,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "3.3.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#791b6d622f64ea454e3ef12037bcebc449954503"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5875,7 +5821,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "bitflags",
  "frame-benchmarking",
@@ -5902,7 +5848,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "bitflags",
  "parity-scale-codec",
@@ -5917,7 +5863,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5944,7 +5890,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "pallet-contracts-primitives",
  "parity-scale-codec",
@@ -5957,7 +5903,7 @@ dependencies = [
 [[package]]
 name = "pallet-custom-signatures"
 version = "4.5.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#791b6d622f64ea454e3ef12037bcebc449954503"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5973,7 +5919,7 @@ dependencies = [
 [[package]]
 name = "pallet-dapps-staking"
 version = "3.6.3"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#791b6d622f64ea454e3ef12037bcebc449954503"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6070,7 +6016,7 @@ source = "git+https://github.com/AstarNetwork/frontier?branch=polkadot-v0.9.29#2
 dependencies = [
  "ethereum",
  "ethereum-types",
- "evm 0.35.0 (git+https://github.com/rust-blockchain/evm?rev=51b8c2ce3104265e1fd5bb0fe5cdfd2e0938239c)",
+ "evm",
  "fp-consensus",
  "fp-ethereum",
  "fp-evm",
@@ -6095,7 +6041,7 @@ name = "pallet-evm"
 version = "6.0.0-dev"
 source = "git+https://github.com/AstarNetwork/frontier?branch=polkadot-v0.9.29#28954b2040d26b5d204bb3eac4a70a65ca76a860"
 dependencies = [
- "evm 0.35.0 (git+https://github.com/rust-blockchain/evm?rev=51b8c2ce3104265e1fd5bb0fe5cdfd2e0938239c)",
+ "evm",
  "fp-evm",
  "frame-benchmarking",
  "frame-support",
@@ -6129,7 +6075,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-assets-erc20"
 version = "0.5.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#791b6d622f64ea454e3ef12037bcebc449954503"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6216,7 +6162,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sr25519"
 version = "1.2.1"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#791b6d622f64ea454e3ef12037bcebc449954503"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
 dependencies = [
  "fp-evm",
  "log",
@@ -6232,7 +6178,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-substrate-ecdsa"
 version = "1.2.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#791b6d622f64ea454e3ef12037bcebc449954503"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
 dependencies = [
  "fp-evm",
  "log",
@@ -6247,8 +6193,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-precompile-xcm"
-version = "0.5.1"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#791b6d622f64ea454e3ef12037bcebc449954503"
+version = "0.7.0"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6271,7 +6217,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-xvm"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#791b6d622f64ea454e3ef12037bcebc449954503"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6532,7 +6478,7 @@ dependencies = [
 [[package]]
 name = "pallet-precompile-dapps-staking"
 version = "3.6.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#791b6d622f64ea454e3ef12037bcebc449954503"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6628,7 +6574,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6736,7 +6682,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6773,7 +6719,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6862,8 +6808,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xc-asset-config"
-version = "1.2.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#791b6d622f64ea454e3ef12037bcebc449954503"
+version = "1.3.0"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6881,7 +6827,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "0.9.28"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#791b6d622f64ea454e3ef12037bcebc449954503"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6934,7 +6880,7 @@ dependencies = [
 [[package]]
 name = "pallet-xvm"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#791b6d622f64ea454e3ef12037bcebc449954503"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8425,9 +8371,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 [[package]]
 name = "precompile-utils"
 version = "0.4.3"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#791b6d622f64ea454e3ef12037bcebc449954503"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
 dependencies = [
- "evm 0.35.0 (git+https://github.com/rust-blockchain/evm?rev=01bcbd2205a212c34451d3b4fabc962793b057d3)",
+ "evm",
  "fp-evm",
  "frame-support",
  "frame-system",
@@ -8448,7 +8394,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#791b6d622f64ea454e3ef12037bcebc449954503"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
 dependencies = [
  "num_enum",
  "proc-macro2",
@@ -10926,7 +10872,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "hash-db",
  "log",
@@ -10944,7 +10890,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "blake2",
  "proc-macro-crate",
@@ -10956,7 +10902,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10969,7 +10915,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -10997,7 +10943,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11126,7 +11072,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "base58",
  "bitflags",
@@ -11172,7 +11118,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "blake2",
  "byteorder",
@@ -11186,7 +11132,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11206,7 +11152,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11216,7 +11162,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -11245,7 +11191,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -11259,7 +11205,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "bytes",
  "futures",
@@ -11296,7 +11242,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "async-trait",
  "futures",
@@ -11361,7 +11307,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -11371,7 +11317,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -11381,7 +11327,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -11403,7 +11349,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -11421,7 +11367,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -11433,7 +11379,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11447,7 +11393,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11461,7 +11407,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11472,7 +11418,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "hash-db",
  "log",
@@ -11494,12 +11440,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 
 [[package]]
 name = "sp-storage"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -11525,7 +11471,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -11541,7 +11487,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -11578,7 +11524,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "ahash",
  "hash-db",
@@ -11601,7 +11547,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -11618,7 +11564,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -11629,7 +11575,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#7c4ac358c29c9748c6e8ed4e05910504cd01a3b9"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#cc370aa61e15c18d23a2f686b812fd576a630afe"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
@@ -12391,7 +12337,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.5",
  "rand 0.8.5",
  "static_assertions",
@@ -13241,7 +13187,7 @@ dependencies = [
 [[package]]
 name = "xcm-primitives"
 version = "0.3.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#791b6d622f64ea454e3ef12037bcebc449954503"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
 dependencies = [
  "frame-support",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,7 +1032,7 @@ dependencies = [
 [[package]]
 name = "chain-extension-trait"
 version = "1.0.3"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
 dependencies = [
  "pallet-contracts",
  "sp-runtime",
@@ -1983,7 +1983,7 @@ dependencies = [
 [[package]]
 name = "dapps-staking-chain-extension"
 version = "1.0.4"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
 dependencies = [
  "chain-extension-trait",
  "dapps-staking-chain-extension-types",
@@ -2005,7 +2005,7 @@ dependencies = [
 [[package]]
 name = "dapps-staking-chain-extension-types"
 version = "1.0.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5728,7 +5728,7 @@ dependencies = [
 [[package]]
 name = "pallet-block-reward"
 version = "2.2.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5784,7 +5784,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "3.3.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5903,7 +5903,7 @@ dependencies = [
 [[package]]
 name = "pallet-custom-signatures"
 version = "4.5.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5919,7 +5919,7 @@ dependencies = [
 [[package]]
 name = "pallet-dapps-staking"
 version = "3.6.3"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6075,7 +6075,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-assets-erc20"
 version = "0.5.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6162,7 +6162,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sr25519"
 version = "1.2.1"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
 dependencies = [
  "fp-evm",
  "log",
@@ -6178,7 +6178,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-substrate-ecdsa"
 version = "1.2.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
 dependencies = [
  "fp-evm",
  "log",
@@ -6194,7 +6194,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-xcm"
 version = "0.7.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6217,7 +6217,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-xvm"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6478,7 +6478,7 @@ dependencies = [
 [[package]]
 name = "pallet-precompile-dapps-staking"
 version = "3.6.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6809,7 +6809,7 @@ dependencies = [
 [[package]]
 name = "pallet-xc-asset-config"
 version = "1.3.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6827,7 +6827,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "0.9.28"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6880,7 +6880,7 @@ dependencies = [
 [[package]]
 name = "pallet-xvm"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8371,7 +8371,7 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 [[package]]
 name = "precompile-utils"
 version = "0.4.3"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
 dependencies = [
  "evm",
  "fp-evm",
@@ -8394,7 +8394,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
 dependencies = [
  "num_enum",
  "proc-macro2",
@@ -12337,7 +12337,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "digest 0.10.5",
  "rand 0.8.5",
  "static_assertions",
@@ -13187,7 +13187,7 @@ dependencies = [
 [[package]]
 name = "xcm-primitives"
 version = "0.3.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#a2345dd3604ada06b22444a4858433f2c9302c2d"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
 dependencies = [
  "frame-support",
  "log",

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -733,6 +733,7 @@ impl pallet_xc_asset_config::Config for Runtime {
     type Event = Event;
     type AssetId = AssetId;
     type XcAssetChanged = EvmRevertCodeHandler;
+    type ManagerOrigin = frame_system::EnsureRoot<AccountId>;
     type WeightInfo = weights::pallet_xc_asset_config::WeightInfo<Self>;
 }
 

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -202,6 +202,12 @@ impl Contains<Call> for BaseFilter {
                 pallet_assets::Call::destroy { id, .. } => *id < u32::MAX.into(),
                 _ => true,
             },
+            // Filter cross-chain asset config, only allow registration for non-root users
+            Call::XcAssetConfig(method) => match method {
+                pallet_xc_asset_config::Call::register_asset_location { .. } => true,
+                // registering the asset location should be good enough for users, any change can be handled via issue ticket or help request
+                _ => false,
+            },
             // These modules are not allowed to be called by transactions:
             // Other modules should works:
             _ => true,
@@ -1011,6 +1017,8 @@ impl pallet_xc_asset_config::Config for Runtime {
     type Event = Event;
     type AssetId = AssetId;
     type XcAssetChanged = EvmRevertCodeHandler;
+    // Good enough for testnet since we lack pallet-assets hooks for now
+    type ManagerOrigin = frame_system::EnsureSigned<AccountId>;
     type WeightInfo = weights::pallet_xc_asset_config::WeightInfo<Self>;
 }
 

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -779,6 +779,7 @@ impl pallet_xc_asset_config::Config for Runtime {
     type Event = Event;
     type AssetId = AssetId;
     type XcAssetChanged = EvmRevertCodeHandler;
+    type ManagerOrigin = frame_system::EnsureRoot<AccountId>;
     type WeightInfo = weights::pallet_xc_asset_config::WeightInfo<Self>;
 }
 


### PR DESCRIPTION
**Pull Request Summary**

Integrates `ManagerOrigin` for `XcAssetConfig` pallet.

This is useful because we can allow `SignedOrigin` to register cross-chain asset on Shibuya, resulting in EVM revert code being registered. Could also be used later on for Governance V2 if we want to have custom origin check for `XcAssetConfig` root-like access.

**TODO** - spec version and semver uplift will be done in https://github.com/AstarNetwork/Astar/pull/755
