### PR TITLE
Optional evm rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,7 +165,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "astar-collator"
-version = "4.44.0"
+version = "4.45.0"
 dependencies = [
  "astar-runtime",
  "async-trait",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "astar-runtime"
-version = "4.44.0"
+version = "4.45.0"
 dependencies = [
  "array-bytes 6.0.0",
  "cumulus-pallet-aura-ext",
@@ -4680,7 +4680,7 @@ checksum = "bb68f22743a3fb35785f1e7f844ca5a3de2dde5bd0c0ef5b372065814699b121"
 
 [[package]]
 name = "local-runtime"
-version = "4.44.0"
+version = "4.45.0"
 dependencies = [
  "array-bytes 6.0.0",
  "fp-rpc",
@@ -10680,7 +10680,7 @@ dependencies = [
 
 [[package]]
 name = "shibuya-runtime"
-version = "4.44.0"
+version = "4.45.0"
 dependencies = [
  "array-bytes 6.0.0",
  "cumulus-pallet-aura-ext",
@@ -10780,7 +10780,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "4.44.0"
+version = "4.45.0"
 dependencies = [
  "array-bytes 6.0.0",
  "cumulus-pallet-aura-ext",

--- a/bin/collator/Cargo.toml
+++ b/bin/collator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-collator"
-version = "4.44.0"
+version = "4.45.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Astar collator implementation in Rust."
 build = "build.rs"

--- a/bin/collator/src/cli.rs
+++ b/bin/collator/src/cli.rs
@@ -30,6 +30,9 @@ pub struct Cli {
     #[clap(flatten)]
     pub run: cumulus_client_cli::RunCmd,
 
+    /// Enable Ethereum compatible JSON-RPC servers (disabled by default).
+    pub enable_evm_rpc: bool,
+
     /// Relaychain arguments
     #[clap(raw = true)]
     pub relaychain_args: Vec<String>,

--- a/bin/collator/src/cli.rs
+++ b/bin/collator/src/cli.rs
@@ -31,6 +31,7 @@ pub struct Cli {
     pub run: cumulus_client_cli::RunCmd,
 
     /// Enable Ethereum compatible JSON-RPC servers (disabled by default).
+    #[clap(name = "enable-evm-rpc")]
     pub enable_evm_rpc: bool,
 
     /// Relaychain arguments

--- a/bin/collator/src/command.rs
+++ b/bin/collator/src/command.rs
@@ -701,17 +701,17 @@ pub fn run() -> Result<()> {
                 );
 
                 if config.chain_spec.is_astar() {
-                    start_astar_node(config, polkadot_config, collator_options, para_id)
+                    start_astar_node(config, polkadot_config, collator_options, para_id, cli.enable_evm_rpc)
                         .await
                         .map(|r| r.0)
                         .map_err(Into::into)
                 } else if config.chain_spec.is_shiden() {
-                    start_shiden_node(config, polkadot_config, collator_options, para_id)
+                    start_shiden_node(config, polkadot_config, collator_options, para_id, cli.enable_evm_rpc)
                         .await
                         .map(|r| r.0)
                         .map_err(Into::into)
                 } else if config.chain_spec.is_shibuya() {
-                    start_shibuya_node(config, polkadot_config, collator_options, para_id)
+                    start_shibuya_node(config, polkadot_config, collator_options, para_id, cli.enable_evm_rpc)
                         .await
                         .map(|r| r.0)
                         .map_err(Into::into)

--- a/bin/collator/src/local/service.rs
+++ b/bin/collator/src/local/service.rs
@@ -305,6 +305,7 @@ pub fn start_node(config: Configuration) -> Result<TaskManager, ServiceError> {
                 fee_history_cache: fee_history_cache.clone(),
                 block_data_cache: block_data_cache.clone(),
                 overrides: overrides.clone(),
+                enable_evm_rpc: true, // enable EVM RPC for dev node by default
             };
 
             crate::rpc::create_full(deps, subscription).map_err::<ServiceError, _>(Into::into)

--- a/bin/collator/src/parachain/service.rs
+++ b/bin/collator/src/parachain/service.rs
@@ -299,6 +299,7 @@ async fn start_node_impl<RuntimeApi, Executor, BIQ, BIC>(
     polkadot_config: Configuration,
     collator_options: CollatorOptions,
     id: ParaId,
+    enable_evm_rpc: bool,
     build_import_queue: BIQ,
     build_consensus: BIC,
 ) -> sc_service::error::Result<(
@@ -484,6 +485,7 @@ where
                 fee_history_cache: fee_history_cache.clone(),
                 block_data_cache: block_data_cache.clone(),
                 overrides: overrides.clone(),
+                enable_evm_rpc,
             };
 
             crate::rpc::create_full(deps, subscription).map_err(Into::into)
@@ -657,6 +659,7 @@ pub async fn start_astar_node(
     polkadot_config: Configuration,
     collator_options: CollatorOptions,
     id: ParaId,
+    enable_evm_rpc: bool,
 ) -> sc_service::error::Result<(
     TaskManager,
     Arc<TFullClient<Block, astar::RuntimeApi, NativeElseWasmExecutor<astar::Executor>>>,
@@ -666,6 +669,7 @@ pub async fn start_astar_node(
         polkadot_config,
         collator_options,
         id,
+        enable_evm_rpc,
         |client,
          block_import,
          config,
@@ -785,6 +789,7 @@ pub async fn start_shiden_node(
     polkadot_config: Configuration,
     collator_options: CollatorOptions,
     id: ParaId,
+    enable_evm_rpc: bool,
 ) -> sc_service::error::Result<(
     TaskManager,
     Arc<TFullClient<Block, shiden::RuntimeApi, NativeElseWasmExecutor<shiden::Executor>>>,
@@ -794,6 +799,7 @@ pub async fn start_shiden_node(
         polkadot_config,
         collator_options,
         id,
+        enable_evm_rpc,
         |client,
          block_import,
          config,
@@ -913,6 +919,7 @@ pub async fn start_shibuya_node(
     polkadot_config: Configuration,
     collator_options: CollatorOptions,
     id: ParaId,
+    enable_evm_rpc: bool,
 ) -> sc_service::error::Result<(
     TaskManager,
     Arc<TFullClient<Block, shibuya::RuntimeApi, NativeElseWasmExecutor<shibuya::Executor>>>,
@@ -922,6 +929,7 @@ pub async fn start_shibuya_node(
         polkadot_config,
         collator_options,
         id,
+        enable_evm_rpc,
         |client,
          block_import,
          config,

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-runtime"
-version = "4.44.0"
+version = "4.45.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/local/Cargo.toml
+++ b/runtime/local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-runtime"
-version = "4.44.0"
+version = "4.45.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "4.44.0"
+version = "4.45.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "4.44.0"
+version = "4.45.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"

--- a/third-party/zombienet/multi_parachains.toml
+++ b/third-party/zombienet/multi_parachains.toml
@@ -35,7 +35,7 @@ cumulus_based = true
   name = "collator1"
   command = "./astar-collator"
   rpc_port = 8545
-  args = [ "-l=xcm=trace" ]
+  args = [ "-l=xcm=trace", "--enable-evm-rpc" ]
 
 # For this one you can download or build some other para and run it.
 # In this example, `astar-collator` is reused but `shiden-dev` chain is used
@@ -47,7 +47,7 @@ cumulus_based = true
   [[parachains.collators]]
   name = "collator2"
   command = "./astar-collator"
-  args = [ "-l=xcm=trace" ]
+  args = [ "-l=xcm=trace", "--enable-evm-rpc" ]
 
 [[hrmp_channels]]
   sender = 2000

--- a/third-party/zombienet/single_parachain.toml
+++ b/third-party/zombienet/single_parachain.toml
@@ -34,9 +34,10 @@ cumulus_based = true
   [[parachains.collators]]
   name = "collator1"
   command = "./astar-collator"
-  args = [ "-l=xcm=trace" ]
+  args = [ "-l=xcm=trace", "--enable-evm-rpc" ]
   
 
   [[parachains.collators]]
   name = "collator2"
   command = "./astar-collator"
+  args = [ "--enable-evm-rpc" ]


### PR DESCRIPTION
**Pull Request Summary**

This PR is **client only**. It disables Ethereum compatible RPC servers by default.

Changelog:

* EVM RPC disabled by default;
* Introduced `--enable-evm-rpc` CLI flag that enables EVM RPC server.

**Check list**
- [ ] added or updated unit tests
- [x] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [ ] updated spec version
- [x] updated semver
