### PR TITLE
Fix double impl for XcAssetConfig in XcmSim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,7 +2070,7 @@ dependencies = [
 [[package]]
 name = "dapps-staking-chain-extension-types"
 version = "1.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#2fd2dca02e530212ed3ea8a2347055c0c2265065"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#07b479cd20c8f6cbd09efe0086e85eefe4430a9d"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6031,7 +6031,7 @@ dependencies = [
 [[package]]
 name = "pallet-block-reward"
 version = "2.2.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#2fd2dca02e530212ed3ea8a2347055c0c2265065"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#07b479cd20c8f6cbd09efe0086e85eefe4430a9d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6068,7 +6068,7 @@ dependencies = [
 [[package]]
 name = "pallet-chain-extension-dapps-staking"
 version = "1.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#2fd2dca02e530212ed3ea8a2347055c0c2265065"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#07b479cd20c8f6cbd09efe0086e85eefe4430a9d"
 dependencies = [
  "dapps-staking-chain-extension-types",
  "frame-support",
@@ -6088,7 +6088,7 @@ dependencies = [
 [[package]]
 name = "pallet-chain-extension-xvm"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#2fd2dca02e530212ed3ea8a2347055c0c2265065"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#07b479cd20c8f6cbd09efe0086e85eefe4430a9d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6127,7 +6127,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "3.3.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#2fd2dca02e530212ed3ea8a2347055c0c2265065"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#07b479cd20c8f6cbd09efe0086e85eefe4430a9d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6232,7 +6232,7 @@ dependencies = [
 [[package]]
 name = "pallet-custom-signatures"
 version = "4.6.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#2fd2dca02e530212ed3ea8a2347055c0c2265065"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#07b479cd20c8f6cbd09efe0086e85eefe4430a9d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6248,7 +6248,7 @@ dependencies = [
 [[package]]
 name = "pallet-dapps-staking"
 version = "3.9.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#2fd2dca02e530212ed3ea8a2347055c0c2265065"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#07b479cd20c8f6cbd09efe0086e85eefe4430a9d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6404,7 +6404,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-assets-erc20"
 version = "0.5.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#2fd2dca02e530212ed3ea8a2347055c0c2265065"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#07b479cd20c8f6cbd09efe0086e85eefe4430a9d"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6491,7 +6491,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sr25519"
 version = "1.2.1"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#2fd2dca02e530212ed3ea8a2347055c0c2265065"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#07b479cd20c8f6cbd09efe0086e85eefe4430a9d"
 dependencies = [
  "fp-evm",
  "log",
@@ -6507,7 +6507,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-substrate-ecdsa"
 version = "1.2.2"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#2fd2dca02e530212ed3ea8a2347055c0c2265065"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#07b479cd20c8f6cbd09efe0086e85eefe4430a9d"
 dependencies = [
  "fp-evm",
  "log",
@@ -6523,7 +6523,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-xcm"
 version = "0.9.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#2fd2dca02e530212ed3ea8a2347055c0c2265065"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#07b479cd20c8f6cbd09efe0086e85eefe4430a9d"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6546,7 +6546,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-xvm"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#2fd2dca02e530212ed3ea8a2347055c0c2265065"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#07b479cd20c8f6cbd09efe0086e85eefe4430a9d"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -6812,7 +6812,7 @@ dependencies = [
 [[package]]
 name = "pallet-precompile-dapps-staking"
 version = "3.6.3"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#2fd2dca02e530212ed3ea8a2347055c0c2265065"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#07b479cd20c8f6cbd09efe0086e85eefe4430a9d"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -7216,7 +7216,7 @@ dependencies = [
 [[package]]
 name = "pallet-xc-asset-config"
 version = "1.3.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#2fd2dca02e530212ed3ea8a2347055c0c2265065"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#07b479cd20c8f6cbd09efe0086e85eefe4430a9d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7234,7 +7234,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "0.9.28"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#2fd2dca02e530212ed3ea8a2347055c0c2265065"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#07b479cd20c8f6cbd09efe0086e85eefe4430a9d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7287,7 +7287,7 @@ dependencies = [
 [[package]]
 name = "pallet-xvm"
 version = "0.2.1"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#2fd2dca02e530212ed3ea8a2347055c0c2265065"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#07b479cd20c8f6cbd09efe0086e85eefe4430a9d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8789,7 +8789,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 [[package]]
 name = "precompile-utils"
 version = "0.4.3"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#2fd2dca02e530212ed3ea8a2347055c0c2265065"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#07b479cd20c8f6cbd09efe0086e85eefe4430a9d"
 dependencies = [
  "evm",
  "fp-evm",
@@ -8812,7 +8812,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#2fd2dca02e530212ed3ea8a2347055c0c2265065"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#07b479cd20c8f6cbd09efe0086e85eefe4430a9d"
 dependencies = [
  "num_enum",
  "proc-macro2",
@@ -14340,7 +14340,7 @@ dependencies = [
 [[package]]
 name = "xcm-primitives"
 version = "0.4.1"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#2fd2dca02e530212ed3ea8a2347055c0c2265065"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#07b479cd20c8f6cbd09efe0086e85eefe4430a9d"
 dependencies = [
  "frame-support",
  "log",
@@ -14434,7 +14434,7 @@ dependencies = [
 [[package]]
 name = "xvm-chain-extension-types"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#2fd2dca02e530212ed3ea8a2347055c0c2265065"
+source = "git+https://github.com/AstarNetwork/astar-frame?branch=polkadot-v0.9.37#07b479cd20c8f6cbd09efe0086e85eefe4430a9d"
 dependencies = [
  "parity-scale-codec",
  "scale-info",

--- a/tests/xcm-simulator/src/mocks/parachain.rs
+++ b/tests/xcm-simulator/src/mocks/parachain.rs
@@ -265,11 +265,6 @@ parameter_types! {
     pub TreasuryAccountId: AccountId = TreasuryPalletId::get().into_account_truncating();
 }
 
-impl pallet_xc_asset_config::XcAssetChanged<Runtime> for () {
-    fn xc_asset_registered(_: AssetId) {}
-    fn xc_asset_unregistered(_: AssetId) {}
-}
-
 impl pallet_xc_asset_config::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type AssetId = AssetId;


### PR DESCRIPTION
**Pull Request Summary**

Removes double implementation of unit tuple of `XcAssetExchanged` trait.
