### PR TITLE
Bump versions for XCM `assets_reserve_transfer` precompile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "astar-collator"
-version = "4.23.0"
+version = "4.24.0"
 dependencies = [
  "astar-runtime",
  "async-trait",
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "astar-runtime"
-version = "4.23.0"
+version = "4.24.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -1032,7 +1032,7 @@ dependencies = [
 [[package]]
 name = "chain-extension-trait"
 version = "1.0.3"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#653c097b2d58ad16321fb92eba23bd91729f1531"
 dependencies = [
  "pallet-contracts",
  "sp-runtime",
@@ -1983,7 +1983,7 @@ dependencies = [
 [[package]]
 name = "dapps-staking-chain-extension"
 version = "1.0.4"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#653c097b2d58ad16321fb92eba23bd91729f1531"
 dependencies = [
  "chain-extension-trait",
  "dapps-staking-chain-extension-types",
@@ -2005,7 +2005,7 @@ dependencies = [
 [[package]]
 name = "dapps-staking-chain-extension-types"
 version = "1.0.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#653c097b2d58ad16321fb92eba23bd91729f1531"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5728,7 +5728,7 @@ dependencies = [
 [[package]]
 name = "pallet-block-reward"
 version = "2.2.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#653c097b2d58ad16321fb92eba23bd91729f1531"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5784,7 +5784,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "3.3.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#653c097b2d58ad16321fb92eba23bd91729f1531"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5903,7 +5903,7 @@ dependencies = [
 [[package]]
 name = "pallet-custom-signatures"
 version = "4.5.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#653c097b2d58ad16321fb92eba23bd91729f1531"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5919,7 +5919,7 @@ dependencies = [
 [[package]]
 name = "pallet-dapps-staking"
 version = "3.6.3"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#653c097b2d58ad16321fb92eba23bd91729f1531"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6075,7 +6075,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-assets-erc20"
 version = "0.5.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#653c097b2d58ad16321fb92eba23bd91729f1531"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6162,7 +6162,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sr25519"
 version = "1.2.1"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#653c097b2d58ad16321fb92eba23bd91729f1531"
 dependencies = [
  "fp-evm",
  "log",
@@ -6178,7 +6178,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-substrate-ecdsa"
 version = "1.2.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#653c097b2d58ad16321fb92eba23bd91729f1531"
 dependencies = [
  "fp-evm",
  "log",
@@ -6194,7 +6194,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-xcm"
 version = "0.7.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#653c097b2d58ad16321fb92eba23bd91729f1531"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6217,7 +6217,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-xvm"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#653c097b2d58ad16321fb92eba23bd91729f1531"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6478,7 +6478,7 @@ dependencies = [
 [[package]]
 name = "pallet-precompile-dapps-staking"
 version = "3.6.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#653c097b2d58ad16321fb92eba23bd91729f1531"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6809,7 +6809,7 @@ dependencies = [
 [[package]]
 name = "pallet-xc-asset-config"
 version = "1.3.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#653c097b2d58ad16321fb92eba23bd91729f1531"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6827,7 +6827,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "0.9.28"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#653c097b2d58ad16321fb92eba23bd91729f1531"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6880,7 +6880,7 @@ dependencies = [
 [[package]]
 name = "pallet-xvm"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#653c097b2d58ad16321fb92eba23bd91729f1531"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8371,7 +8371,7 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 [[package]]
 name = "precompile-utils"
 version = "0.4.3"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#653c097b2d58ad16321fb92eba23bd91729f1531"
 dependencies = [
  "evm",
  "fp-evm",
@@ -8394,7 +8394,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#653c097b2d58ad16321fb92eba23bd91729f1531"
 dependencies = [
  "num_enum",
  "proc-macro2",
@@ -10534,7 +10534,7 @@ dependencies = [
 
 [[package]]
 name = "shibuya-runtime"
-version = "4.23.0"
+version = "4.24.0"
 dependencies = [
  "chain-extension-trait",
  "cumulus-pallet-aura-ext",
@@ -10632,7 +10632,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "4.23.0"
+version = "4.24.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -12337,7 +12337,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.5",
  "rand 0.8.5",
  "static_assertions",
@@ -13187,7 +13187,7 @@ dependencies = [
 [[package]]
 name = "xcm-primitives"
 version = "0.3.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#861b8fbef4a04b5ad177e364d40a56dbba5f45ab"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.29#653c097b2d58ad16321fb92eba23bd91729f1531"
 dependencies = [
  "frame-support",
  "log",

--- a/bin/collator/Cargo.toml
+++ b/bin/collator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-collator"
-version = "4.23.0"
+version = "4.24.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Astar collator implementation in Rust."
 build = "build.rs"

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-runtime"
-version = "4.23.0"
+version = "4.24.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -95,7 +95,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("astar"),
     impl_name: create_runtime_str!("astar"),
     authoring_version: 1,
-    spec_version: 36,
+    spec_version: 37,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "4.23.0"
+version = "4.24.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -136,7 +136,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shibuya"),
     impl_name: create_runtime_str!("shibuya"),
     authoring_version: 1,
-    spec_version: 69,
+    spec_version: 70,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "4.23.0"
+version = "4.24.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -95,7 +95,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shiden"),
     impl_name: create_runtime_str!("shiden"),
     authoring_version: 1,
-    spec_version: 72,
+    spec_version: 73,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,


### PR DESCRIPTION
Recent `frame-astar` contains XCM precompile for `assets_reserve_transfer`.

This PR bumps collator and runtime versions and spec versions and updates `xcm-primitives` dependency.