### PR TITLE
add wss bootnodes

### DIFF
--- a/bin/collator/res/astar.json
+++ b/bin/collator/res/astar.json
@@ -6,6 +6,8 @@
     "/dnsaddr/bootnode.astar.network/p2p/12D3KooWMaG4prEjqt1C6Mfas8LCFs31f5k11jw4nRuV52KR3yaB",
     "/ip4/51.91.105.142/tcp/30333/ws/p2p/12D3KooWMfHf9G1Mtawz4qySe1EqaBmrieidqn2xnEYckUYkpe52",
     "/ip4/35.197.38.107/tcp/30333/ws/p2p/12D3KooWHV4YxifTpBkLWPPaF8EfoMSXeGNWWxXqUokGsBGxwioK",
+    "/dns/astar-02.wss-bootnode.astar.network/tcp/443/wss/p2p/12D3KooWMfHf9G1Mtawz4qySe1EqaBmrieidqn2xnEYckUYkpe52",
+    "/dns/astar-03.wss-bootnode.astar.network/tcp/443/wss/p2p/12D3KooWHV4YxifTpBkLWPPaF8EfoMSXeGNWWxXqUokGsBGxwioK",
     "/dns4/node-6877180792046243840-0.p2p.onfinality.io/tcp/19932/ws/p2p/12D3KooWARXaG1Ft65ZgCPK8isSg1UBLASQenrH9sJsjEYEDAvQf",
     "/dns4/node-6877173450521071616-0.p2p.onfinality.io/tcp/12708/ws/p2p/12D3KooWFPbDQjtCXhRjsvu1HCqTrSc6KEazEnETLPQMS4gDpoQq",
     "/dns4/node-6877173614090539008-0.p2p.onfinality.io/tcp/29128/ws/p2p/12D3KooWERrQFE8ss7zYfcHp8ULVCc1N7gur7GqZ8ESuZB1Nmioh"

--- a/bin/collator/res/astar.raw.json
+++ b/bin/collator/res/astar.raw.json
@@ -6,6 +6,8 @@
     "/dnsaddr/bootnode.astar.network/p2p/12D3KooWMaG4prEjqt1C6Mfas8LCFs31f5k11jw4nRuV52KR3yaB",
     "/ip4/51.91.105.142/tcp/30333/ws/p2p/12D3KooWMfHf9G1Mtawz4qySe1EqaBmrieidqn2xnEYckUYkpe52",
     "/ip4/35.197.38.107/tcp/30333/ws/p2p/12D3KooWHV4YxifTpBkLWPPaF8EfoMSXeGNWWxXqUokGsBGxwioK",
+    "/dns/astar-02.wss-bootnode.astar.network/tcp/443/wss/p2p/12D3KooWMfHf9G1Mtawz4qySe1EqaBmrieidqn2xnEYckUYkpe52",
+    "/dns/astar-03.wss-bootnode.astar.network/tcp/443/wss/p2p/12D3KooWHV4YxifTpBkLWPPaF8EfoMSXeGNWWxXqUokGsBGxwioK",
     "/dns4/node-6877180792046243840-0.p2p.onfinality.io/tcp/19932/ws/p2p/12D3KooWARXaG1Ft65ZgCPK8isSg1UBLASQenrH9sJsjEYEDAvQf",
     "/dns4/node-6877173450521071616-0.p2p.onfinality.io/tcp/12708/ws/p2p/12D3KooWFPbDQjtCXhRjsvu1HCqTrSc6KEazEnETLPQMS4gDpoQq",
     "/dns4/node-6877173614090539008-0.p2p.onfinality.io/tcp/29128/ws/p2p/12D3KooWERrQFE8ss7zYfcHp8ULVCc1N7gur7GqZ8ESuZB1Nmioh"

--- a/bin/collator/res/shibuya.json
+++ b/bin/collator/res/shibuya.json
@@ -5,7 +5,9 @@
   "bootNodes": [
     "/ip4/3.114.212.146/tcp/30333/p2p/12D3KooWEHWUJ3Rzf8RLRihohbgXafz3Y4LnnKSzFDeZ1sXnopJs",
     "/ip4/20.40.146.211/tcp/30333/ws/p2p/12D3KooWBVXQ1WgLjHhWMn8mVEdpwF6uepMT1sYkDvAhYAomZvvx",
-    "/ip4/34.168.19.219/tcp/30333/ws/p2p/12D3KooWBwxyvhLfMLLBaC4umejNUZu2C1RiyCRAJSTxnNDzywQ4"
+    "/ip4/34.168.19.219/tcp/30333/ws/p2p/12D3KooWBwxyvhLfMLLBaC4umejNUZu2C1RiyCRAJSTxnNDzywQ4",
+    "/dns/shibuya-02.wss-bootnode.astar.network/tcp/443/wss/p2p/12D3KooWBVXQ1WgLjHhWMn8mVEdpwF6uepMT1sYkDvAhYAomZvvx",
+    "/dns/shibuya-03.wss-bootnode.astar.network/tcp/443/wss/p2p/12D3KooWBwxyvhLfMLLBaC4umejNUZu2C1RiyCRAJSTxnNDzywQ4"
   ],
   "telemetryEndpoints": null,
   "protocolId": "shibuya",

--- a/bin/collator/res/shibuya.raw.json
+++ b/bin/collator/res/shibuya.raw.json
@@ -5,7 +5,9 @@
   "bootNodes": [
     "/ip4/3.114.212.146/tcp/30333/p2p/12D3KooWEHWUJ3Rzf8RLRihohbgXafz3Y4LnnKSzFDeZ1sXnopJs",
     "/ip4/20.40.146.211/tcp/30333/ws/p2p/12D3KooWBVXQ1WgLjHhWMn8mVEdpwF6uepMT1sYkDvAhYAomZvvx",
-    "/ip4/34.168.19.219/tcp/30333/ws/p2p/12D3KooWBwxyvhLfMLLBaC4umejNUZu2C1RiyCRAJSTxnNDzywQ4"
+    "/ip4/34.168.19.219/tcp/30333/ws/p2p/12D3KooWBwxyvhLfMLLBaC4umejNUZu2C1RiyCRAJSTxnNDzywQ4",
+    "/dns/shibuya-02.wss-bootnode.astar.network/tcp/443/wss/p2p/12D3KooWBVXQ1WgLjHhWMn8mVEdpwF6uepMT1sYkDvAhYAomZvvx",
+    "/dns/shibuya-03.wss-bootnode.astar.network/tcp/443/wss/p2p/12D3KooWBwxyvhLfMLLBaC4umejNUZu2C1RiyCRAJSTxnNDzywQ4"
   ],
   "telemetryEndpoints": null,
   "protocolId": "shibuya",

--- a/bin/collator/res/shiden.json
+++ b/bin/collator/res/shiden.json
@@ -5,7 +5,9 @@
   "bootNodes": [
     "/ip4/54.64.145.3/tcp/30333/ws/p2p/12D3KooWDYfspdMj1tQJZuiecmKKaQjGuSX2cy5rExtqcMqmiNrR",
     "/ip4/54.38.192.54/tcp/30333/ws/p2p/12D3KooWAgdZ27WhBzLRinaE7iTR1pXxKTsSJniXYu1xAEJD7LzS",
-    "/ip4/34.168.164.206/tcp/30333/p2p/12D3KooWAQhseqYAL3NfqS38151wVbABeogWB3AbfnzvBUic2ozp"
+    "/ip4/34.168.164.206/tcp/30333/p2p/12D3KooWAQhseqYAL3NfqS38151wVbABeogWB3AbfnzvBUic2ozp",
+    "/dns/shiden-01.wss-bootnode.astar.network/tcp/443/wss/p2p/12D3KooWDYfspdMj1tQJZuiecmKKaQjGuSX2cy5rExtqcMqmiNrR",
+    "/dns/shiden-02.wss-bootnode.astar.network/tcp/443/wss/p2p/12D3KooWAgdZ27WhBzLRinaE7iTR1pXxKTsSJniXYu1xAEJD7LzS"
   ],
   "telemetryEndpoints": null,
   "protocolId": "shiden",

--- a/bin/collator/res/shiden.raw.json
+++ b/bin/collator/res/shiden.raw.json
@@ -5,7 +5,9 @@
   "bootNodes": [
     "/ip4/54.64.145.3/tcp/30333/ws/p2p/12D3KooWDYfspdMj1tQJZuiecmKKaQjGuSX2cy5rExtqcMqmiNrR",
     "/ip4/54.38.192.54/tcp/30333/ws/p2p/12D3KooWAgdZ27WhBzLRinaE7iTR1pXxKTsSJniXYu1xAEJD7LzS",
-    "/ip4/34.168.164.206/tcp/30333/p2p/12D3KooWAQhseqYAL3NfqS38151wVbABeogWB3AbfnzvBUic2ozp"
+    "/ip4/34.168.164.206/tcp/30333/p2p/12D3KooWAQhseqYAL3NfqS38151wVbABeogWB3AbfnzvBUic2ozp",
+    "/dns/shiden-01.wss-bootnode.astar.network/tcp/443/wss/p2p/12D3KooWDYfspdMj1tQJZuiecmKKaQjGuSX2cy5rExtqcMqmiNrR",
+    "/dns/shiden-02.wss-bootnode.astar.network/tcp/443/wss/p2p/12D3KooWAgdZ27WhBzLRinaE7iTR1pXxKTsSJniXYu1xAEJD7LzS"
   ],
   "telemetryEndpoints": null,
   "protocolId": "shiden",


### PR DESCRIPTION
**Pull Request Summary**

Adding bootnodes behing Secure Web Socket to allow smoldot sync.
2 bootnodes per network: Astar, Shiden and Shibuya

**Check list**
- [ ] added or updated unit tests
- [ ] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [X] updated spec version
- [ ] updated semver
