### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,7 +354,7 @@ jobs:
         os: ["ubuntu", "macOS"]
         arch: ["x86_64", "aarch64"]
         exclude:
-        - os: macos
+        - os: macOS
           arch: aarch64
     steps:
     - name: Create download folder


### PR DESCRIPTION
I think the macOS fix is obvious, let's make sure it then does what you expect.

While running actionlint on the workflow directory, I found these errors.
`bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)`

```
release.yml:95:12: workflow command "set-output" was deprecated. use `echo "{name}={value}" >> $GITHUB_OUTPUT` instead: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions [deprecated-commands]
   |
95 |       run: echo "::set-output name=name::astar-ubuntu-latest-${TARGET%%-*}"
   |            ^~~~

release.yml:364:15: value "macos" in "exclude" does not exist in matrix "os" combinations. possible values are "ubuntu", "macOS" [matrix]
    |
364 |         - os: macos
    |               ^~~~~

release.yml:407:12: workflow command "set-output" was deprecated. use `echo "{name}={value}" >> $GITHUB_OUTPUT` instead: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions [deprecated-commands]
    |
407 |       run: |
    |            ^
```

**Pull Request Summary**


**Check list**
- [ ] added or updated unit tests
- [ ] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [ ] updated spec version
- [ ] updated semver
