### PR TITLE
Add account32hash to xcm-tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13249,7 +13249,7 @@ dependencies = [
 
 [[package]]
 name = "xcm-tools"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap 4.0.15",
  "cumulus-primitives-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ version = "4.25.0"
 dependencies = [
  "astar-runtime",
  "async-trait",
- "clap",
+ "clap 3.2.22",
  "cumulus-client-cli",
  "cumulus-client-consensus-aura",
  "cumulus-client-consensus-common",
@@ -1103,13 +1103,28 @@ checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.18",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf8832993da70a4c6d13c581f4463c2bdda27b9bf1c5498dc4365543abe6d6f"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive 4.0.13",
+ "clap_lex 0.3.0",
+ "once_cell",
+ "strsim",
+ "termcolor",
 ]
 
 [[package]]
@@ -1126,10 +1141,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1479,7 +1516,7 @@ name = "cumulus-client-cli"
 version = "0.1.0"
 source = "git+https://github.com/paritytech/cumulus?branch=polkadot-v0.9.29#35dd14f0fefbb159790045b60a05fe03b73703b9"
 dependencies = [
- "clap",
+ "clap 3.2.22",
  "parity-scale-codec",
  "sc-chain-spec",
  "sc-cli",
@@ -2870,7 +2907,7 @@ source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#3f
 dependencies = [
  "Inflector",
  "chrono",
- "clap",
+ "clap 3.2.22",
  "comfy-table",
  "frame-benchmarking",
  "frame-support",
@@ -7279,7 +7316,7 @@ name = "polkadot-cli"
 version = "0.9.29"
 source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.29#94078b44fb6c9767bf60ffcaaa3be40681be5a76"
 dependencies = [
- "clap",
+ "clap 3.2.22",
  "frame-benchmarking-cli",
  "futures",
  "log",
@@ -9321,7 +9358,7 @@ version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#3f70bcedf020d072e2f611a2448f2af46a4ae9b4"
 dependencies = [
  "chrono",
- "clap",
+ "clap 3.2.22",
  "fdlimit",
  "futures",
  "hex",
@@ -12304,7 +12341,7 @@ name = "try-runtime-cli"
 version = "0.10.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.29#3f70bcedf020d072e2f611a2448f2af46a4ae9b4"
 dependencies = [
- "clap",
+ "clap 3.2.22",
  "frame-try-runtime",
  "jsonrpsee",
  "log",
@@ -12337,7 +12374,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "digest 0.10.5",
  "rand 0.8.5",
  "static_assertions",
@@ -13214,10 +13251,12 @@ dependencies = [
 name = "xcm-tools"
 version = "0.2.0"
 dependencies = [
- "clap",
+ "clap 4.0.15",
  "cumulus-primitives-core",
+ "hex",
  "polkadot-parachain",
  "polkadot-primitives",
+ "regex",
  "sp-core",
  "sp-runtime",
  "substrate-build-script-utils",

--- a/bin/xcm-tools/Cargo.toml
+++ b/bin/xcm-tools/Cargo.toml
@@ -21,8 +21,8 @@ xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.2
 xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
 xcm-executor = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
 
-regex = "1.6.0"
 hex = "0.4.3"
+regex = "1.6.0"
 
 [build-dependencies]
 build-script-utils = { package = "substrate-build-script-utils", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }

--- a/bin/xcm-tools/Cargo.toml
+++ b/bin/xcm-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xcm-tools"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Astar XCM tools."
 edition = "2021"
@@ -11,7 +11,7 @@ name = "xcm-tools"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "3.2.17", features = ["derive"] }
+clap = { version = "4.0.13", features = ["derive"] }
 cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.29" }
 polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
 polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
@@ -20,6 +20,9 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkad
 xcm = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
 xcm-builder = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
 xcm-executor = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.29" }
+
+regex = "1.6.0"
+hex = "0.4.3"
 
 [build-dependencies]
 build-script-utils = { package = "substrate-build-script-utils", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.29" }

--- a/bin/xcm-tools/src/cli.rs
+++ b/bin/xcm-tools/src/cli.rs
@@ -54,7 +54,7 @@ pub struct Account32HashCmd {
 
 /// Used to parse AccountId32 as [u8; 32] from the received string.
 fn account_id_32_parser(account_str: &str) -> Result<[u8; 32], String> {
-    let re = Regex::new(r"^0x([0-9a-fA-F]{64})$").unwrap();
+    let re = Regex::new(r"^0x([0-9a-fA-F]{64})$").map_err(|e| e.to_string())?;
     if !re.is_match(account_str) {
         return Err(
             "Invalid AccountId32 received. Expected format is '0x1234...4321' (64 hex digits)."
@@ -62,7 +62,12 @@ fn account_id_32_parser(account_str: &str) -> Result<[u8; 32], String> {
         );
     }
 
-    let hex_acc = re.captures(account_str).unwrap().get(1).unwrap().as_str();
+    let hex_acc = re
+        .captures(account_str)
+        .expect("Regex match confirmed above.")
+        .get(1)
+        .expect("Group 1 confirmed in match above.")
+        .as_str();
     let decoded_hex = hex::decode(hex_acc).expect("Regex ensures correctness; infallible.");
 
     TryInto::<[u8; 32]>::try_into(decoded_hex)

--- a/bin/xcm-tools/src/cli.rs
+++ b/bin/xcm-tools/src/cli.rs
@@ -17,6 +17,8 @@ pub enum Subcommand {
     /// Prints AssetId for desired parachain asset.
     AssetId(AssetIdCmd),
     /// Prints Account32Hash for the derived multilocation.
+    /// In case parachain-id is provided, multilocation is in format { parents: 1, X2(Parachain, AccountId32) }.
+    /// In case parachain-id is omitted, multilocation is in format  { parents: 1, X1(AccountId32) }.
     Account32Hash(Account32HashCmd),
 }
 
@@ -43,11 +45,11 @@ pub struct AssetIdCmd {
 #[derive(Debug, clap::Parser)]
 pub struct Account32HashCmd {
     /// Parachain id in case sender is from a sibling parachain.
-    #[clap(short)]
+    #[clap(short, long)]
     #[arg(default_value = None)]
     pub parachain_id: Option<u32>,
     /// AccountId32 (SS58 scheme, public key) of the sender account.
-    #[clap(short)]
+    #[clap(short, long)]
     #[arg(value_parser = account_id_32_parser)]
     pub account_id_32: [u8; 32],
 }

--- a/bin/xcm-tools/src/cli.rs
+++ b/bin/xcm-tools/src/cli.rs
@@ -1,3 +1,5 @@
+use regex::Regex;
+
 /// Astar XCM tools.
 #[derive(Debug, clap::Parser)]
 #[clap(subcommand_required = true)]
@@ -14,6 +16,8 @@ pub enum Subcommand {
     ParachainAccount(ParachainAccountCmd),
     /// Prints AssetId for desired parachain asset.
     AssetId(AssetIdCmd),
+    /// Prints Account32Hash for the derived multilocation.
+    Account32Hash(Account32HashCmd),
 }
 
 /// Helper that prints AccountId of parachain.
@@ -33,4 +37,34 @@ pub struct AssetIdCmd {
     /// External AssetId [relay by default].
     #[clap(default_value = "340282366920938463463374607431768211455")]
     pub asset_id: u128,
+}
+
+/// Helper that prints AccountId32 hash value for the derived multilocation.
+#[derive(Debug, clap::Parser)]
+pub struct Account32HashCmd {
+    /// Parachain id in case sender is from a sibling parachain.
+    #[clap(short)]
+    #[arg(default_value = None)]
+    pub parachain_id: Option<u32>,
+    /// AccountId32 (SS58 scheme, public key) of the sender account.
+    #[clap(short)]
+    #[arg(value_parser = account_id_32_parser)]
+    pub account_id_32: [u8; 32],
+}
+
+/// Used to parse AccountId32 as [u8; 32] from the received string.
+fn account_id_32_parser(account_str: &str) -> Result<[u8; 32], String> {
+    let re = Regex::new(r"^0x([0-9a-fA-F]{64})$").unwrap();
+    if !re.is_match(account_str) {
+        return Err(
+            "Invalid AccountId32 received. Expected format is '0x1234...4321' (64 hex digits)."
+                .into(),
+        );
+    }
+
+    let hex_acc = re.captures(account_str).unwrap().get(1).unwrap().as_str();
+    let decoded_hex = hex::decode(hex_acc).expect("Regex ensures correctness; infallible.");
+
+    TryInto::<[u8; 32]>::try_into(decoded_hex)
+        .map_err(|_| "Failed to create [u8; 32] array from received account Id string.".into())
 }

--- a/bin/xcm-tools/src/cli.rs
+++ b/bin/xcm-tools/src/cli.rs
@@ -45,12 +45,10 @@ pub struct AssetIdCmd {
 #[derive(Debug, clap::Parser)]
 pub struct Account32HashCmd {
     /// Parachain id in case sender is from a sibling parachain.
-    #[clap(short, long)]
-    #[arg(default_value = None)]
+    #[clap(short, long, default_value = None)]
     pub parachain_id: Option<u32>,
     /// AccountId32 (SS58 scheme, public key) of the sender account.
-    #[clap(short, long)]
-    #[arg(value_parser = account_id_32_parser)]
+    #[clap(short, long, value_parser = account_id_32_parser)]
     pub account_id_32: [u8; 32],
 }
 

--- a/bin/xcm-tools/src/command.rs
+++ b/bin/xcm-tools/src/command.rs
@@ -7,9 +7,9 @@ use cumulus_primitives_core::ParaId;
 use polkadot_parachain::primitives::Sibling;
 use polkadot_primitives::v2::AccountId;
 use sp_core::hexdisplay::HexDisplay;
-use sp_runtime::traits::AccountIdConversion;
+use sp_runtime::traits::{AccountIdConversion, Get};
 use xcm::latest::prelude::*;
-use xcm_builder::SiblingParachainConvertsVia;
+use xcm_builder::{Account32Hash, SiblingParachainConvertsVia};
 use xcm_executor::traits::Convert;
 
 /// CLI error type.
@@ -40,6 +40,40 @@ pub fn run() -> Result<(), Error> {
             data[4..20].copy_from_slice(&cmd.asset_id.to_be_bytes());
             println!("pallet_assets: {}", cmd.asset_id);
             println!("EVM XC20: 0x{}", HexDisplay::from(&data));
+        }
+        Some(Subcommand::Account32Hash(cmd)) => {
+            let sender_multilocation = if let Some(parachain_id) = cmd.parachain_id {
+                MultiLocation {
+                    parents: 1,
+                    interior: X2(
+                        Parachain(parachain_id),
+                        AccountId32 {
+                            network: NetworkId::Any,
+                            id: cmd.account_id_32,
+                        },
+                    ),
+                }
+            } else {
+                MultiLocation {
+                    parents: 1,
+                    interior: X1(AccountId32 {
+                        network: NetworkId::Any,
+                        id: cmd.account_id_32,
+                    }),
+                }
+            };
+
+            // Not important for the functionality, totally redundant
+            struct AnyNetwork;
+            impl Get<NetworkId> for AnyNetwork {
+                fn get() -> NetworkId {
+                    NetworkId::Any
+                }
+            }
+
+            let derived_acc =
+                Account32Hash::<AnyNetwork, AccountId>::convert_ref(&sender_multilocation).unwrap();
+            println!("{}", derived_acc);
         }
         None => {}
     }


### PR DESCRIPTION
**Pull Request Summary**

Extend `xcm-tools` with new command to calculate `Account32Hash`.
This is useful when processing `Transact` XCM instruction from non-sovereign-account origin.
