### PR TITLE
chore: bump nix rust to match `rust-toolchain.toml`

### DIFF
--- a/third-party/nix/nixpkgs.nix
+++ b/third-party/nix/nixpkgs.nix
@@ -1,7 +1,7 @@
-{ moz_overlay ? import (builtins.fetchTarball https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz)
+{ rust-overlay ? import (builtins.fetchTarball https://github.com/oxalica/rust-overlay/archive/master.tar.gz)
 , nixpkgs ? import (builtins.fetchTarball https://github.com/nixos/nixpkgs-channels/archive/nixos-21.11.tar.gz)
 }:
 
 nixpkgs {
-  overlays = [ moz_overlay ];
+  overlays = [ rust-overlay ];
 }

--- a/third-party/nix/release.nix
+++ b/third-party/nix/release.nix
@@ -3,7 +3,7 @@
 
 let
   pkgs = import <nixpkgs> { overlays = [ moz_overlay ]; };
-  channel = pkgs.rustChannelOf { date = "2022-08-05"; channel = "nightly"; };
+  channel = pkgs.rustChannelOf { date = "2023-01-10"; channel = "nightly"; };
 in {
   inherit pkgs;
   rust-nightly = channel.rust.override {

--- a/third-party/nix/release.nix
+++ b/third-party/nix/release.nix
@@ -1,13 +1,9 @@
-{ moz_overlay ? import (builtins.fetchTarball https://github.com/mozilla/nixpkgs-mozilla/archive/master.tar.gz)
+{ rust-overlay ? import (builtins.fetchTarball https://github.com/oxalica/rust-overlay/archive/master.tar.gz)
 }:
 
 let
-  pkgs = import <nixpkgs> { overlays = [ moz_overlay ]; };
-  channel = pkgs.rustChannelOf { date = "2023-01-10"; channel = "nightly"; };
+  pkgs = import <nixpkgs> { overlays = [ rust-overlay ]; };
 in {
   inherit pkgs;
-  rust-nightly = channel.rust.override {
-    targets = [ "wasm32-unknown-unknown" ];
-    extensions = [ "rustfmt-preview" ];
-  };
+  rust-nightly = pkgs.rust-bin.fromRustupToolchainFile ../../rust-toolchain.toml;
 }


### PR DESCRIPTION
**Pull Request Summary**
Bumping Rust channel in Nix env.

When using Nix to build runtime with command `nix-shell -I nixpkgs=channel:nixos-21.05 third-party/nix/shell.nix --run "cargo build --release"` was failing due to old rustc version (although it should pick the correct one from rust-toolchain file). Builds fine after bumping rust in nix env.

**Check list**
- [ ] added or updated unit tests
- [ ] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [ ] updated spec version
- [ ] updated semver
