### PR TITLE
StakerRewardClaim proxy type

### DIFF
--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -817,6 +817,7 @@ pub enum ProxyType {
     Governance,
     CancelProxy,
     DappsStaking,
+    StakerRewardClaim,
 }
 
 impl Default for ProxyType {
@@ -875,6 +876,13 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
             ProxyType::DappsStaking => {
                 matches!(c, RuntimeCall::DappsStaking(..) | RuntimeCall::Utility(..))
             }
+            ProxyType::StakerRewardClaim => {
+                matches!(
+                    c,
+                    RuntimeCall::DappsStaking(pallet_dapps_staking::Call::claim_staker { .. })
+                        | RuntimeCall::Utility(..)
+                )
+            }
         }
     }
 
@@ -884,6 +892,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
             (ProxyType::Any, _) => true,
             (_, ProxyType::Any) => false,
             (ProxyType::NonTransfer, _) => true,
+            (ProxyType::StakerRewardClaim, ProxyType::DappsStaking) => true,
             _ => false,
         }
     }

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -1022,6 +1022,7 @@ pub enum ProxyType {
     IdentityJudgement,
     CancelProxy,
     DappsStaking,
+    StakerRewardClaim,
 }
 
 impl Default for ProxyType {
@@ -1098,6 +1099,13 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
             ProxyType::DappsStaking => {
                 matches!(c, RuntimeCall::DappsStaking(..) | RuntimeCall::Utility(..))
             }
+            ProxyType::StakerRewardClaim => {
+                matches!(
+                    c,
+                    RuntimeCall::DappsStaking(pallet_dapps_staking::Call::claim_staker { .. })
+                        | RuntimeCall::Utility(..)
+                )
+            }
         }
     }
 
@@ -1107,6 +1115,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
             (ProxyType::Any, _) => true,
             (_, ProxyType::Any) => false,
             (ProxyType::NonTransfer, _) => true,
+            (ProxyType::StakerRewardClaim, ProxyType::DappsStaking) => true,
             _ => false,
         }
     }

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -834,6 +834,7 @@ impl pallet_xc_asset_config::Config for Runtime {
 pub enum ProxyType {
     CancelProxy,
     DappsStaking,
+    StakerRewardClaim,
 }
 
 impl Default for ProxyType {
@@ -854,12 +855,20 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
             ProxyType::DappsStaking => {
                 matches!(c, RuntimeCall::DappsStaking(..) | RuntimeCall::Utility(..))
             }
+            ProxyType::StakerRewardClaim => {
+                matches!(
+                    c,
+                    RuntimeCall::DappsStaking(pallet_dapps_staking::Call::claim_staker { .. })
+                        | RuntimeCall::Utility(..)
+                )
+            }
         }
     }
 
     fn is_superset(&self, o: &Self) -> bool {
         match (self, o) {
             (x, y) if x == y => true,
+            (ProxyType::StakerRewardClaim, ProxyType::DappsStaking) => true,
             _ => false,
         }
     }


### PR DESCRIPTION
**Pull Request Summary**

Added a new proxy type `StakerRewardClaim`.
Only allows `claim_staker` call (and `pallet-utility` calls) to be executed.
This is less permissive than existing `DappsStaking` proxy type and is more appropriate for remote reward claim.

**WIP** - will most likely be merged after `polkadot-v0.9.36` uplift.

**Check list**
- [ ] decide on a different name?
- [ ] updated spec version
- [ ] updated semver
