### PR TITLE
Uplift XCM precompile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "astar-collator"
-version = "4.35.0"
+version = "4.37.0"
 dependencies = [
  "astar-runtime",
  "async-trait",
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "astar-runtime"
-version = "4.35.0"
+version = "4.37.0"
 dependencies = [
  "array-bytes",
  "cumulus-pallet-aura-ext",
@@ -2091,7 +2091,7 @@ dependencies = [
 [[package]]
 name = "dapps-staking-chain-extension-types"
 version = "1.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#7ec4bda68e57d2a86e60fca585c0e3bd7d63ba94"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#c6296eaf4619f20f27813505f99a328e996b31cf"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4908,7 +4908,7 @@ checksum = "bb68f22743a3fb35785f1e7f844ca5a3de2dde5bd0c0ef5b372065814699b121"
 
 [[package]]
 name = "local-runtime"
-version = "4.35.0"
+version = "4.37.0"
 dependencies = [
  "array-bytes",
  "fp-rpc",
@@ -5823,7 +5823,7 @@ dependencies = [
 [[package]]
 name = "pallet-block-reward"
 version = "2.2.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#7ec4bda68e57d2a86e60fca585c0e3bd7d63ba94"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#c6296eaf4619f20f27813505f99a328e996b31cf"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5860,7 +5860,7 @@ dependencies = [
 [[package]]
 name = "pallet-chain-extension-dapps-staking"
 version = "1.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#7ec4bda68e57d2a86e60fca585c0e3bd7d63ba94"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#c6296eaf4619f20f27813505f99a328e996b31cf"
 dependencies = [
  "dapps-staking-chain-extension-types",
  "frame-support",
@@ -5881,7 +5881,7 @@ dependencies = [
 [[package]]
 name = "pallet-chain-extension-xvm"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#7ec4bda68e57d2a86e60fca585c0e3bd7d63ba94"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#c6296eaf4619f20f27813505f99a328e996b31cf"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5921,7 +5921,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "3.3.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#7ec4bda68e57d2a86e60fca585c0e3bd7d63ba94"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#c6296eaf4619f20f27813505f99a328e996b31cf"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6040,7 +6040,7 @@ dependencies = [
 [[package]]
 name = "pallet-custom-signatures"
 version = "4.5.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#7ec4bda68e57d2a86e60fca585c0e3bd7d63ba94"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#c6296eaf4619f20f27813505f99a328e996b31cf"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6056,7 +6056,7 @@ dependencies = [
 [[package]]
 name = "pallet-dapps-staking"
 version = "3.8.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#7ec4bda68e57d2a86e60fca585c0e3bd7d63ba94"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#c6296eaf4619f20f27813505f99a328e996b31cf"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6214,7 +6214,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-assets-erc20"
 version = "0.5.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#7ec4bda68e57d2a86e60fca585c0e3bd7d63ba94"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#c6296eaf4619f20f27813505f99a328e996b31cf"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6301,7 +6301,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sr25519"
 version = "1.2.1"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#7ec4bda68e57d2a86e60fca585c0e3bd7d63ba94"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#c6296eaf4619f20f27813505f99a328e996b31cf"
 dependencies = [
  "fp-evm",
  "log",
@@ -6317,7 +6317,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-substrate-ecdsa"
 version = "1.2.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#7ec4bda68e57d2a86e60fca585c0e3bd7d63ba94"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#c6296eaf4619f20f27813505f99a328e996b31cf"
 dependencies = [
  "fp-evm",
  "log",
@@ -6332,8 +6332,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-precompile-xcm"
-version = "0.8.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#7ec4bda68e57d2a86e60fca585c0e3bd7d63ba94"
+version = "0.9.0"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#c6296eaf4619f20f27813505f99a328e996b31cf"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6356,7 +6356,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-xvm"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#7ec4bda68e57d2a86e60fca585c0e3bd7d63ba94"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#c6296eaf4619f20f27813505f99a328e996b31cf"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6639,7 +6639,7 @@ dependencies = [
 [[package]]
 name = "pallet-precompile-dapps-staking"
 version = "3.6.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#7ec4bda68e57d2a86e60fca585c0e3bd7d63ba94"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#c6296eaf4619f20f27813505f99a328e996b31cf"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6970,7 +6970,7 @@ dependencies = [
 [[package]]
 name = "pallet-xc-asset-config"
 version = "1.3.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#7ec4bda68e57d2a86e60fca585c0e3bd7d63ba94"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#c6296eaf4619f20f27813505f99a328e996b31cf"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6988,7 +6988,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "0.9.28"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#7ec4bda68e57d2a86e60fca585c0e3bd7d63ba94"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#c6296eaf4619f20f27813505f99a328e996b31cf"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7041,7 +7041,7 @@ dependencies = [
 [[package]]
 name = "pallet-xvm"
 version = "0.2.1"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#7ec4bda68e57d2a86e60fca585c0e3bd7d63ba94"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#c6296eaf4619f20f27813505f99a328e996b31cf"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8545,7 +8545,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 [[package]]
 name = "precompile-utils"
 version = "0.4.3"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#7ec4bda68e57d2a86e60fca585c0e3bd7d63ba94"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#c6296eaf4619f20f27813505f99a328e996b31cf"
 dependencies = [
  "evm",
  "fp-evm",
@@ -8568,7 +8568,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#7ec4bda68e57d2a86e60fca585c0e3bd7d63ba94"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#c6296eaf4619f20f27813505f99a328e996b31cf"
 dependencies = [
  "num_enum",
  "proc-macro2",
@@ -10813,7 +10813,7 @@ dependencies = [
 
 [[package]]
 name = "shibuya-runtime"
-version = "4.35.0"
+version = "4.37.0"
 dependencies = [
  "array-bytes",
  "cumulus-pallet-aura-ext",
@@ -10911,7 +10911,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "4.35.0"
+version = "4.37.0"
 dependencies = [
  "array-bytes",
  "cumulus-pallet-aura-ext",
@@ -12670,7 +12670,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "digest 0.10.5",
  "rand 0.8.5",
  "static_assertions",
@@ -13588,7 +13588,7 @@ dependencies = [
 [[package]]
 name = "xcm-primitives"
 version = "0.4.1"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#7ec4bda68e57d2a86e60fca585c0e3bd7d63ba94"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#c6296eaf4619f20f27813505f99a328e996b31cf"
 dependencies = [
  "frame-support",
  "log",
@@ -13632,7 +13632,7 @@ dependencies = [
 [[package]]
 name = "xvm-chain-extension-types"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#7ec4bda68e57d2a86e60fca585c0e3bd7d63ba94"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.30#c6296eaf4619f20f27813505f99a328e996b31cf"
 dependencies = [
  "parity-scale-codec",
  "scale-info",

--- a/bin/collator/Cargo.toml
+++ b/bin/collator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-collator"
-version = "4.36.0"
+version = "4.37.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Astar collator implementation in Rust."
 build = "build.rs"

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-runtime"
-version = "4.36.0"
+version = "4.37.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -97,7 +97,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("astar"),
     impl_name: create_runtime_str!("astar"),
     authoring_version: 1,
-    spec_version: 44,
+    spec_version: 45,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/runtime/local/Cargo.toml
+++ b/runtime/local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-runtime"
-version = "4.36.0"
+version = "4.37.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "4.36.0"
+version = "4.37.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -133,7 +133,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shibuya"),
     impl_name: create_runtime_str!("shibuya"),
     authoring_version: 1,
-    spec_version: 80,
+    spec_version: 81,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "4.36.0"
+version = "4.37.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -97,7 +97,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shiden"),
     impl_name: create_runtime_str!("shiden"),
     authoring_version: 1,
-    spec_version: 80,
+    spec_version: 81,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,


### PR DESCRIPTION
**Pull Request Summary**

Uplifts `xcm-precompile` to use latest version where `remote_transact` can accept native currency as payment asset.

astar-docs PR: [here](https://github.com/AstarNetwork/astar-docs/pull/157)

**Check list**
- [x] updated Astar official documentation
- [x] updated spec version
- [x] updated semver
