### PR TITLE
migrate shiden bootnode2

### DIFF
--- a/bin/collator/res/shiden.json
+++ b/bin/collator/res/shiden.json
@@ -4,7 +4,7 @@
   "chainType": "Live",
   "bootNodes": [
     "/ip4/54.64.145.3/tcp/30333/ws/p2p/12D3KooWDYfspdMj1tQJZuiecmKKaQjGuSX2cy5rExtqcMqmiNrR",
-    "/ip4/20.40.146.192/tcp/30333/p2p/12D3KooWEnYEZpxqD5ZvZ89nsTTqqvijtpCTfYgFchVQcbwA8rve",
+    "/ip4/54.38.192.54/tcp/30333/ws/p2p/12D3KooWAgdZ27WhBzLRinaE7iTR1pXxKTsSJniXYu1xAEJD7LzS",
     "/ip4/34.168.164.206/tcp/30333/p2p/12D3KooWAQhseqYAL3NfqS38151wVbABeogWB3AbfnzvBUic2ozp"
   ],
   "telemetryEndpoints": null,

--- a/bin/collator/res/shiden.raw.json
+++ b/bin/collator/res/shiden.raw.json
@@ -4,7 +4,7 @@
   "chainType": "Live",
   "bootNodes": [
     "/ip4/54.64.145.3/tcp/30333/ws/p2p/12D3KooWDYfspdMj1tQJZuiecmKKaQjGuSX2cy5rExtqcMqmiNrR",
-    "/ip4/20.40.146.192/tcp/30333/p2p/12D3KooWEnYEZpxqD5ZvZ89nsTTqqvijtpCTfYgFchVQcbwA8rve",
+    "/ip4/54.38.192.54/tcp/30333/ws/p2p/12D3KooWAgdZ27WhBzLRinaE7iTR1pXxKTsSJniXYu1xAEJD7LzS",
     "/ip4/34.168.164.206/tcp/30333/p2p/12D3KooWAQhseqYAL3NfqS38151wVbABeogWB3AbfnzvBUic2ozp"
   ],
   "telemetryEndpoints": null,


### PR DESCRIPTION
**Pull Request Summary**

Migrate Shiden bootnode 2 server and switch it to WebSocket

**Check list**
- [ ] added or updated unit tests
- [ ] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [X] updated spec version
- [ ] updated semver
