### PR TITLE
Shiden - burn only fee, not the tip

### DIFF
--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -619,7 +619,7 @@ impl OnUnbalanced<NegativeImbalance> for DealWithFees {
             let (to_burn, collators) = fees.ration(20, 80);
 
             // burn part of fees
-            let _ = Balances::burn(to_burn.peek());
+            drop(to_burn);
 
             // pay fees to collators
             <ToStakingPot as OnUnbalanced<_>>::on_unbalanced(collators);

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -716,7 +716,7 @@ impl OnUnbalanced<NegativeImbalance> for DealWithFees {
             let (to_burn, collators) = fees.ration(20, 80);
 
             // burn part of fees
-            let _ = Balances::burn(to_burn.peek());
+            drop(to_burn);
 
             // pay fees to collators
             <ToStakingPot as OnUnbalanced<_>>::on_unbalanced(collators);

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -12,7 +12,7 @@ use frame_support::{
     parameter_types,
     traits::{
         AsEnsureOriginWithArg, ConstU32, Contains, Currency, FindAuthor, Get, GetStorageVersion,
-        Imbalance, InstanceFilter, Nothing, OnUnbalanced, WithdrawReasons,
+        InstanceFilter, Nothing, OnUnbalanced, WithdrawReasons,
     },
     weights::{
         constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
@@ -658,13 +658,13 @@ pub struct BurnFees;
 impl OnUnbalanced<NegativeImbalance> for BurnFees {
     /// Payout tips but burn all the fees
     fn on_unbalanceds<B>(mut fees_then_tips: impl Iterator<Item = NegativeImbalance>) {
-        if let Some(fees) = fees_then_tips.next() {
+        if let Some(fees_to_burn) = fees_then_tips.next() {
             if let Some(tips) = fees_then_tips.next() {
                 <ToStakingPot as OnUnbalanced<_>>::on_unbalanced(tips);
             }
 
             // burn fees
-            let _ = Balances::burn(fees.peek());
+            drop(fees_to_burn);
         }
     }
 }


### PR DESCRIPTION
**Pull Request Summary**

Modified `Shiden` burning so only fee is burned, not the tip.
Also fixed `Shibuya`'s and `Astar`'s double burn.

No updates to semver or spec version is intentional.
