### PR TITLE
Root or Signed for Shibuya's XC-asset config

### DIFF
--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -1093,7 +1093,8 @@ impl pallet_xc_asset_config::Config for Runtime {
     type AssetId = AssetId;
     type XcAssetChanged = EvmRevertCodeHandler;
     // Good enough for testnet since we lack pallet-assets hooks for now
-    type ManagerOrigin = frame_system::EnsureSigned<AccountId>;
+    type ManagerOrigin =
+        EitherOfDiverse<frame_system::EnsureRoot<AccountId>, frame_system::EnsureSigned<AccountId>>;
     type WeightInfo = weights::pallet_xc_asset_config::WeightInfo<Self>;
 }
 


### PR DESCRIPTION
**Pull Request Summary**

Allows both `Root` and `SignedOrigin` to manipulate Xc-asset config values for Shibuya.
