### PR TITLE
Fix CI to test code with & without EVM tracing

### DIFF
--- a/.github/workflows/base_checks.yaml
+++ b/.github/workflows/base_checks.yaml
@@ -31,4 +31,7 @@ jobs:
       run: rustup target list --installed
 
     - name: Check all features compilation
-      run: cargo check --verbose --all-features --locked
+      run: cargo check --verbose --features try-runtime,runtime-benchmarks --locked
+
+    - name: Check EVM tracing features compilation
+      run: cargo check --verbose --features evm-tracing --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,10 @@ jobs:
       run: rustup target list --installed
 
     - name: Check all features compilation
-      run: cargo check --verbose --all-features --locked
+      run: cargo check --verbose --features try-runtime,runtime-benchmarks --locked
 
     - name: Run all tests
-      run: cargo test --all-features --locked
+      run: cargo test --features try-runtime,runtime-benchmarks --locked
 
   native-linux:
     needs: checks-and-tests

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -48,7 +48,7 @@ jobs:
     - uses: actions-rs/clippy-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        args: --all-features -- -D warnings
+        args: --features try-runtime,runtime-benchmarks -- -D warnings
 
   check-license:
     if: github.event.pull_request.draft == false


### PR DESCRIPTION
**Pull Request Summary**

Modify CI to check & test without `evm-tracing` features enabled.

Also expands standard PR check to also include `evm-tracing` check.
However, this might need to be changed if the check proves to be too lenghty.