### PR TITLE
Shiden - DS burn functionality & 100% fee burn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "astar-collator"
-version = "4.40.0"
+version = "4.41.0"
 dependencies = [
  "astar-runtime",
  "async-trait",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "astar-runtime"
-version = "4.40.0"
+version = "4.41.0"
 dependencies = [
  "array-bytes 6.0.0",
  "cumulus-pallet-aura-ext",
@@ -2015,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "dapps-staking-chain-extension-types"
 version = "1.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#7db1b337346529bf559f33616ccab89c3d271ea0"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#94a2185ef123462cdb1488d8fb1697019852b1cb"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4680,7 +4680,7 @@ checksum = "bb68f22743a3fb35785f1e7f844ca5a3de2dde5bd0c0ef5b372065814699b121"
 
 [[package]]
 name = "local-runtime"
-version = "4.40.0"
+version = "4.41.0"
 dependencies = [
  "array-bytes 6.0.0",
  "fp-rpc",
@@ -5583,7 +5583,7 @@ dependencies = [
 [[package]]
 name = "pallet-block-reward"
 version = "2.2.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#7db1b337346529bf559f33616ccab89c3d271ea0"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#94a2185ef123462cdb1488d8fb1697019852b1cb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5620,7 +5620,7 @@ dependencies = [
 [[package]]
 name = "pallet-chain-extension-dapps-staking"
 version = "1.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#7db1b337346529bf559f33616ccab89c3d271ea0"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#94a2185ef123462cdb1488d8fb1697019852b1cb"
 dependencies = [
  "dapps-staking-chain-extension-types",
  "frame-support",
@@ -5640,7 +5640,7 @@ dependencies = [
 [[package]]
 name = "pallet-chain-extension-xvm"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#7db1b337346529bf559f33616ccab89c3d271ea0"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#94a2185ef123462cdb1488d8fb1697019852b1cb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5679,7 +5679,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "3.3.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#7db1b337346529bf559f33616ccab89c3d271ea0"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#94a2185ef123462cdb1488d8fb1697019852b1cb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5798,7 +5798,7 @@ dependencies = [
 [[package]]
 name = "pallet-custom-signatures"
 version = "4.6.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#7db1b337346529bf559f33616ccab89c3d271ea0"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#94a2185ef123462cdb1488d8fb1697019852b1cb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5813,8 +5813,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-dapps-staking"
-version = "3.8.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#7db1b337346529bf559f33616ccab89c3d271ea0"
+version = "3.9.0"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#94a2185ef123462cdb1488d8fb1697019852b1cb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5974,7 +5974,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-assets-erc20"
 version = "0.5.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#7db1b337346529bf559f33616ccab89c3d271ea0"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#94a2185ef123462cdb1488d8fb1697019852b1cb"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6061,7 +6061,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sr25519"
 version = "1.2.1"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#7db1b337346529bf559f33616ccab89c3d271ea0"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#94a2185ef123462cdb1488d8fb1697019852b1cb"
 dependencies = [
  "fp-evm",
  "log",
@@ -6077,7 +6077,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-substrate-ecdsa"
 version = "1.2.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#7db1b337346529bf559f33616ccab89c3d271ea0"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#94a2185ef123462cdb1488d8fb1697019852b1cb"
 dependencies = [
  "fp-evm",
  "log",
@@ -6093,7 +6093,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-xcm"
 version = "0.9.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#7db1b337346529bf559f33616ccab89c3d271ea0"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#94a2185ef123462cdb1488d8fb1697019852b1cb"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6116,7 +6116,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-xvm"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#7db1b337346529bf559f33616ccab89c3d271ea0"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#94a2185ef123462cdb1488d8fb1697019852b1cb"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6397,8 +6397,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-precompile-dapps-staking"
-version = "3.6.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#7db1b337346529bf559f33616ccab89c3d271ea0"
+version = "3.6.3"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#94a2185ef123462cdb1488d8fb1697019852b1cb"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6800,7 +6800,7 @@ dependencies = [
 [[package]]
 name = "pallet-xc-asset-config"
 version = "1.3.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#7db1b337346529bf559f33616ccab89c3d271ea0"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#94a2185ef123462cdb1488d8fb1697019852b1cb"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6818,7 +6818,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "0.9.28"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#7db1b337346529bf559f33616ccab89c3d271ea0"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#94a2185ef123462cdb1488d8fb1697019852b1cb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6871,7 +6871,7 @@ dependencies = [
 [[package]]
 name = "pallet-xvm"
 version = "0.2.1"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#7db1b337346529bf559f33616ccab89c3d271ea0"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#94a2185ef123462cdb1488d8fb1697019852b1cb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8368,7 +8368,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 [[package]]
 name = "precompile-utils"
 version = "0.4.3"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#7db1b337346529bf559f33616ccab89c3d271ea0"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#94a2185ef123462cdb1488d8fb1697019852b1cb"
 dependencies = [
  "evm",
  "fp-evm",
@@ -8391,7 +8391,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#7db1b337346529bf559f33616ccab89c3d271ea0"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#94a2185ef123462cdb1488d8fb1697019852b1cb"
 dependencies = [
  "num_enum",
  "proc-macro2",
@@ -10630,7 +10630,7 @@ dependencies = [
 
 [[package]]
 name = "shibuya-runtime"
-version = "4.40.0"
+version = "4.41.0"
 dependencies = [
  "array-bytes 6.0.0",
  "cumulus-pallet-aura-ext",
@@ -10729,7 +10729,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "4.40.0"
+version = "4.41.0"
 dependencies = [
  "array-bytes 6.0.0",
  "cumulus-pallet-aura-ext",
@@ -13440,7 +13440,7 @@ dependencies = [
 [[package]]
 name = "xcm-primitives"
 version = "0.4.1"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#7db1b337346529bf559f33616ccab89c3d271ea0"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#94a2185ef123462cdb1488d8fb1697019852b1cb"
 dependencies = [
  "frame-support",
  "log",
@@ -13484,7 +13484,7 @@ dependencies = [
 [[package]]
 name = "xvm-chain-extension-types"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#7db1b337346529bf559f33616ccab89c3d271ea0"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.33#94a2185ef123462cdb1488d8fb1697019852b1cb"
 dependencies = [
  "parity-scale-codec",
  "scale-info",

--- a/bin/collator/Cargo.toml
+++ b/bin/collator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-collator"
-version = "4.40.0"
+version = "4.41.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Astar collator implementation in Rust."
 build = "build.rs"

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-runtime"
-version = "4.40.0"
+version = "4.41.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -103,7 +103,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("astar"),
     impl_name: create_runtime_str!("astar"),
     authoring_version: 1,
-    spec_version: 47,
+    spec_version: 48,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,
@@ -315,6 +315,8 @@ impl pallet_dapps_staking::Config for Runtime {
     type UnbondingPeriod = UnbondingPeriod;
     type MinimumRemainingAmount = MinimumRemainingAmount;
     type MaxEraStakeValues = MaxEraStakeValues;
+    // Not allowed on Astar yet
+    type UnregisteredDappRewardRetention = ConstU32<{ u32::MAX }>;
 }
 
 /// Multi-VM pointer to smart contract instance.

--- a/runtime/local/Cargo.toml
+++ b/runtime/local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-runtime"
-version = "4.40.0"
+version = "4.41.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -391,6 +391,7 @@ impl pallet_dapps_staking::Config for Runtime {
     type UnbondingPeriod = UnbondingPeriod;
     type MinimumRemainingAmount = MinimumRemainingAmount;
     type MaxEraStakeValues = MaxEraStakeValues;
+    type UnregisteredDappRewardRetention = ConstU32<3>;
 }
 
 /// Multi-VM pointer to smart contract instance.

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "4.40.0"
+version = "4.41.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -136,7 +136,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shibuya"),
     impl_name: create_runtime_str!("shibuya"),
     authoring_version: 1,
-    spec_version: 84,
+    spec_version: 85,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,
@@ -391,6 +391,7 @@ impl pallet_dapps_staking::Config for Runtime {
     type UnbondingPeriod = UnbondingPeriod;
     type MinimumRemainingAmount = MinimumRemainingAmount;
     type MaxEraStakeValues = MaxEraStakeValues;
+    type UnregisteredDappRewardRetention = ConstU32<10>;
 }
 
 /// Multi-VM pointer to smart contract instance.
@@ -1238,7 +1239,6 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
-    pallet_contracts_migration::CustomMigration<Runtime>,
 >;
 
 impl fp_self_contained::SelfContainedCall for RuntimeCall {

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "4.40.0"
+version = "4.41.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -12,7 +12,7 @@ use frame_support::{
     parameter_types,
     traits::{
         AsEnsureOriginWithArg, ConstU32, Contains, Currency, FindAuthor, Get, GetStorageVersion,
-        Imbalance, Nothing, OnUnbalanced, WithdrawReasons,
+        Nothing, OnUnbalanced, WithdrawReasons,
     },
     weights::{
         constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
@@ -654,28 +654,16 @@ impl WeightToFeePolynomial for WeightToFee {
     }
 }
 
-pub struct DealWithFees;
-impl OnUnbalanced<NegativeImbalance> for DealWithFees {
-    fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance>) {
-        if let Some(mut fees) = fees_then_tips.next() {
-            if let Some(tips) = fees_then_tips.next() {
-                tips.merge_into(&mut fees);
-            }
-
-            let (to_burn, collators) = fees.ration(20, 80);
-
-            // burn part of fees
-            let _ = Balances::burn(to_burn.peek());
-
-            // pay fees to collators
-            <ToStakingPot as OnUnbalanced<_>>::on_unbalanced(collators);
-        }
+pub struct BurnFees;
+impl OnUnbalanced<NegativeImbalance> for BurnFees {
+    fn on_unbalanceds<B>(_: impl Iterator<Item = NegativeImbalance>) {
+        // burns the fees
     }
 }
 
 impl pallet_transaction_payment::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type OnChargeTransaction = pallet_transaction_payment::CurrencyAdapter<Balances, DealWithFees>;
+    type OnChargeTransaction = pallet_transaction_payment::CurrencyAdapter<Balances, BurnFees>;
     type WeightToFee = WeightToFee;
     type OperationalFeeMultiplier = OperationalFeeMultiplier;
     type FeeMultiplierUpdate = TargetedFeeAdjustment<

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -102,7 +102,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shiden"),
     impl_name: create_runtime_str!("shiden"),
     authoring_version: 1,
-    spec_version: 84,
+    spec_version: 85,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,
@@ -321,6 +321,7 @@ impl pallet_dapps_staking::Config for Runtime {
     type MaxUnlockingChunks = MaxUnlockingChunks;
     type UnbondingPeriod = UnbondingPeriod;
     type MaxEraStakeValues = MaxEraStakeValues;
+    type UnregisteredDappRewardRetention = ConstU32<7>;
 }
 
 /// Multi-VM pointer to smart contract instance.

--- a/runtime/shiden/src/xcm_config.rs
+++ b/runtime/shiden/src/xcm_config.rs
@@ -1,5 +1,5 @@
 use super::{
-    AccountId, AssetId, Assets, Balance, Balances, DealWithFees, ParachainInfo, ParachainSystem,
+    AccountId, AssetId, Assets, Balance, Balances, BurnFees, ParachainInfo, ParachainSystem,
     PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, ShidenAssetLocationIdConverter,
     TreasuryAccountId, WeightToFee, XcAssetConfig, XcmpQueue, MAXIMUM_BLOCK_WEIGHT,
 };
@@ -147,7 +147,7 @@ impl Config for XcmConfig {
     type Barrier = XcmBarrier;
     type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
     type Trader = (
-        UsingComponents<WeightToFee, ShidenLocation, AccountId, Balances, DealWithFees>,
+        UsingComponents<WeightToFee, ShidenLocation, AccountId, Balances, BurnFees>,
         FixedRateOfForeignAsset<XcAssetConfig, ShidenXcmFungibleFeeHandler>,
     );
     type ResponseHandler = PolkadotXcm;


### PR DESCRIPTION
**Pull Request Summary**

Introduces latest `pallet-dapps-staking` version which introduces a new extrinsic call: `burn_stale_reward`
In case contract gets unregistered, its rewards will remain claimable for a predetermined number of eras.
After that, the new call can be used to burn the rewards.
* `Shiden` retention period is **7 eras**
* `Astar` retention period is **u32::MAX**, essentially disabling the functionality

Also introducing to `Shiden` is 100% fee burning. 

**Check list**
- [x] updated spec version
- [x] updated semver
