### PR TITLE
NetworkId for account32-hash command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13613,7 +13613,7 @@ dependencies = [
 
 [[package]]
 name = "xcm-tools"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap 4.0.22",
  "cumulus-primitives-core",

--- a/bin/xcm-tools/Cargo.toml
+++ b/bin/xcm-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xcm-tools"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Astar XCM tools."
 edition = "2021"

--- a/bin/xcm-tools/src/cli.rs
+++ b/bin/xcm-tools/src/cli.rs
@@ -52,6 +52,9 @@ pub struct Account32HashCmd {
     /// AccountId32 (SS58 scheme, public key) of the sender account.
     #[clap(short, long, value_parser = account_id_32_parser)]
     pub account_id_32: [u8; 32],
+    /// NetworkId of the AccountId32 - if not provided, will be set to `Any`
+    #[clap(short, long)]
+    pub network_id: Option<String>,
 }
 
 /// Used to parse AccountId32 as [u8; 32] from the received string.

--- a/bin/xcm-tools/src/command.rs
+++ b/bin/xcm-tools/src/command.rs
@@ -47,7 +47,7 @@ pub fn run() -> Result<(), Error> {
             println!("EVM XC20: 0x{}", HexDisplay::from(&data));
         }
         Some(Subcommand::Account32Hash(cmd)) => {
-            let network_id = if let Some(ref id) = cmd.network_id {
+            let network = if let Some(ref id) = cmd.network_id {
                 match id.to_lowercase().as_str() {
                     "any" => NetworkId::Any,
                     "polkadot" => NetworkId::Polkadot,
@@ -58,26 +58,20 @@ pub fn run() -> Result<(), Error> {
                 NetworkId::Any
             };
 
-            let sender_multilocation = if let Some(parachain_id) = cmd.parachain_id {
-                MultiLocation {
-                    parents: 1,
-                    interior: X2(
-                        Parachain(parachain_id),
-                        AccountId32 {
-                            network: network_id,
-                            id: cmd.account_id_32,
-                        },
-                    ),
-                }
-            } else {
-                MultiLocation {
-                    parents: 1,
-                    interior: X1(AccountId32 {
-                        network: network_id,
-                        id: cmd.account_id_32,
-                    }),
-                }
-            };
+            let mut sender_multilocation = MultiLocation::parent();
+
+            if let Some(parachain_id) = cmd.parachain_id {
+                sender_multilocation
+                    .append_with(X1(Parachain(parachain_id)))
+                    .expect("infallible");
+            }
+
+            sender_multilocation
+                .append_with(X1(AccountId32 {
+                    network,
+                    id: cmd.account_id_32,
+                }))
+                .expect("infallible");
 
             // Not important for the functionality, totally redundant
             struct AnyNetwork;

--- a/bin/xcm-tools/src/command.rs
+++ b/bin/xcm-tools/src/command.rs
@@ -63,7 +63,7 @@ pub fn run() -> Result<(), Error> {
             if let Some(parachain_id) = cmd.parachain_id {
                 sender_multilocation
                     .append_with(X1(Parachain(parachain_id)))
-                    .expect("infallible");
+                    .expect("infallible, short sequence");
             }
 
             sender_multilocation
@@ -71,7 +71,7 @@ pub fn run() -> Result<(), Error> {
                     network,
                     id: cmd.account_id_32,
                 }))
-                .expect("infallible");
+                .expect("infallible, short sequence");
 
             // Not important for the functionality, totally redundant
             struct AnyNetwork;

--- a/bin/xcm-tools/src/command.rs
+++ b/bin/xcm-tools/src/command.rs
@@ -47,13 +47,24 @@ pub fn run() -> Result<(), Error> {
             println!("EVM XC20: 0x{}", HexDisplay::from(&data));
         }
         Some(Subcommand::Account32Hash(cmd)) => {
+            let network_id = if let Some(id) = cmd.network_id.clone() {
+                match id.to_lowercase().as_str() {
+                    "any" => NetworkId::Any,
+                    "polkadot" => NetworkId::Polkadot,
+                    "kusama" => NetworkId::Kusama,
+                    _ => return Err("Unexpected network Id value.".into()),
+                }
+            } else {
+                NetworkId::Any
+            };
+
             let sender_multilocation = if let Some(parachain_id) = cmd.parachain_id {
                 MultiLocation {
                     parents: 1,
                     interior: X2(
                         Parachain(parachain_id),
                         AccountId32 {
-                            network: NetworkId::Any,
+                            network: network_id,
                             id: cmd.account_id_32,
                         },
                     ),
@@ -62,7 +73,7 @@ pub fn run() -> Result<(), Error> {
                 MultiLocation {
                     parents: 1,
                     interior: X1(AccountId32 {
-                        network: NetworkId::Any,
+                        network: network_id,
                         id: cmd.account_id_32,
                     }),
                 }

--- a/bin/xcm-tools/src/command.rs
+++ b/bin/xcm-tools/src/command.rs
@@ -47,7 +47,7 @@ pub fn run() -> Result<(), Error> {
             println!("EVM XC20: 0x{}", HexDisplay::from(&data));
         }
         Some(Subcommand::Account32Hash(cmd)) => {
-            let network_id = if let Some(id) = cmd.network_id.clone() {
+            let network_id = if let Some(ref id) = cmd.network_id {
                 match id.to_lowercase().as_str() {
                     "any" => NetworkId::Any,
                     "polkadot" => NetworkId::Polkadot,


### PR DESCRIPTION
**Pull Request Summary**

Expanded `account32-hash` command in `xcm-tools` with parameter which specifies network Id.
