### PR TITLE
Contracts migration logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10662,6 +10662,7 @@ dependencies = [
  "pallet-collator-selection",
  "pallet-collective",
  "pallet-contracts",
+ "pallet-contracts-migration",
  "pallet-contracts-primitives",
  "pallet-custom-signatures",
  "pallet-dapps-staking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5745,15 +5745,11 @@ dependencies = [
 name = "pallet-contracts-migration"
 version = "1.0.0"
 dependencies = [
- "frame-benchmarking",
  "frame-support",
  "frame-system",
- "pallet-balances",
  "pallet-contracts",
- "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
- "serde",
  "sp-arithmetic",
  "sp-core",
  "sp-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10759,6 +10759,7 @@ dependencies = [
  "pallet-collator-selection",
  "pallet-collective",
  "pallet-contracts",
+ "pallet-contracts-migration",
  "pallet-contracts-primitives",
  "pallet-custom-signatures",
  "pallet-dapps-staking",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "astar-collator"
-version = "4.39.1"
+version = "4.40.0"
 dependencies = [
  "astar-runtime",
  "async-trait",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "astar-runtime"
-version = "4.39.1"
+version = "4.40.0"
 dependencies = [
  "array-bytes 6.0.0",
  "cumulus-pallet-aura-ext",
@@ -4680,7 +4680,7 @@ checksum = "bb68f22743a3fb35785f1e7f844ca5a3de2dde5bd0c0ef5b372065814699b121"
 
 [[package]]
 name = "local-runtime"
-version = "4.39.1"
+version = "4.40.0"
 dependencies = [
  "array-bytes 6.0.0",
  "fp-rpc",
@@ -10615,7 +10615,7 @@ dependencies = [
 
 [[package]]
 name = "shibuya-runtime"
-version = "4.39.1"
+version = "4.40.0"
 dependencies = [
  "array-bytes 6.0.0",
  "cumulus-pallet-aura-ext",
@@ -10713,7 +10713,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "4.39.1"
+version = "4.40.0"
 dependencies = [
  "array-bytes 6.0.0",
  "cumulus-pallet-aura-ext",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5742,6 +5742,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-contracts-migration"
+version = "1.0.0"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "pallet-contracts",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-contracts-primitives"
 version = "6.0.0"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.33#2dff067e9f7f6f3cc4dbfdaaa97753eccc407689"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
 	"runtime/astar",
 	"runtime/shiden",
 	"runtime/shibuya",
+	"runtime/contracts-migration",
 ]
 
 exclude = ["vendor"]

--- a/bin/collator/Cargo.toml
+++ b/bin/collator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-collator"
-version = "4.39.1"
+version = "4.40.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Astar collator implementation in Rust."
 build = "build.rs"

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-runtime"
-version = "4.39.1"
+version = "4.40.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/contracts-migration/Cargo.toml
+++ b/runtime/contracts-migration/Cargo.toml
@@ -15,9 +15,9 @@ frame-system = { git = "https://github.com/paritytech/substrate", branch = "polk
 pallet-contracts = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false, features = ["unstable-interface"] }
 scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
 sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false, optional = true }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false, optional = true }
 
 [features]
 default = ["std"]

--- a/runtime/contracts-migration/Cargo.toml
+++ b/runtime/contracts-migration/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "pallet-contracts-migration"
+version = "1.0.0"
+authors = ["Stake  Technologies <devops@stake.co.jp>"]
+edition = "2021"
+license = "Apache-2.0"
+homepage = "https://astar.network"
+repository = "https://github.com/AstarNetwork/Astar"
+description = "FRAME pallet for managing multi-block pallet contracts storage migration"
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false }
+scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
+sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false }
+pallet-contracts = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false, features = ["unstable-interface"] }
+
+frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.33', default-features = false, optional = true }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false, optional = true }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false, optional = true }
+serde = { version = "1.0.136", optional = true }
+sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false, optional = true }
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"sp-core/std",
+	"scale-info/std",
+	"sp-std/std",
+	"serde/std",
+	"frame-support/std",
+	"frame-system/std",
+	"pallet-timestamp/std",
+	"pallet-balances/std",
+    "pallet-contracts/std",
+]
+try-runtime = ["frame-support/try-runtime"]

--- a/runtime/contracts-migration/Cargo.toml
+++ b/runtime/contracts-migration/Cargo.toml
@@ -12,16 +12,11 @@ description = "FRAME pallet for managing multi-block pallet contracts storage mi
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false }
+pallet-contracts = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false, features = ["unstable-interface"] }
 scale-info = { version = "2.3.0", default-features = false, features = ["derive"] }
 sp-arithmetic = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false }
-pallet-contracts = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false, features = ["unstable-interface"] }
-
-frame-benchmarking = { git = 'https://github.com/paritytech/substrate.git', branch = 'polkadot-v0.9.33', default-features = false, optional = true }
-pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false, optional = true }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false, optional = true }
-serde = { version = "1.0.136", optional = true }
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false, optional = true }
 
 [features]
@@ -31,11 +26,8 @@ std = [
 	"sp-core/std",
 	"scale-info/std",
 	"sp-std/std",
-	"serde/std",
 	"frame-support/std",
 	"frame-system/std",
-	"pallet-timestamp/std",
-	"pallet-balances/std",
-    "pallet-contracts/std",
+	"pallet-contracts/std",
 ]
 try-runtime = ["frame-support/try-runtime"]

--- a/runtime/contracts-migration/src/lib.rs
+++ b/runtime/contracts-migration/src/lib.rs
@@ -1,0 +1,227 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub use pallet::*;
+
+use frame_support::{
+    log,
+    pallet_prelude::*,
+    storage::{
+        generator::{StorageDoubleMap, StorageMap},
+        unhashed,
+    },
+    storage_alias,
+    traits::{Currency, Get, Imbalance, OnTimestampSet},
+    WeakBoundedVec,
+};
+
+use codec::{Decode, Encode, FullCodec};
+use frame_system::{limits::BlockWeights, pallet_prelude::*};
+use pallet_contracts::Determinism;
+use sp_runtime::{
+    traits::{CheckedAdd, Zero},
+    Perbill, Saturating,
+};
+use sp_std::{fmt::Debug, vec};
+
+const LOG_TARGET: &str = "pallet-contracts-migration";
+
+#[frame_support::pallet]
+pub mod pallet {
+    use super::*;
+
+    #[pallet::pallet]
+    pub struct Pallet<T>(PhantomData<T>);
+
+    #[pallet::config]
+    pub trait Config: frame_system::Config + pallet_contracts::Config {
+        /// The overarching event type.
+        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+    }
+
+    #[pallet::storage]
+    #[pallet::getter(fn migration_state)]
+    pub type MigrationStateStorage<T: Config> = StorageValue<_, MigrationState, ValueQuery>;
+
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(crate) fn deposit_event)]
+    pub enum Event<T: Config> {
+        SomeEvent,
+    }
+
+    #[pallet::error]
+    pub enum Error<T> {
+        SomeError,
+    }
+
+    #[storage_alias]
+    type CodeStorage<T: pallet_contracts::Config> =
+        StorageMap<pallet_contracts::Pallet<T>, Identity, CodeHash<T>, PrefabWasmModule<T>>;
+
+    type CodeHash<T> = <T as frame_system::Config>::Hash;
+
+    type RelaxedCodeVec<T> = WeakBoundedVec<u8, <T as pallet_contracts::Config>::MaxCodeLen>;
+
+    #[derive(Encode, Decode, RuntimeDebug, MaxEncodedLen)]
+    pub struct OldPrefabWasmModule<T: pallet_contracts::Config> {
+        #[codec(compact)]
+        pub instruction_weights_version: u32,
+        #[codec(compact)]
+        pub initial: u32,
+        #[codec(compact)]
+        pub maximum: u32,
+        pub code: RelaxedCodeVec<T>,
+    }
+
+    #[derive(Encode, Decode, RuntimeDebug, MaxEncodedLen)]
+    pub struct PrefabWasmModule<T: pallet_contracts::Config> {
+        #[codec(compact)]
+        pub instruction_weights_version: u32,
+        #[codec(compact)]
+        pub initial: u32,
+        #[codec(compact)]
+        pub maximum: u32,
+        pub code: RelaxedCodeVec<T>,
+        pub determinism: Determinism,
+    }
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        #[pallet::weight(1_000_000)]
+        pub fn migrate(
+            origin: OriginFor<T>,
+            weight_limit: Option<Weight>,
+        ) -> DispatchResultWithPostInfo {
+            ensure_signed(origin)?;
+
+            let version = <pallet_contracts::Pallet<T>>::on_chain_storage_version();
+            let mut consumed_weight = T::DbWeight::get().reads(1);
+
+            if version != 8 {
+                log::trace!(
+                    target: LOG_TARGET,
+                    "Version is {:?} so skipping migration procedures.",
+                    version,
+                );
+                return Ok(Some(consumed_weight).into());
+            }
+
+            let max_allowed_call_weight = Self::max_call_weight();
+            let weight_limit = weight_limit
+                .unwrap_or(max_allowed_call_weight)
+                .min(max_allowed_call_weight);
+
+            let migration_state = MigrationStateStorage::<T>::get().for_iteration();
+
+            if let MigrationState::CodeStorage(last_processed_key) = migration_state.clone() {
+                // First, get correct iterator.
+                let key_iter = if let Some(previous_key) = last_processed_key {
+                    CodeStorage::<T>::iter_keys_from(previous_key.into_inner())
+                } else {
+                    CodeStorage::<T>::iter_keys()
+                };
+
+                for key in key_iter {
+                    // TODO: need function from map that will only translate ONE value!
+                    let key_as_vec = CodeStorage::<T>::storage_map_final_key(key);
+                    let mut proof_size = 0_u64;
+                    Self::translate(&key_as_vec, |old: OldPrefabWasmModule<T>| {
+                        proof_size = old.using_encoded(|o| o.len() as u64);
+                        Some(PrefabWasmModule::<T> {
+                            instruction_weights_version: old.instruction_weights_version,
+                            initial: old.initial,
+                            maximum: old.maximum,
+                            code: old.code,
+                            determinism: Determinism::Deterministic,
+                        })
+                    });
+
+                    // Increment total consumed weight.
+                    consumed_weight.saturating_accrue(T::DbWeight::get().reads_writes(1, 1));
+                    // consumed_weight.saturating_accrue(Weight::from_proof_size())
+
+                    // // Check if we've consumed enough weight already.
+                    // if consumed_weight >= weight_limit {
+                    //     log::info!(
+                    //         ">>> Ledger migration stopped after consuming {:?} weight.",
+                    //         consumed_weight
+                    //     );
+                    //     MigrationStateV2::<T>::put(MigrationState::Ledger(Some(key_as_vec)));
+                    //     consumed_weight = consumed_weight.saturating_add(T::DbWeight::get().writes(1));
+
+                    //     // we want try-runtime to execute the entire migration
+                    //     if cfg!(feature = "try-runtime") {
+                    //         return stateful_migrate::<T>(weight_limit);
+                    //     } else {
+                    //         return consumed_weight;
+                    //     }
+                    // }
+                }
+
+                // log::info!(">>> Ledger migration finished.");
+                // // This means we're finished with migration of the Ledger. Hooray!
+                // // Next step of the migration should be configured.
+                // migration_state = MigrationState::StakingInfo(None);
+            }
+
+            Ok(().into())
+        }
+    }
+
+    impl<T: Config> Pallet<T> {
+        /// Max allowed weight that migration shoudl be allowed to consume
+        fn max_call_weight() -> Weight {
+            T::BlockWeights::get().max_block / 5 * 3
+        }
+
+        fn translate<O: FullCodec, V: FullCodec, F: FnMut(O) -> Option<V>>(
+            key: &[u8],
+            mut f: F,
+        ) -> Weight {
+            let value = match unhashed::get::<O>(key) {
+                Some(value) => value,
+                None => {
+                    return Weight::from_parts(
+                        T::DbWeight::get().reads(1).ref_time(),
+                        OldPrefabWasmModule::<T>::max_encoded_len() as u64,
+                    );
+                }
+            };
+
+            let mut proof_size = value.using_encoded(|o| o.len() as u64);
+
+            match f(value) {
+                Some(new) => {
+                    proof_size.saturating_accrue(new.using_encoded(|n| n.len() as u64));
+                    unhashed::put::<V>(key, &new);
+                }
+                // Cannot happen in this file
+                None => unhashed::kill(key),
+            }
+
+            Weight::from_parts(T::DbWeight::get().reads_writes(1, 1).ref_time(), proof_size)
+        }
+    }
+
+    #[derive(PartialEq, Eq, Clone, Encode, Decode, TypeInfo, RuntimeDebug, MaxEncodedLen)]
+    pub enum MigrationState {
+        NotInProgress,
+        /// In the middle of `CodeStorage` migration.
+        CodeStorage(Option<WeakBoundedVec<u8, ConstU32<1000>>>),
+    }
+
+    impl MigrationState {
+        fn for_iteration(self) -> Self {
+            if self == Self::NotInProgress {
+                Self::CodeStorage(None)
+            } else {
+                self
+            }
+        }
+    }
+
+    impl Default for MigrationState {
+        fn default() -> Self {
+            MigrationState::NotInProgress
+        }
+    }
+}

--- a/runtime/contracts-migration/src/lib.rs
+++ b/runtime/contracts-migration/src/lib.rs
@@ -44,6 +44,7 @@ pub mod pallet {
     #[pallet::event]
     #[pallet::generate_deposit(pub(crate) fn deposit_event)]
     pub enum Event<T: Config> {
+        /// Number of contracts that were migrated in the migration call
         ContractsMigrated(u32),
     }
 
@@ -135,7 +136,7 @@ pub mod pallet {
 
             let migration_state = MigrationStateStorage::<T>::get().for_iteration();
 
-            if let MigrationState::CodeStorage(last_processed_key) = migration_state.clone() {
+            if let MigrationState::CodeStorage(last_processed_key) = migration_state {
                 // First, get correct iterator.
                 let key_iter = if let Some(previous_key) = last_processed_key {
                     CodeStorage::<T>::iter_keys_from(previous_key.into_inner())

--- a/runtime/contracts-migration/src/lib.rs
+++ b/runtime/contracts-migration/src/lib.rs
@@ -15,7 +15,7 @@ use codec::{Decode, Encode, FullCodec};
 use frame_system::pallet_prelude::*;
 use pallet_contracts::Determinism;
 use sp_runtime::Saturating;
-use sp_std::vec;
+use sp_std::vec::Vec;
 
 const LOG_TARGET: &str = "pallet-contracts-migration";
 
@@ -249,7 +249,7 @@ pub mod pallet {
         }
 
         #[cfg(feature = "try-runtime")]
-        fn post_upgrade(state: Vec<u8>) -> Result<(), &'static str> {
+        fn post_upgrade(_state: Vec<u8>) -> Result<(), &'static str> {
             for value in CodeStorage::<T>::iter_values() {
                 ensure!(
                     value.determinism == Determinism::Deterministic,

--- a/runtime/contracts-migration/src/lib.rs
+++ b/runtime/contracts-migration/src/lib.rs
@@ -15,7 +15,10 @@ use codec::{Decode, Encode, FullCodec};
 use frame_system::pallet_prelude::*;
 use pallet_contracts::Determinism;
 use sp_runtime::Saturating;
+#[cfg(feature = "try-runtime")]
 use sp_std::vec::Vec;
+
+pub use crate::pallet::CustomMigration;
 
 const LOG_TARGET: &str = "pallet-contracts-migration";
 
@@ -256,6 +259,10 @@ pub mod pallet {
                     "All pre-existing codes need to be deterministic."
                 );
             }
+            ensure!(
+                !MigrationStateStorage::<T>::exists(),
+                "MigrationStateStorage has to be killed at the end of migration."
+            );
             Ok(())
         }
     }

--- a/runtime/contracts-migration/src/lib.rs
+++ b/runtime/contracts-migration/src/lib.rs
@@ -2,8 +2,6 @@
 
 /// Purpose of this pallet is to provide multi-stage migration features for pallet-contracts v9 migration.
 /// Once it's finished for both `Shibuya` and `Shiden`, it should be deleted.
-///
-/// We don't need to disable pallet-contract calls since translation will only work for types that are encoded using the old storage type.
 pub use pallet::*;
 
 use frame_support::{

--- a/runtime/contracts-migration/src/lib.rs
+++ b/runtime/contracts-migration/src/lib.rs
@@ -159,7 +159,7 @@ pub mod pallet {
                     if consumed_weight.any_gt(weight_limit) {
                         log::trace!(
                             target: LOG_TARGET,
-                            "CodeStorage migration stopped after consuming {:?} weight and after processing {:?} DB entires.",
+                            "CodeStorage migration stopped after consuming {:?} weight and after processing {:?} DB entries.",
                             consumed_weight, counter,
                         );
                         MigrationStateStorage::<T>::put(MigrationState::CodeStorage(Some(

--- a/runtime/contracts-migration/src/lib.rs
+++ b/runtime/contracts-migration/src/lib.rs
@@ -2,7 +2,8 @@
 
 /// Purpose of this pallet is to provide multi-stage migration features for pallet-contracts v9 migration.
 /// Once it's finished for both `Shibuya` and `Shiden`, it should be deleted.
-
+///
+/// We don't need to disable pallet-contract calls since translation will only work for types that are encoded using the old storage type.
 pub use pallet::*;
 
 use frame_support::{

--- a/runtime/local/Cargo.toml
+++ b/runtime/local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-runtime"
-version = "4.39.1"
+version = "4.40.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -105,6 +105,9 @@ pallet-xcm = { git = "https://github.com/AstarNetwork/astar-frame", branch = "po
 pallet-xvm = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.33", default-features = false, features = ["evm", "wasm"] }
 xcm-primitives = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.33", default-features = false }
 
+# Remove after migration is done
+pallet-contracts-migration = { path = "../contracts-migration", default-features = false }
+
 # benchmarking
 array-bytes = "6.0.0"
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33", default-features = false, optional = true }
@@ -205,6 +208,7 @@ std = [
 	"xcm-builder/std",
 	"xcm-executor/std",
 	"xcm-primitives/std",
+	"pallet-contracts-migration/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking",
@@ -266,4 +270,5 @@ try-runtime = [
 	"pallet-preimage/try-runtime",
 	"pallet-base-fee/try-runtime",
 	"pallet-evm/try-runtime",
+	"pallet-contracts-migration/try-runtime",
 ]

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "4.39.1"
+version = "4.40.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -1229,26 +1229,6 @@ pub type Executive = frame_executive::Executive<
     (pallet_contracts::Migration<Runtime>,),
 >;
 
-use frame_support::traits::StorageVersion;
-use sp_std::marker::PhantomData;
-
-// Required beucase current scheduler version is 0.
-pub struct SchedulerStorageVersionMigration<T: pallet_scheduler::Config>(PhantomData<T>);
-impl<T: pallet_scheduler::Config> frame_support::traits::OnRuntimeUpgrade
-    for SchedulerStorageVersionMigration<T>
-{
-    fn on_runtime_upgrade() -> Weight {
-        let version = StorageVersion::get::<pallet_scheduler::Pallet<T>>();
-
-        if version < 3 {
-            StorageVersion::new(3).put::<pallet_scheduler::Pallet<T>>();
-            T::DbWeight::get().reads_writes(1, 1)
-        } else {
-            T::DbWeight::get().reads(1)
-        }
-    }
-}
-
 impl fp_self_contained::SelfContainedCall for RuntimeCall {
     type SignedInfo = H160;
 

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -657,6 +657,10 @@ impl pallet_contracts::Config for Runtime {
     type MaxStorageKeyLen = ConstU32<128>;
 }
 
+impl pallet_contracts_migration::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+}
+
 parameter_types! {
     pub const TransactionByteFee: Balance = MILLISDN / 100;
     pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
@@ -1175,6 +1179,9 @@ construct_runtime!(
         Xvm: pallet_xvm = 90,
 
         Sudo: pallet_sudo = 99,
+
+        // This will be removed after migration is finished
+        ContractsMigration: pallet_contracts_migration = 200,
     }
 );
 

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -1233,7 +1233,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
-    (),
+    pallet_contracts_migration::CustomMigration<Runtime>,
 >;
 
 impl fp_self_contained::SelfContainedCall for RuntimeCall {

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -136,7 +136,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shibuya"),
     impl_name: create_runtime_str!("shibuya"),
     authoring_version: 1,
-    spec_version: 83,
+    spec_version: 84,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,
@@ -1226,12 +1226,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
-    (
-        SchedulerStorageVersionMigration<Runtime>,
-        pallet_scheduler::migration::v3::MigrateToV4<Runtime>,
-        pallet_democracy::migrations::v1::Migration<Runtime>,
-        pallet_multisig::migrations::v1::MigrateToV1<Runtime>,
-    ),
+    (pallet_contracts::Migration<Runtime>,),
 >;
 
 use frame_support::traits::StorageVersion;

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -9,7 +9,7 @@ use cumulus_pallet_parachain_system::AnyRelayNumber;
 use frame_support::{
     construct_runtime,
     dispatch::DispatchClass,
-    parameter_types,
+    ensure, parameter_types, storage_alias,
     traits::{
         AsEnsureOriginWithArg, ConstU128, ConstU32, Contains, Currency, EitherOfDiverse,
         EqualPrivilegeOnly, FindAuthor, Get, Imbalance, InstanceFilter, Nothing, OnUnbalanced,
@@ -26,6 +26,7 @@ use frame_system::{
     limits::{BlockLength, BlockWeights},
     EnsureRoot, EnsureSigned,
 };
+use pallet_contracts::Determinism;
 use pallet_evm::{FeeCalculator, Runner};
 use pallet_transaction_payment::{
     FeeDetails, Multiplier, RuntimeDispatchInfo, TargetedFeeAdjustment,
@@ -1226,8 +1227,79 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
-    (pallet_contracts::Migration<Runtime>,),
+    (CustomMigration<Runtime>,),
 >;
+
+use frame_support::traits::StorageVersion;
+use sp_std::marker::PhantomData;
+
+#[derive(Encode, Decode, MaxEncodedLen)]
+pub struct OldPrefabWasmModule {
+    #[codec(compact)]
+    pub instruction_weights_version: u32,
+    #[codec(compact)]
+    pub initial: u32,
+    #[codec(compact)]
+    pub maximum: u32,
+    pub code: Vec<u8>,
+}
+
+#[derive(Encode, Decode, MaxEncodedLen)]
+pub struct PrefabWasmModule {
+    #[codec(compact)]
+    pub instruction_weights_version: u32,
+    #[codec(compact)]
+    pub initial: u32,
+    #[codec(compact)]
+    pub maximum: u32,
+    pub code: Vec<u8>,
+    pub determinism: Determinism,
+}
+
+#[storage_alias]
+type CodeStorage<T: pallet_contracts::Config> =
+    StorageMap<pallet_contracts::Pallet<T>, frame_support::Identity, CodeHash<T>, PrefabWasmModule>;
+
+type CodeHash<T> = <T as frame_system::Config>::Hash;
+
+// Required beucase current scheduler version is 0.
+pub struct CustomMigration<T: pallet_contracts::Config>(PhantomData<T>);
+impl<T: pallet_contracts::Config> frame_support::traits::OnRuntimeUpgrade for CustomMigration<T> {
+    fn on_runtime_upgrade() -> Weight {
+        let mut weight = Weight::zero();
+        let mut counter = 0_u32;
+        <CodeStorage<T>>::translate_values(|old: OldPrefabWasmModule| {
+            weight.saturating_accrue(T::DbWeight::get().reads_writes(1, 1));
+            weight.saturating_accrue(Weight::from_proof_size(
+                OldPrefabWasmModule::max_encoded_len(),
+            ));
+            weight.saturating_accrue(Weight::from_proof_size(PrefabWasmModule::max_encoded_len()));
+            counter += 1;
+            Some(PrefabWasmModule {
+                instruction_weights_version: old.instruction_weights_version,
+                initial: old.initial,
+                maximum: old.maximum,
+                code: old.code,
+                determinism: Determinism::Deterministic,
+            })
+        });
+
+        log::info!("Number of DB entries for migration: {:?}", counter);
+
+        weight
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn post_upgrade(state: Vec<u8>) -> Result<(), &'static str> {
+        for value in CodeStorage::<T>::iter_values() {
+            ensure!(
+                value.determinism == Determinism::Deterministic,
+                "All pre-existing codes need to be deterministic."
+            );
+        }
+        Ok(())
+    }
+}
 
 impl fp_self_contained::SelfContainedCall for RuntimeCall {
     type SignedInfo = H160;

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -12,8 +12,8 @@ use frame_support::{
     parameter_types,
     traits::{
         AsEnsureOriginWithArg, ConstU128, ConstU32, Contains, Currency, EitherOfDiverse,
-        EqualPrivilegeOnly, FindAuthor, Get, Imbalance, InstanceFilter, Nothing, OnUnbalanced,
-        WithdrawReasons,
+        EqualPrivilegeOnly, FindAuthor, Get, GetStorageVersion, Imbalance, InstanceFilter, Nothing,
+        OnUnbalanced, WithdrawReasons,
     },
     weights::{
         constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
@@ -210,6 +210,11 @@ impl Contains<RuntimeCall> for BaseFilter {
                 // registering the asset location should be good enough for users, any change can be handled via issue ticket or help request
                 _ => false,
             },
+            RuntimeCall::Contracts(_) => {
+                // We block the calls until storage migration has been finished.
+                // The DB read is already accounted for in the migration pallet's `on_initialize` function.
+                <pallet_contracts::Pallet<Runtime>>::on_chain_storage_version() == 9
+            }
             // These modules are not allowed to be called by transactions:
             // Other modules should works:
             _ => true,

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -212,7 +212,7 @@ impl Contains<RuntimeCall> for BaseFilter {
             },
             RuntimeCall::Contracts(_) => {
                 // We block the calls until storage migration has been finished.
-                // The DB read is already accounted for in the migration pallet's `on_initialize` function.
+                // The DB read weight is already accounted for in the migration pallet's `on_initialize` function.
                 <pallet_contracts::Pallet<Runtime>>::on_chain_storage_version() == 9
             }
             // These modules are not allowed to be called by transactions:

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "4.39.1"
+version = "4.40.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -103,6 +103,9 @@ pallet-xc-asset-config = { git = "https://github.com/AstarNetwork/astar-frame", 
 pallet-xcm = { git = "https://github.com/AstarNetwork/astar-frame", default-features = false, branch = "polkadot-v0.9.33" }
 xcm-primitives = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.33", default-features = false }
 
+# Remove after migration is done
+pallet-contracts-migration = { path = "../contracts-migration", default-features = false }
+
 [build-dependencies]
 substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.33" }
 
@@ -184,6 +187,7 @@ std = [
 	"xcm-executor/std",
 	"pallet-xc-asset-config/std",
 	"xcm-primitives/std",
+	"pallet-contracts-migration/std",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking",
@@ -236,4 +240,5 @@ try-runtime = [
 	"parachain-info/try-runtime",
 	"pallet-base-fee/try-runtime",
 	"pallet-evm/try-runtime",
+	"pallet-contracts-migration/try-runtime",
 ]

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -11,8 +11,8 @@ use frame_support::{
     dispatch::DispatchClass,
     parameter_types,
     traits::{
-        AsEnsureOriginWithArg, ConstU32, Contains, Currency, FindAuthor, Get, Imbalance, Nothing,
-        OnUnbalanced, WithdrawReasons,
+        AsEnsureOriginWithArg, ConstU32, Contains, Currency, FindAuthor, Get, GetStorageVersion,
+        Imbalance, Nothing, OnUnbalanced, WithdrawReasons,
     },
     weights::{
         constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
@@ -170,6 +170,11 @@ impl Contains<RuntimeCall> for BaseFilter {
                 pallet_assets::Call::destroy { id, .. } => *id < u32::MAX.into(),
                 _ => true,
             },
+            RuntimeCall::Contracts(_) => {
+                // We block the calls until storage migration has been finished.
+                // The DB read weight is already accounted for in the migration pallet's `on_initialize` function.
+                <pallet_contracts::Pallet<Runtime>>::on_chain_storage_version() == 9
+            }
             // These modules are not allowed to be called by transactions:
             // To leave collator just shutdown it, next session funds will be released
             // Other modules should works:
@@ -609,6 +614,10 @@ impl pallet_contracts::Config for Runtime {
     type MaxStorageKeyLen = ConstU32<128>;
 }
 
+impl pallet_contracts_migration::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
+}
+
 parameter_types! {
     pub const TransactionByteFee: Balance = MILLISDN / 100;
     pub const TargetBlockFullness: Perquintill = Perquintill::from_percent(25);
@@ -836,6 +845,9 @@ construct_runtime!(
         RandomnessCollectiveFlip: pallet_randomness_collective_flip = 71,
 
         Sudo: pallet_sudo = 99,
+
+        // This will be removed after migration is finished
+        ContractsMigration: pallet_contracts_migration = 200,
     }
 );
 
@@ -889,7 +901,7 @@ pub type Executive = frame_executive::Executive<
     AllPalletsWithSystem,
     (
         pallet_multisig::migrations::v1::MigrateToV1<Runtime>,
-        pallet_contracts::Migration<Runtime>,
+        pallet_contracts_migration::CustomMigration<Runtime>,
     ),
 >;
 

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -102,7 +102,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shiden"),
     impl_name: create_runtime_str!("shiden"),
     authoring_version: 1,
-    spec_version: 83,
+    spec_version: 84,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,
@@ -887,7 +887,10 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
-    (pallet_multisig::migrations::v1::MigrateToV1<Runtime>,),
+    (
+        pallet_multisig::migrations::v1::MigrateToV1<Runtime>,
+        pallet_contracts::Migration<Runtime>,
+    ),
 >;
 
 impl fp_self_contained::SelfContainedCall for RuntimeCall {


### PR DESCRIPTION
**Pull Request Summary**

### Context
`pallet-contracts` **v9** storage migration can blow up in PoV size and this happened with Shibuya.
This PR provides an approach to migrate the storage in multiple steps.
* I wanted to avoid forking the `pallet-contracts` and doing the modification directly in there
* Most of the types needed from `pallet-contracts` are only available to `pallet-contracts` crate so they had to be redefined here

**NOTE**
It seems that PoV size is overestimated in the code (double the size we got with Shibuya upgrade).
As long as it's not underestimated it should be fine.
```
INFO main try-runtime::cli: TryRuntime_on_runtime_upgrade executed without errors. Consumed weight = (79450000000 ps, 47731515 byte), total weight = (500000000000 ps, 5242880 byte) (15.89 %, 910.41 %).
```

**Check list**
- [x] implement solution & test it
- [x] update Shiden too
- [x] updated spec version
- [x] updated semver