### PR TITLE
use same runner for build and benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,7 +31,7 @@ jobs:
     # run only when PR comments start with '/bench'.
     if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/bench')
     needs: check-permission
-    runs-on: [self-hosted, Linux, X64, bench]
+    runs-on: [self-hosted, Linux, X64]
     steps:
     - name: Validate and set inputs
       id: bench-input

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
   SUBWASM_VERSION: 0.16.1
 jobs:
   checks-and-tests:
-    runs-on: [self-hosted, Linux, X64, build]
+    runs-on: [self-hosted, Linux, X64]
     steps:
     - name: Free disk space
       run: |
@@ -40,7 +40,7 @@ jobs:
 
   native-linux:
     needs: checks-and-tests
-    runs-on: [self-hosted, Linux, X64, build]
+    runs-on: [self-hosted, Linux, X64]
     strategy:
       matrix:
         target:
@@ -101,7 +101,7 @@ jobs:
 
   rpc-tests:
     needs: native-linux
-    runs-on: [self-hosted, Linux, X64, build]
+    runs-on: [self-hosted, Linux, X64]
     strategy:
       matrix:
         network: [astar, shiden]


### PR DESCRIPTION
**Pull Request Summary**
Use the same github actions runner labels for binary build and benchmarks.
