### PR TITLE
Plugable EVM tracing 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "astar-collator"
-version = "5.0.1"
+version = "5.1.0"
 dependencies = [
  "astar-runtime",
  "async-trait",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "astar-runtime"
-version = "5.0.1"
+version = "5.1.0"
 dependencies = [
  "array-bytes 6.0.0",
  "cumulus-pallet-aura-ext",
@@ -5059,7 +5059,7 @@ checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "local-runtime"
-version = "5.0.1"
+version = "5.1.0"
 dependencies = [
  "array-bytes 6.0.0",
  "fp-rpc",
@@ -11443,7 +11443,7 @@ dependencies = [
 
 [[package]]
 name = "shibuya-runtime"
-version = "5.0.1"
+version = "5.1.0"
 dependencies = [
  "array-bytes 6.0.0",
  "cumulus-pallet-aura-ext",
@@ -11545,7 +11545,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "5.0.1"
+version = "5.1.0"
 dependencies = [
  "array-bytes 6.0.0",
  "cumulus-pallet-aura-ext",

--- a/bin/collator/Cargo.toml
+++ b/bin/collator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-collator"
-version = "5.0.1"
+version = "5.1.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 description = "Astar collator implementation in Rust."
 build = "build.rs"
@@ -129,12 +129,12 @@ frame-try-runtime = { git = "https://github.com/paritytech/substrate", branch = 
 try-runtime-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", optional = true }
 
 # evm-tracing
-moonbeam-primitives-ext = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37" }
-moonbeam-rpc-debug = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37" }
-moonbeam-rpc-primitives-debug = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37" }
-moonbeam-rpc-primitives-txpool = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37" }
-moonbeam-rpc-trace = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37" }
-moonbeam-rpc-txpool = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37" }
+moonbeam-primitives-ext = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", optional = true }
+moonbeam-rpc-debug = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", optional = true }
+moonbeam-rpc-primitives-debug = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", optional = true }
+moonbeam-rpc-primitives-txpool = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", optional = true }
+moonbeam-rpc-trace = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", optional = true }
+moonbeam-rpc-txpool = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", optional = true }
 
 [build-dependencies]
 build-script-utils = { package = "substrate-build-script-utils", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37" }
@@ -158,3 +158,11 @@ runtime-benchmarks = [
 ]
 cli = ['try-runtime-cli']
 try-runtime = ["local-runtime/try-runtime", "try-runtime-cli/try-runtime"]
+evm-tracing = [
+	"moonbeam-primitives-ext",
+	"moonbeam-rpc-debug",
+	"moonbeam-rpc-primitives-debug",
+	"moonbeam-rpc-primitives-txpool",
+	"moonbeam-rpc-trace",
+	"moonbeam-rpc-txpool",
+]

--- a/bin/collator/src/cli.rs
+++ b/bin/collator/src/cli.rs
@@ -31,6 +31,7 @@ pub struct Cli {
     pub run: cumulus_client_cli::RunCmd,
 
     /// Enable EVM tracing module on a non-authority node.
+    #[cfg(feature = "evm-tracing")]
     #[clap(
         long,
         conflicts_with = "collator",
@@ -40,34 +41,41 @@ pub struct Cli {
     pub ethapi: Vec<EthApi>,
 
     /// Number of concurrent tracing tasks. Meant to be shared by both "debug" and "trace" modules.
+    #[cfg(feature = "evm-tracing")]
     #[clap(long, default_value = "10")]
     pub ethapi_max_permits: u32,
 
     /// Maximum number of trace entries a single request of `trace_filter` is allowed to return.
     /// A request asking for more or an unbounded one going over this limit will both return an
     /// error.
+    #[cfg(feature = "evm-tracing")]
     #[clap(long, default_value = "500")]
     pub ethapi_trace_max_count: u32,
 
     /// Duration (in seconds) after which the cache of `trace_filter` for a given block will be
     /// discarded.
+    #[cfg(feature = "evm-tracing")]
     #[clap(long, default_value = "300")]
     pub ethapi_trace_cache_duration: u64,
 
     /// Size in bytes of the LRU cache for block data.
+    #[cfg(feature = "evm-tracing")]
     #[clap(long, default_value = "300000000")]
     pub eth_log_block_cache: usize,
 
     /// Size in bytes of the LRU cache for transactions statuses data.
+    #[cfg(feature = "evm-tracing")]
     #[clap(long, default_value = "300000000")]
     pub eth_statuses_cache: usize,
 
     /// Size in bytes of data a raw tracing request is allowed to use.
     /// Bound the size of memory, stack and storage data.
+    #[cfg(feature = "evm-tracing")]
     #[clap(long, default_value = "20000000")]
     pub tracing_raw_max_memory_usage: usize,
 
     /// Maximum number of logs in a query.
+    #[cfg(feature = "evm-tracing")]
     #[clap(long, default_value = "10000")]
     pub max_past_logs: u32,
 
@@ -168,6 +176,7 @@ impl RelayChainCli {
 }
 
 /// EVM tracing CLI flags.
+#[cfg(feature = "evm-tracing")]
 #[derive(Debug, PartialEq, Clone)]
 pub enum EthApi {
     /// Enable EVM debug RPC methods.
@@ -178,6 +187,7 @@ pub enum EthApi {
     TxPool,
 }
 
+#[cfg(feature = "evm-tracing")]
 impl std::str::FromStr for EthApi {
     type Err = String;
 
@@ -197,6 +207,7 @@ impl std::str::FromStr for EthApi {
 }
 
 /// EVM tracing CLI config.
+#[cfg(feature = "evm-tracing")]
 pub struct EvmTracingConfig {
     /// Enabled EVM tracing flags.
     pub ethapi: Vec<EthApi>,

--- a/bin/collator/src/parachain/service.rs
+++ b/bin/collator/src/parachain/service.rs
@@ -47,8 +47,10 @@ use std::{collections::BTreeMap, sync::Arc, time::Duration};
 use substrate_prometheus_endpoint::Registry;
 
 use super::shell_upgrade::*;
+#[cfg(feature = "evm-tracing")]
 use crate::cli::{EthApi as EthApiCmd, EvmTracingConfig};
 use crate::primitives::*;
+#[cfg(feature = "evm-tracing")]
 use crate::rpc::tracing;
 
 /// Astar network runtime executor.
@@ -58,10 +60,16 @@ pub mod astar {
     /// Shibuya runtime executor.
     pub struct Executor;
     impl sc_executor::NativeExecutionDispatch for Executor {
-        #[cfg(not(feature = "runtime-benchmarks"))]
+        #[cfg(all(not(feature = "evm-tracing"), not(feature = "runtime-benchmarks")))]
+        type ExtendHostFunctions = ();
+
+        #[cfg(all(not(feature = "runtime-benchmarks"), feature = "evm-tracing"))]
         type ExtendHostFunctions = moonbeam_primitives_ext::moonbeam_ext::HostFunctions;
 
-        #[cfg(feature = "runtime-benchmarks")]
+        #[cfg(all(not(feature = "evm-tracing"), feature = "runtime-benchmarks"))]
+        type ExtendHostFunctions = frame_benchmarking::benchmarking::HostFunctions;
+
+        #[cfg(all(feature = "runtime-benchmarks", feature = "evm-tracing"))]
         type ExtendHostFunctions = (
             frame_benchmarking::benchmarking::HostFunctions,
             moonbeam_primitives_ext::moonbeam_ext::HostFunctions,
@@ -84,10 +92,16 @@ pub mod shiden {
     /// Shiden runtime executor.
     pub struct Executor;
     impl sc_executor::NativeExecutionDispatch for Executor {
-        #[cfg(not(feature = "runtime-benchmarks"))]
+        #[cfg(all(not(feature = "evm-tracing"), not(feature = "runtime-benchmarks")))]
+        type ExtendHostFunctions = ();
+
+        #[cfg(all(not(feature = "runtime-benchmarks"), feature = "evm-tracing"))]
         type ExtendHostFunctions = moonbeam_primitives_ext::moonbeam_ext::HostFunctions;
 
-        #[cfg(feature = "runtime-benchmarks")]
+        #[cfg(all(not(feature = "evm-tracing"), feature = "runtime-benchmarks"))]
+        type ExtendHostFunctions = frame_benchmarking::benchmarking::HostFunctions;
+
+        #[cfg(all(feature = "runtime-benchmarks", feature = "evm-tracing"))]
         type ExtendHostFunctions = (
             frame_benchmarking::benchmarking::HostFunctions,
             moonbeam_primitives_ext::moonbeam_ext::HostFunctions,
@@ -110,10 +124,16 @@ pub mod shibuya {
     /// Shibuya runtime executor.
     pub struct Executor;
     impl sc_executor::NativeExecutionDispatch for Executor {
-        #[cfg(not(feature = "runtime-benchmarks"))]
+        #[cfg(all(not(feature = "evm-tracing"), not(feature = "runtime-benchmarks")))]
+        type ExtendHostFunctions = (); // TODO: dummy tracing functions to help shibuya sync
+
+        #[cfg(all(not(feature = "runtime-benchmarks"), feature = "evm-tracing"))]
         type ExtendHostFunctions = moonbeam_primitives_ext::moonbeam_ext::HostFunctions;
 
-        #[cfg(feature = "runtime-benchmarks")]
+        #[cfg(all(not(feature = "evm-tracing"), feature = "runtime-benchmarks"))]
+        type ExtendHostFunctions = frame_benchmarking::benchmarking::HostFunctions;
+
+        #[cfg(all(feature = "runtime-benchmarks", feature = "evm-tracing"))]
         type ExtendHostFunctions = (
             frame_benchmarking::benchmarking::HostFunctions,
             moonbeam_primitives_ext::moonbeam_ext::HostFunctions,
@@ -308,10 +328,289 @@ async fn build_relay_chain_interface(
         )
     }
 }
+/// Start a node with the given parachain `Configuration` and relay chain `Configuration`.
+///
+/// This is the actual implementation that is abstract over the executor and the runtime api.
+#[cfg(not(feature = "evm-tracing"))]
+#[sc_tracing::logging::prefix_logs_with("Parachain")]
+async fn start_node_impl<RuntimeApi, Executor, BIQ, BIC>(
+    parachain_config: Configuration,
+    polkadot_config: Configuration,
+    collator_options: CollatorOptions,
+    id: ParaId,
+    enable_evm_rpc: bool,
+    build_import_queue: BIQ,
+    build_consensus: BIC,
+) -> sc_service::error::Result<(
+    TaskManager,
+    Arc<TFullClient<Block, RuntimeApi, NativeElseWasmExecutor<Executor>>>,
+)>
+where
+    RuntimeApi: ConstructRuntimeApi<Block, TFullClient<Block, RuntimeApi, NativeElseWasmExecutor<Executor>>>
+        + Send
+        + Sync
+        + 'static,
+    RuntimeApi::RuntimeApi: sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block>
+        + sp_api::Metadata<Block>
+        + sp_session::SessionKeys<Block>
+        + sp_api::ApiExt<
+            Block,
+            StateBackend = sc_client_api::StateBackendFor<TFullBackend<Block>, Block>,
+        > + sp_offchain::OffchainWorkerApi<Block>
+        + sp_block_builder::BlockBuilder<Block>
+        + substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>
+        + pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
+        + fp_rpc::EthereumRuntimeRPCApi<Block>
+        + fp_rpc::ConvertTransactionRuntimeApi<Block>
+        + cumulus_primitives_core::CollectCollationInfo<Block>,
+    sc_client_api::StateBackendFor<TFullBackend<Block>, Block>: sp_api::StateBackend<BlakeTwo256>,
+    Executor: sc_executor::NativeExecutionDispatch + 'static,
+    BIQ: FnOnce(
+        Arc<TFullClient<Block, RuntimeApi, NativeElseWasmExecutor<Executor>>>,
+        ParachainBlockImport<
+            Block,
+            FrontierBlockImport<
+                Block,
+                Arc<TFullClient<Block, RuntimeApi, NativeElseWasmExecutor<Executor>>>,
+                TFullClient<Block, RuntimeApi, NativeElseWasmExecutor<Executor>>,
+            >,
+            TFullBackend<Block>,
+        >,
+        &Configuration,
+        Option<TelemetryHandle>,
+        &TaskManager,
+    ) -> Result<
+        sc_consensus::DefaultImportQueue<
+            Block,
+            TFullClient<Block, RuntimeApi, NativeElseWasmExecutor<Executor>>,
+        >,
+        sc_service::Error,
+    >,
+    BIC: FnOnce(
+        Arc<TFullClient<Block, RuntimeApi, NativeElseWasmExecutor<Executor>>>,
+        ParachainBlockImport<
+            Block,
+            FrontierBlockImport<
+                Block,
+                Arc<TFullClient<Block, RuntimeApi, NativeElseWasmExecutor<Executor>>>,
+                TFullClient<Block, RuntimeApi, NativeElseWasmExecutor<Executor>>,
+            >,
+            TFullBackend<Block>,
+        >,
+        Option<&Registry>,
+        Option<TelemetryHandle>,
+        &TaskManager,
+        Arc<dyn RelayChainInterface>,
+        Arc<
+            sc_transaction_pool::FullPool<
+                Block,
+                TFullClient<Block, RuntimeApi, NativeElseWasmExecutor<Executor>>,
+            >,
+        >,
+        Arc<NetworkService<Block, Hash>>,
+        SyncCryptoStorePtr,
+        bool,
+    ) -> Result<Box<dyn ParachainConsensus<Block>>, sc_service::Error>,
+{
+    let parachain_config = prepare_node_config(parachain_config);
+
+    let params = new_partial::<RuntimeApi, Executor, BIQ>(&parachain_config, build_import_queue)?;
+    let (parachain_block_import, mut telemetry, telemetry_worker_handle, frontier_backend) =
+        params.other;
+
+    let client = params.client.clone();
+    let backend = params.backend.clone();
+
+    let mut task_manager = params.task_manager;
+    let (relay_chain_interface, collator_key) = build_relay_chain_interface(
+        polkadot_config,
+        &parachain_config,
+        telemetry_worker_handle,
+        &mut task_manager,
+        collator_options.clone(),
+    )
+    .await
+    .map_err(|e| match e {
+        RelayChainError::ServiceError(polkadot_service::Error::Sub(x)) => x,
+        s => format!("{}", s).into(),
+    })?;
+    let block_announce_validator = BlockAnnounceValidator::new(relay_chain_interface.clone(), id);
+
+    let force_authoring = parachain_config.force_authoring;
+    let is_authority = parachain_config.role.is_authority();
+    let prometheus_registry = parachain_config.prometheus_registry().cloned();
+    let transaction_pool = params.transaction_pool.clone();
+    let import_queue_service = params.import_queue.service();
+    let (network, system_rpc_tx, tx_handler_controller, start_network) =
+        sc_service::build_network(sc_service::BuildNetworkParams {
+            config: &parachain_config,
+            client: client.clone(),
+            transaction_pool: transaction_pool.clone(),
+            spawn_handle: task_manager.spawn_handle(),
+            import_queue: params.import_queue,
+            block_announce_validator_builder: Some(Box::new(|_| {
+                Box::new(block_announce_validator)
+            })),
+            warp_sync: None,
+        })?;
+
+    let filter_pool: FilterPool = Arc::new(std::sync::Mutex::new(BTreeMap::new()));
+    let fee_history_cache: FeeHistoryCache = Arc::new(std::sync::Mutex::new(BTreeMap::new()));
+    let overrides = crate::rpc::overrides_handle(client.clone());
+
+    // Frontier offchain DB task. Essential.
+    // Maps emulated ethereum data to substrate native data.
+    task_manager.spawn_essential_handle().spawn(
+        "frontier-mapping-sync-worker",
+        Some("frontier"),
+        fc_mapping_sync::MappingSyncWorker::new(
+            client.import_notification_stream(),
+            Duration::new(6, 0),
+            client.clone(),
+            backend.clone(),
+            frontier_backend.clone(),
+            3,
+            0,
+            fc_mapping_sync::SyncStrategy::Parachain,
+        )
+        .for_each(|()| futures::future::ready(())),
+    );
+
+    // Frontier `EthFilterApi` maintenance. Manages the pool of user-created Filters.
+    // Each filter is allowed to stay in the pool for 100 blocks.
+    const FILTER_RETAIN_THRESHOLD: u64 = 100;
+    task_manager.spawn_essential_handle().spawn(
+        "frontier-filter-pool",
+        Some("frontier"),
+        fc_rpc::EthTask::filter_pool_task(
+            client.clone(),
+            filter_pool.clone(),
+            FILTER_RETAIN_THRESHOLD,
+        ),
+    );
+
+    const FEE_HISTORY_LIMIT: u64 = 2048;
+    task_manager.spawn_essential_handle().spawn(
+        "frontier-fee-history",
+        Some("frontier"),
+        fc_rpc::EthTask::fee_history_task(
+            client.clone(),
+            overrides.clone(),
+            fee_history_cache.clone(),
+            FEE_HISTORY_LIMIT,
+        ),
+    );
+
+    let block_data_cache = Arc::new(fc_rpc::EthBlockDataCacheTask::new(
+        task_manager.spawn_handle(),
+        overrides.clone(),
+        50,
+        50,
+        prometheus_registry.clone(),
+    ));
+
+    let rpc_extensions_builder = {
+        let client = client.clone();
+        let network = network.clone();
+        let transaction_pool = transaction_pool.clone();
+
+        Box::new(move |deny_unsafe, subscription| {
+            let deps = crate::rpc::FullDeps {
+                client: client.clone(),
+                pool: transaction_pool.clone(),
+                graph: transaction_pool.pool().clone(),
+                network: network.clone(),
+                is_authority,
+                deny_unsafe,
+                frontier_backend: frontier_backend.clone(),
+                filter_pool: filter_pool.clone(),
+                fee_history_limit: FEE_HISTORY_LIMIT,
+                fee_history_cache: fee_history_cache.clone(),
+                block_data_cache: block_data_cache.clone(),
+                overrides: overrides.clone(),
+                enable_evm_rpc,
+            };
+
+            crate::rpc::create_full(deps, subscription).map_err(Into::into)
+        })
+    };
+
+    // Spawn basic services.
+    sc_service::spawn_tasks(sc_service::SpawnTasksParams {
+        rpc_builder: rpc_extensions_builder,
+        client: client.clone(),
+        transaction_pool: transaction_pool.clone(),
+        task_manager: &mut task_manager,
+        config: parachain_config,
+        keystore: params.keystore_container.sync_keystore(),
+        backend: backend.clone(),
+        network: network.clone(),
+        system_rpc_tx,
+        tx_handler_controller,
+        telemetry: telemetry.as_mut(),
+    })?;
+
+    let announce_block = {
+        let network = network.clone();
+        Arc::new(move |hash, data| network.announce_block(hash, data))
+    };
+
+    let relay_chain_slot_duration = Duration::from_secs(6);
+
+    if is_authority {
+        let parachain_consensus = build_consensus(
+            client.clone(),
+            parachain_block_import,
+            prometheus_registry.as_ref(),
+            telemetry.as_ref().map(|t| t.handle()),
+            &task_manager,
+            relay_chain_interface.clone(),
+            transaction_pool,
+            network,
+            params.keystore_container.sync_keystore(),
+            force_authoring,
+        )?;
+
+        let spawner = task_manager.spawn_handle();
+
+        let params = StartCollatorParams {
+            para_id: id,
+            block_status: client.clone(),
+            announce_block,
+            client: client.clone(),
+            task_manager: &mut task_manager,
+            relay_chain_interface: relay_chain_interface.clone(),
+            spawner,
+            parachain_consensus,
+            import_queue: import_queue_service,
+            collator_key: collator_key.expect("Command line arguments do not allow this. qed"),
+            relay_chain_slot_duration,
+        };
+
+        start_collator(params).await?;
+    } else {
+        let params = StartFullNodeParams {
+            client: client.clone(),
+            announce_block,
+            task_manager: &mut task_manager,
+            para_id: id,
+            relay_chain_interface,
+            relay_chain_slot_duration,
+            import_queue: import_queue_service,
+        };
+
+        start_full_node(params)?;
+    }
+
+    start_network.start_network();
+
+    Ok((task_manager, client))
+}
 
 /// Start a node with the given parachain `Configuration` and relay chain `Configuration`.
 ///
 /// This is the actual implementation that is abstract over the executor and the runtime api.
+#[cfg(feature = "evm-tracing")]
 #[sc_tracing::logging::prefix_logs_with("Parachain")]
 async fn start_node_impl<RuntimeApi, Executor, BIQ, BIC>(
     parachain_config: Configuration,
@@ -708,6 +1007,7 @@ where
 }
 
 /// Start a parachain node for Astar.
+#[cfg(feature = "evm-tracing")]
 pub async fn start_astar_node(
     parachain_config: Configuration,
     polkadot_config: Configuration,
@@ -839,7 +1139,139 @@ pub async fn start_astar_node(
     }).await
 }
 
+/// Start a parachain node for Astar.
+#[cfg(not(feature = "evm-tracing"))]
+pub async fn start_astar_node(
+    parachain_config: Configuration,
+    polkadot_config: Configuration,
+    collator_options: CollatorOptions,
+    id: ParaId,
+    enable_evm_rpc: bool,
+) -> sc_service::error::Result<(
+    TaskManager,
+    Arc<TFullClient<Block, astar::RuntimeApi, NativeElseWasmExecutor<astar::Executor>>>,
+)> {
+    start_node_impl::<astar::RuntimeApi, astar::Executor, _, _>(
+        parachain_config,
+        polkadot_config,
+        collator_options,
+        id,
+        enable_evm_rpc,
+        |client,
+         block_import,
+         config,
+         telemetry,
+         task_manager| {
+            let slot_duration = cumulus_client_consensus_aura::slot_duration(&*client)?;
+
+            cumulus_client_consensus_aura::import_queue::<
+                sp_consensus_aura::sr25519::AuthorityPair,
+                _,
+                _,
+                _,
+                _,
+                _,
+            >(cumulus_client_consensus_aura::ImportQueueParams {
+                block_import,
+                client,
+                create_inherent_data_providers: move |_, _| async move {
+                    let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
+
+                    let slot =
+                        sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
+                            *timestamp,
+                            slot_duration,
+                        );
+
+                    Ok((slot, timestamp))
+                },
+                registry: config.prometheus_registry(),
+                spawner: &task_manager.spawn_essential_handle(),
+                telemetry,
+            })
+            .map_err(Into::into)
+        },
+        |client,
+         block_import,
+         prometheus_registry,
+         telemetry,
+         task_manager,
+         relay_chain_interface,
+         transaction_pool,
+         sync_oracle,
+         keystore,
+         force_authoring| {
+            let spawn_handle = task_manager.spawn_handle();
+
+            let slot_duration =
+                cumulus_client_consensus_aura::slot_duration(&*client).unwrap();
+
+            let proposer_factory =
+                sc_basic_authorship::ProposerFactory::with_proof_recording(
+                    spawn_handle,
+                    client.clone(),
+                    transaction_pool,
+                    prometheus_registry,
+                    telemetry.clone(),
+                );
+
+            let relay_chain_for_aura = relay_chain_interface.clone();
+
+            Ok(AuraConsensus::build::<
+                sp_consensus_aura::sr25519::AuthorityPair,
+                _,
+                _,
+                _,
+                _,
+                _,
+                _,
+            >(BuildAuraConsensusParams {
+                proposer_factory,
+                create_inherent_data_providers:
+                    move |_, (relay_parent, validation_data)| {
+                        let relay_chain_for_aura = relay_chain_for_aura.clone();
+                        async move {
+                            let parachain_inherent =
+                                cumulus_primitives_parachain_inherent::ParachainInherentData::create_at(
+                                    relay_parent,
+                                    &relay_chain_for_aura,
+                                    &validation_data,
+                                    id,
+                                ).await;
+                            let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
+                            let slot =
+                                sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
+                                    *timestamp,
+                                    slot_duration,
+                                );
+
+                            let parachain_inherent = parachain_inherent.ok_or_else(|| {
+                                Box::<dyn std::error::Error + Send + Sync>::from(
+                                    "Failed to create parachain inherent",
+                                )
+                            })?;
+                            Ok((slot, timestamp, parachain_inherent))
+                        }
+                    },
+                block_import: block_import,
+                para_client: client,
+                backoff_authoring_blocks: Option::<()>::None,
+                sync_oracle,
+                keystore,
+                force_authoring,
+                slot_duration,
+                // We got around 500ms for proposing
+                block_proposal_slot_portion: SlotProportion::new(1f32 / 24f32),
+                // And a maximum of 750ms if slots are skipped
+                max_block_proposal_slot_portion: Some(SlotProportion::new(1f32 / 16f32)),
+                telemetry,
+            })
+        )
+    }).await
+}
+
 /// Start a parachain node for Shiden.
+#[cfg(feature = "evm-tracing")]
 pub async fn start_shiden_node(
     parachain_config: Configuration,
     polkadot_config: Configuration,
@@ -997,7 +1429,165 @@ pub async fn start_shiden_node(
     }).await
 }
 
+/// Start a parachain node for Shiden.
+#[cfg(not(feature = "evm-tracing"))]
+pub async fn start_shiden_node(
+    parachain_config: Configuration,
+    polkadot_config: Configuration,
+    collator_options: CollatorOptions,
+    id: ParaId,
+    enable_evm_rpc: bool,
+) -> sc_service::error::Result<(
+    TaskManager,
+    Arc<TFullClient<Block, shiden::RuntimeApi, NativeElseWasmExecutor<shiden::Executor>>>,
+)> {
+    start_node_impl::<shiden::RuntimeApi, shiden::Executor, _, _>(
+        parachain_config,
+        polkadot_config,
+        collator_options,
+        id,
+        enable_evm_rpc,
+        build_import_queue,
+        |client,
+         block_import,
+         prometheus_registry,
+         telemetry,
+         task_manager,
+         relay_chain_interface,
+         transaction_pool,
+         sync_oracle,
+         keystore,
+         force_authoring| {
+            let client2 = client.clone();
+            let spawn_handle = task_manager.spawn_handle();
+            let transaction_pool2 = transaction_pool.clone();
+            let telemetry2 = telemetry.clone();
+            let prometheus_registry2 = prometheus_registry.map(|r| (*r).clone());
+            let relay_chain_for_aura = relay_chain_interface.clone();
+            let block_import2 = block_import.clone();
+            let sync_oracle2 = sync_oracle.clone();
+            let keystore2 = keystore.clone();
+
+            let aura_consensus = BuildOnAccess::Uninitialized(Some(
+                Box::new(move || {
+                    let slot_duration =
+                        cumulus_client_consensus_aura::slot_duration(&*client2).unwrap();
+
+                    let proposer_factory =
+                        sc_basic_authorship::ProposerFactory::with_proof_recording(
+                            spawn_handle,
+                            client2.clone(),
+                            transaction_pool2,
+                            prometheus_registry2.as_ref(),
+                            telemetry2.clone(),
+                        );
+
+                    AuraConsensus::build::<
+                        sp_consensus_aura::sr25519::AuthorityPair,
+                        _,
+                        _,
+                        _,
+                        _,
+                        _,
+                        _,
+                    >(BuildAuraConsensusParams {
+                        proposer_factory,
+                        create_inherent_data_providers:
+                            move |_, (relay_parent, validation_data)| {
+                                let relay_chain_for_aura = relay_chain_for_aura.clone();
+                                async move {
+                                    let parachain_inherent =
+                                        cumulus_primitives_parachain_inherent::ParachainInherentData::create_at(
+                                            relay_parent,
+                                            &relay_chain_for_aura,
+                                            &validation_data,
+                                            id,
+                                        ).await;
+                                    let timestamp =
+                                        sp_timestamp::InherentDataProvider::from_system_time();
+
+                                    let slot =
+                                    sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
+                                        *timestamp,
+                                        slot_duration,
+                                    );
+
+                                    let parachain_inherent =
+                                        parachain_inherent.ok_or_else(|| {
+                                            Box::<dyn std::error::Error + Send + Sync>::from(
+                                                "Failed to create parachain inherent",
+                                            )
+                                        })?;
+                                    Ok((slot, timestamp, parachain_inherent))
+                                }
+                            },
+                        block_import: block_import2.clone(),
+                        para_client: client2.clone(),
+                        backoff_authoring_blocks: Option::<()>::None,
+                        sync_oracle: sync_oracle2,
+                        keystore: keystore2,
+                        force_authoring,
+                        slot_duration,
+                        // We got around 500ms for proposing
+                        block_proposal_slot_portion: SlotProportion::new(1f32 / 24f32),
+                        // And a maximum of 750ms if slots are skipped
+                        max_block_proposal_slot_portion: Some(SlotProportion::new(1f32 / 16f32)),
+                        telemetry: telemetry2,
+                    })
+                }),
+            ));
+
+            let proposer_factory =
+                sc_basic_authorship::ProposerFactory::with_proof_recording(
+                    task_manager.spawn_handle(),
+                    client.clone(),
+                    transaction_pool,
+                    prometheus_registry,
+                    telemetry.clone(),
+                );
+
+            let relay_chain_consensus =
+                cumulus_client_consensus_relay_chain::build_relay_chain_consensus(
+                    cumulus_client_consensus_relay_chain::BuildRelayChainConsensusParams {
+                        para_id: id,
+                        proposer_factory,
+                        block_import: block_import, //client.clone(),
+                        relay_chain_interface: relay_chain_interface.clone(),
+                        create_inherent_data_providers:
+                            move |_, (relay_parent, validation_data)| {
+                                let relay_chain_for_aura = relay_chain_interface.clone();
+                                async move {
+                                    let parachain_inherent =
+                                        cumulus_primitives_parachain_inherent::ParachainInherentData::create_at(
+                                            relay_parent,
+                                            &relay_chain_for_aura,
+                                            &validation_data,
+                                            id,
+                                        ).await;
+                                    let parachain_inherent =
+                                        parachain_inherent.ok_or_else(|| {
+                                            Box::<dyn std::error::Error + Send + Sync>::from(
+                                                "Failed to create parachain inherent",
+                                            )
+                                        })?;
+                                    Ok(parachain_inherent)
+                                }
+                            },
+                    },
+                );
+
+            let parachain_consensus = Box::new(WaitForAuraConsensus {
+                client,
+                aura_consensus: Arc::new(Mutex::new(aura_consensus)),
+                relay_chain_consensus: Arc::new(Mutex::new(relay_chain_consensus)),
+            });
+
+            Ok(parachain_consensus)
+    }).await
+}
+
 /// Start a parachain node for Shibuya.
+#[cfg(feature = "evm-tracing")]
 pub async fn start_shibuya_node(
     parachain_config: Configuration,
     polkadot_config: Configuration,
@@ -1013,6 +1603,135 @@ pub async fn start_shibuya_node(
         parachain_config,
         polkadot_config,
         evm_tracing_config,
+        collator_options,
+        id,
+        enable_evm_rpc,
+        |client,
+         block_import,
+         config,
+         telemetry,
+         task_manager| {
+            let slot_duration = cumulus_client_consensus_aura::slot_duration(&*client)?;
+
+            cumulus_client_consensus_aura::import_queue::<
+                sp_consensus_aura::sr25519::AuthorityPair,
+                _,
+                _,
+                _,
+                _,
+                _,
+            >(cumulus_client_consensus_aura::ImportQueueParams {
+                block_import,
+                client,
+                create_inherent_data_providers: move |_, _| async move {
+                    let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
+
+                    let slot =
+                        sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
+                            *timestamp,
+                            slot_duration,
+                        );
+
+                    Ok((slot, timestamp))
+                },
+                registry: config.prometheus_registry(),
+                spawner: &task_manager.spawn_essential_handle(),
+                telemetry,
+            })
+            .map_err(Into::into)
+        },
+        |client,
+         block_import,
+         prometheus_registry,
+         telemetry,
+         task_manager,
+         relay_chain_interface,
+         transaction_pool,
+         sync_oracle,
+         keystore,
+         force_authoring| {
+            let spawn_handle = task_manager.spawn_handle();
+
+            let slot_duration =
+                cumulus_client_consensus_aura::slot_duration(&*client).unwrap();
+
+            let proposer_factory =
+                sc_basic_authorship::ProposerFactory::with_proof_recording(
+                    spawn_handle,
+                    client.clone(),
+                    transaction_pool,
+                    prometheus_registry,
+                    telemetry.clone(),
+                );
+
+            Ok(AuraConsensus::build::<
+                sp_consensus_aura::sr25519::AuthorityPair,
+                _,
+                _,
+                _,
+                _,
+                _,
+                _,
+            >(BuildAuraConsensusParams {
+                proposer_factory,
+                create_inherent_data_providers:
+                    move |_, (relay_parent, validation_data)| {
+                        let relay_chain_for_aura = relay_chain_interface.clone();
+                        async move {
+                            let parachain_inherent =
+                                cumulus_primitives_parachain_inherent::ParachainInherentData::create_at(
+                                    relay_parent,
+                                    &relay_chain_for_aura,
+                                    &validation_data,
+                                    id,
+                                ).await;
+                            let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
+                            let slot =
+                                sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
+                                    *timestamp,
+                                    slot_duration,
+                                );
+
+                            let parachain_inherent = parachain_inherent.ok_or_else(|| {
+                                Box::<dyn std::error::Error + Send + Sync>::from(
+                                    "Failed to create parachain inherent",
+                                )
+                            })?;
+                            Ok((slot, timestamp, parachain_inherent))
+                        }
+                    },
+                block_import: block_import,
+                para_client: client,
+                backoff_authoring_blocks: Option::<()>::None,
+                sync_oracle,
+                keystore,
+                force_authoring,
+                slot_duration,
+                // We got around 500ms for proposing
+                block_proposal_slot_portion: SlotProportion::new(1f32 / 24f32),
+                // And a maximum of 750ms if slots are skipped
+                max_block_proposal_slot_portion: Some(SlotProportion::new(1f32 / 16f32)),
+                telemetry,
+            })
+        )
+    }).await
+}
+
+/// Start a parachain node for Shibuya.
+#[cfg(not(feature = "evm-tracing"))]
+pub async fn start_shibuya_node(
+    parachain_config: Configuration,
+    polkadot_config: Configuration,
+    collator_options: CollatorOptions,
+    id: ParaId,
+    enable_evm_rpc: bool,
+) -> sc_service::error::Result<(
+    TaskManager,
+    Arc<TFullClient<Block, shibuya::RuntimeApi, NativeElseWasmExecutor<shibuya::Executor>>>,
+)> {
+    start_node_impl::<shibuya::RuntimeApi, shibuya::Executor, _, _>(
+        parachain_config,
+        polkadot_config,
         collator_options,
         id,
         enable_evm_rpc,

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-runtime"
-version = "5.0.1"
+version = "5.1.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"
@@ -101,9 +101,9 @@ pallet-xcm = { git = "https://github.com/AstarNetwork/astar-frame", branch = "po
 xcm-primitives = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false }
 
 # Moonbeam tracing
-moonbeam-evm-tracer = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false }
-moonbeam-rpc-primitives-debug = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false }
-moonbeam-rpc-primitives-txpool = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false }
+moonbeam-evm-tracer = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false, optional = true }
+moonbeam-rpc-primitives-debug = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false, optional = true }
+moonbeam-rpc-primitives-txpool = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false, optional = true }
 
 [build-dependencies]
 substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", optional = true }
@@ -239,4 +239,9 @@ try-runtime = [
 	"parachain-info/try-runtime",
 	"pallet-base-fee/try-runtime",
 	"pallet-evm/try-runtime",
+]
+evm-tracing = [
+	"moonbeam-evm-tracer",
+	"moonbeam-rpc-primitives-debug",
+	"moonbeam-rpc-primitives-txpool",
 ]

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -140,7 +140,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("astar"),
     impl_name: create_runtime_str!("astar"),
     authoring_version: 1,
-    spec_version: 53,
+    spec_version: 54,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,
@@ -1287,6 +1287,7 @@ impl_runtime_apis! {
         }
     }
 
+    #[cfg(feature = "evm-tracing")]
     impl moonbeam_rpc_primitives_debug::DebugRuntimeApi<Block> for Runtime {
         fn trace_transaction(
             extrinsics: Vec<<Block as BlockT>::Extrinsic>,
@@ -1351,6 +1352,7 @@ impl_runtime_apis! {
         }
     }
 
+    #[cfg(feature = "evm-tracing")]
     impl moonbeam_rpc_primitives_txpool::TxPoolRuntimeApi<Block> for Runtime {
         fn extrinsic_filter(
             xts_ready: Vec<<Block as BlockT>::Extrinsic>,

--- a/runtime/local/Cargo.toml
+++ b/runtime/local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-runtime"
-version = "5.0.1"
+version = "5.1.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"
@@ -73,9 +73,9 @@ pallet-precompile-dapps-staking = { git = "https://github.com/AstarNetwork/astar
 pallet-xvm = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false, features = ["evm", "wasm"] }
 
 # Moonbeam tracing
-moonbeam-evm-tracer = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false }
-moonbeam-rpc-primitives-debug = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false }
-moonbeam-rpc-primitives-txpool = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false }
+moonbeam-evm-tracer = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false, optional = true }
+moonbeam-rpc-primitives-debug = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false, optional = true }
+moonbeam-rpc-primitives-txpool = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false, optional = true }
 
 # chain-extensions
 pallet-assets-chain-extension = { git = "https://github.com/AstarNetwork/pallet-assets-chain-extension", branch = "polkadot-v0.9.37", default-features = false, features = ["substrate"] }
@@ -204,4 +204,9 @@ try-runtime = [
 	"pallet-preimage/try-runtime",
 	"pallet-base-fee/try-runtime",
 	"pallet-evm/try-runtime",
+]
+evm-tracing = [
+	"moonbeam-evm-tracer",
+	"moonbeam-rpc-primitives-debug",
+	"moonbeam-rpc-primitives-txpool",
 ]

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -1476,6 +1476,7 @@ impl_runtime_apis! {
         }
     }
 
+    #[cfg(feature = "evm-tracing")]
     impl moonbeam_rpc_primitives_debug::DebugRuntimeApi<Block> for Runtime {
         fn trace_transaction(
             extrinsics: Vec<<Block as BlockT>::Extrinsic>,
@@ -1540,6 +1541,7 @@ impl_runtime_apis! {
         }
     }
 
+    #[cfg(feature = "evm-tracing")]
     impl moonbeam_rpc_primitives_txpool::TxPoolRuntimeApi<Block> for Runtime {
         fn extrinsic_filter(
             xts_ready: Vec<<Block as BlockT>::Extrinsic>,

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "5.0.1"
+version = "5.1.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"
@@ -106,9 +106,9 @@ pallet-xvm = { git = "https://github.com/AstarNetwork/astar-frame", branch = "po
 xcm-primitives = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false }
 
 # Moonbeam tracing
-moonbeam-evm-tracer = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false }
-moonbeam-rpc-primitives-debug = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false }
-moonbeam-rpc-primitives-txpool = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false }
+moonbeam-evm-tracer = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false, optional = true }
+moonbeam-rpc-primitives-debug = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false, optional = true }
+moonbeam-rpc-primitives-txpool = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false, optional = true }
 
 # chain-extensions
 pallet-assets-chain-extension = { git = "https://github.com/AstarNetwork/pallet-assets-chain-extension", branch = "polkadot-v0.9.37", default-features = false, features = ["substrate"] }
@@ -281,4 +281,9 @@ try-runtime = [
 	"pallet-preimage/try-runtime",
 	"pallet-base-fee/try-runtime",
 	"pallet-evm/try-runtime",
+]
+evm-tracing = [
+	"moonbeam-evm-tracer",
+	"moonbeam-rpc-primitives-debug",
+	"moonbeam-rpc-primitives-txpool",
 ]

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -170,7 +170,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shibuya"),
     impl_name: create_runtime_str!("shibuya"),
     authoring_version: 1,
-    spec_version: 92,
+    spec_version: 93,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,
@@ -1732,6 +1732,7 @@ impl_runtime_apis! {
         }
     }
 
+    #[cfg(feature = "evm-tracing")]
     impl moonbeam_rpc_primitives_debug::DebugRuntimeApi<Block> for Runtime {
         fn trace_transaction(
             extrinsics: Vec<<Block as BlockT>::Extrinsic>,
@@ -1796,6 +1797,7 @@ impl_runtime_apis! {
         }
     }
 
+    #[cfg(feature = "evm-tracing")]
     impl moonbeam_rpc_primitives_txpool::TxPoolRuntimeApi<Block> for Runtime {
         fn extrinsic_filter(
             xts_ready: Vec<<Block as BlockT>::Extrinsic>,

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "5.0.1"
+version = "5.1.0"
 authors = ["Stake Technologies <devops@stake.co.jp>"]
 edition = "2021"
 build = "build.rs"
@@ -105,9 +105,9 @@ pallet-xcm = { git = "https://github.com/AstarNetwork/astar-frame", default-feat
 xcm-primitives = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false }
 
 # Moonbeam tracing
-moonbeam-evm-tracer = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false }
-moonbeam-rpc-primitives-debug = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false }
-moonbeam-rpc-primitives-txpool = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false }
+moonbeam-evm-tracer = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false, optional = true }
+moonbeam-rpc-primitives-debug = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false, optional = true }
+moonbeam-rpc-primitives-txpool = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.37", default-features = false, optional = true }
 
 [build-dependencies]
 substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.37", optional = true }
@@ -250,4 +250,9 @@ try-runtime = [
 	"parachain-info/try-runtime",
 	"pallet-base-fee/try-runtime",
 	"pallet-evm/try-runtime",
+]
+evm-tracing = [
+	"moonbeam-evm-tracer",
+	"moonbeam-rpc-primitives-debug",
+	"moonbeam-rpc-primitives-txpool",
 ]

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -139,7 +139,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shiden"),
     impl_name: create_runtime_str!("shiden"),
     authoring_version: 1,
-    spec_version: 91,
+    spec_version: 92,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,
@@ -1455,6 +1455,7 @@ impl_runtime_apis! {
         }
     }
 
+    #[cfg(feature = "evm-tracing")]
     impl moonbeam_rpc_primitives_debug::DebugRuntimeApi<Block> for Runtime {
         fn trace_transaction(
             extrinsics: Vec<<Block as BlockT>::Extrinsic>,
@@ -1519,6 +1520,7 @@ impl_runtime_apis! {
         }
     }
 
+    #[cfg(feature = "evm-tracing")]
     impl moonbeam_rpc_primitives_txpool::TxPoolRuntimeApi<Block> for Runtime {
         fn extrinsic_filter(
             xts_ready: Vec<<Block as BlockT>::Extrinsic>,


### PR DESCRIPTION
**Pull Request Summary**

This PR introduce EVM tracing as optional feature. Using runtime overriding it makes possible to enable tracing on runtimes that don't have tracing runtime API.

New rust features:
* `evm-tracing` on runtimes: enable tracing runtime API when build with specified feature - used for tracing runtimes
* `evm-tracing` on collator: enable tracing RPC and host functions required for tracing runtimes.

Usage:
* download `tracing` node and runtime
* use `--wasm-runtime-overrides` flag to substitute tracing runtime instead of production
* EVM tracing API available on node

**Check list**
- [ ] added or updated unit tests
- [ ] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [x] updated spec version
- [x] updated semver
