### PR TITLE
Relay chain account command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13538,7 +13538,7 @@ dependencies = [
 
 [[package]]
 name = "xcm-tools"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap 4.0.18",
  "cumulus-primitives-core",

--- a/bin/xcm-tools/Cargo.toml
+++ b/bin/xcm-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xcm-tools"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Astar XCM tools."
 edition = "2021"

--- a/bin/xcm-tools/src/cli.rs
+++ b/bin/xcm-tools/src/cli.rs
@@ -12,6 +12,8 @@ pub struct Cli {
 /// Possible subcommands of the main binary.
 #[derive(Debug, clap::Subcommand)]
 pub enum Subcommand {
+    /// Prints relay-chain AccountId
+    RelayChainAccount,
     /// Prints parachain AccountId.
     ParachainAccount(ParachainAccountCmd),
     /// Prints AssetId for desired parachain asset.

--- a/bin/xcm-tools/src/command.rs
+++ b/bin/xcm-tools/src/command.rs
@@ -9,7 +9,7 @@ use polkadot_primitives::v2::AccountId;
 use sp_core::hexdisplay::HexDisplay;
 use sp_runtime::traits::{AccountIdConversion, Get};
 use xcm::latest::prelude::*;
-use xcm_builder::{Account32Hash, SiblingParachainConvertsVia};
+use xcm_builder::{Account32Hash, ParentIsPreset, SiblingParachainConvertsVia};
 use xcm_executor::traits::Convert;
 
 /// CLI error type.
@@ -20,6 +20,11 @@ pub fn run() -> Result<(), Error> {
     let cli = Cli::parse();
 
     match &cli.subcommand {
+        Some(Subcommand::RelayChainAccount) => {
+            let relay_account =
+                ParentIsPreset::<AccountId>::convert_ref(&MultiLocation::parent()).unwrap();
+            println!("{}", relay_account);
+        }
         Some(Subcommand::ParachainAccount(cmd)) => {
             let parachain_account = if cmd.sibling {
                 let location = MultiLocation {


### PR DESCRIPTION
**Pull Request Summary**

Adds support for `relay-chain-account` command for `xcm-tools`.
Useful when we need to generate relay chain's sovereign account.
