### PR TITLE
Add `--locked` to cargo invocations

### DIFF
--- a/.github/workflows/base_checks.yaml
+++ b/.github/workflows/base_checks.yaml
@@ -31,4 +31,4 @@ jobs:
       run: rustup target list --installed
 
     - name: Check all features compilation
-      run: cargo check --verbose --all-features --frozen --locked
+      run: cargo check --verbose --all-features --locked

--- a/.github/workflows/base_checks.yaml
+++ b/.github/workflows/base_checks.yaml
@@ -31,4 +31,4 @@ jobs:
       run: rustup target list --installed
 
     - name: Check all features compilation
-      run: cargo check --verbose --all-features
+      run: cargo check --verbose --all-features --frozen --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,10 @@ jobs:
       run: rustup target list --installed
 
     - name: Check all features compilation
-      run: cargo check --verbose --all-features --frozen --locked
+      run: cargo check --verbose --all-features --locked
 
     - name: Run all tests
-      run: cargo test --all-features --frozen --locked
+      run: cargo test --all-features --locked
 
   native-linux:
     needs: checks-and-tests
@@ -86,7 +86,7 @@ jobs:
       run: rustup target list --installed
 
     - name: Build optimized binary
-      run: CARGO_PROFILE_RELEASE_LTO=true RUSTFLAGS="-C codegen-units=1" cargo build --release --target ${{ matrix.target }} --verbose --frozen --locked
+      run: CARGO_PROFILE_RELEASE_LTO=true RUSTFLAGS="-C codegen-units=1" cargo build --release --target ${{ matrix.target }} --verbose --locked
 
     - name: Set artifact name
       env:
@@ -159,7 +159,7 @@ jobs:
       run: rustup target list --installed
 
     - name: Build optimized binary
-      run: cargo build --release --verbose --frozen --locked
+      run: cargo build --release --verbose --locked
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,10 @@ jobs:
       run: rustup target list --installed
 
     - name: Check all features compilation
-      run: cargo check --verbose --all-features
+      run: cargo check --verbose --all-features --frozen --locked
 
     - name: Run all tests
-      run: cargo test --all-features
+      run: cargo test --all-features --frozen --locked
 
   native-linux:
     needs: checks-and-tests
@@ -86,7 +86,7 @@ jobs:
       run: rustup target list --installed
 
     - name: Build optimized binary
-      run: CARGO_PROFILE_RELEASE_LTO=true RUSTFLAGS="-C codegen-units=1" cargo build --release --target ${{ matrix.target }} --verbose
+      run: CARGO_PROFILE_RELEASE_LTO=true RUSTFLAGS="-C codegen-units=1" cargo build --release --target ${{ matrix.target }} --verbose --frozen --locked
 
     - name: Set artifact name
       env:
@@ -159,7 +159,7 @@ jobs:
       run: rustup target list --installed
 
     - name: Build optimized binary
-      run: cargo build --release --verbose
+      run: cargo build --release --verbose --frozen --locked
 
     - uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
Current CI does not check for outdated/uncommitted `Cargo.lock`.

By passing `--locked` we ensure that lock file should be up to date.