### PR TITLE
Fix/rpc test config

### DIFF
--- a/rpc-tests/README.md
+++ b/rpc-tests/README.md
@@ -26,7 +26,8 @@ cargo build --release
 Copy the binary in rpc-tests/bin folder.
 
 ```
-cp target/release/astar-collator tests/bin/astar-collator
+mkdir -p rpc-tests/bin
+cp target/release/astar-collator rpc-tests/bin/astar-collator
 ```
 
 Download and copy latest polkadot binary from https://github.com/paritytech/polkadot/releases to rpc-tests/bin folder

--- a/rpc-tests/config.js
+++ b/rpc-tests/config.js
@@ -1,4 +1,4 @@
-const config = (network) => ({
+const config = (network, paraId) => ({
 	"relaychain": {
 		"bin": "./bin/polkadot",
 		"chain": "rococo-local",
@@ -40,7 +40,7 @@ const config = (network) => ({
 	"parachains": [
 		{
 			"bin": "./bin/astar-collator",
-			"id": "2000",
+			"id": `${paraId}`,
  			"chain": `${network}-dev`,
 			"balance": "1000000000000000000000",
 			"nodes": [

--- a/rpc-tests/package.json
+++ b/rpc-tests/package.json
@@ -4,8 +4,8 @@
   "description": "tests for rpc node",
   "type": "module",
   "scripts": {
-    "test:astar": "export NETWORK=astar && export NODE_ENV=test && mocha --timeout 50000 tests/**/test-*.js",
-    "test:shiden": "export NETWORK=shiden && export NODE_ENV=test && mocha --timeout 50000 tests/**/test-*.js"
+    "test:astar": "export NETWORK=astar && export PARA_ID=2006 && export NODE_ENV=test && mocha --timeout 50000 tests/**/test-*.js",
+    "test:shiden": "export NETWORK=shiden && export PARA_ID=2007 && export NODE_ENV=test && mocha --timeout 50000 tests/**/test-*.js"
   },
   "author": "AstarNetwork",
   "license": "ISC",

--- a/rpc-tests/tests/test-rpc.js
+++ b/rpc-tests/tests/test-rpc.js
@@ -21,12 +21,13 @@ const evmAccount = {
 export const getAddressEnum = (address) => ({ Evm: address });
 
 const network = process.env.NETWORK;
+const paraId = process.env.PARA_ID;
 
 if (['astar', 'shiden', 'shibuya'].includes(network) === false) {
     throw new Error('Please set valid network in NETWORK env variable');
 }
 
-describeWithNetwork(network, `${network} RPC`, function(context) {
+describeWithNetwork(network, paraId, `${network} RPC`, function(context) {
     let deployedContract;
 
 	it('should fetch chain from rpc node', async function () {

--- a/rpc-tests/tests/util.js
+++ b/rpc-tests/tests/util.js
@@ -72,10 +72,11 @@ export async function sendTransaction(transaction, sender) {
  * describeWithNetwork: special mocha describe which has global setup and teardown steps for spawning and taking down local network
  *
  * @param {string} network [astar | shiden | shibuya]
+ * @param {number} paraId [2006 | 2007 | 1000]
  * @param {*} title title of the test suite
  * @param {*} cb callback function which take a context object which will be available in tests
  */
-export function describeWithNetwork(network, title, cb) {
+export function describeWithNetwork(network, paraId, title, cb) {
 	describe(title, () => {
 		let context = {
 			api: null,
@@ -91,7 +92,7 @@ export function describeWithNetwork(network, title, cb) {
 		before('Starting Astar Test Node', async function () {
 			this.timeout(SPAWNING_TIME);
 
-			await run(process.cwd(), config(network));
+			await run(process.cwd(), config(network, paraId));
 
 			const api = await ApiPromise.create({
 				provider: new WsProvider(`ws://localhost:${WS_PORT}`)


### PR DESCRIPTION
**Pull Request Summary**
This rpc test config change is required together with https://github.com/AstarNetwork/Astar/pull/765.
Use different parachain ids for each dev chain (`2007` for shiden-dev, `2006` for astar-dev) in polkadot-launch, otherwise, they cannot produce blocks with fixed parachain id `2000`.

