### PR TITLE
Zombienet toml fix

### DIFF
--- a/third-party/zombienet/multi_parachains.toml
+++ b/third-party/zombienet/multi_parachains.toml
@@ -1,7 +1,7 @@
-# Used to start 4 validator nodes and 2 collator nodes - 1 per parachain
-
 [settings]
 timeout = 1000
+
+# Used to start 4 validator nodes and 2 collator nodes - 1 per parachain
 
 [relaychain]
 default_command = "./polkadot"

--- a/third-party/zombienet/single_parachain.toml
+++ b/third-party/zombienet/single_parachain.toml
@@ -1,7 +1,7 @@
-# Used to start 4 validator nodes and 2 collator nodes for a single parachain.
-
 [settings]
 timeout = 1000
+
+# Used to start 4 validator nodes and 2 collator nodes for a single parachain.
 
 [relaychain]
 default_command = "./polkadot"


### PR DESCRIPTION
**Pull Request Summary**

Latest `zombienet` release adds some `.toml` checks that fails if file starts with a comment.
