### PR TITLE
recover ubuntu aarch build in release ci

### DIFF
--- a/.github/scripts/generate-release-body.ts
+++ b/.github/scripts/generate-release-body.ts
@@ -270,8 +270,9 @@ ${moduleLinks.map((modules) => `${capitalize(modules.name)}: ${modules.link}`).j
 ## Download Links
 | Arch |  Link  |
 | ----------- | ------- |
-|  \`MacOS\` | [Download](https://github.com/AstarNetwork/Astar/releases/download/${newTag}/astar-collator-${newTag}-macOS-x86_64.tar.gz) |
-| \`Ubuntu\` | [Download](https://github.com/AstarNetwork/Astar/releases/download/${newTag}/astar-collator-${newTag}-ubuntu-x86_64.tar.gz) |
+|  \`MacOS x86_64\` | [Download](https://github.com/AstarNetwork/Astar/releases/download/${newTag}/astar-collator-${newTag}-macOS-x86_64.tar.gz) |
+| \`Ubuntu x86_64\` | [Download](https://github.com/AstarNetwork/Astar/releases/download/${newTag}/astar-collator-${newTag}-ubuntu-x86_64.tar.gz) |
+| \`Ubuntu aarch64\` | [Download](https://github.com/AstarNetwork/Astar/releases/download/${newTag}/astar-collator-${newTag}-ubuntu-aarch64.tar.gz) |
 
 [<img src="https://github.com/AstarNetwork/Astar/blob/master/.github/images/docker.webp" height="200px">](https://hub.docker.com/r/staketechnologies/astar-collator/tags) 
 `

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,10 +321,10 @@ jobs:
         name: shibuya-runtime
         path: runtime-artifacts
 
-    - name: Use Node.js 16.x
+    - name: Use Node.js 18.x
       uses: actions/setup-node@v2
       with:
-        node-version: 16.x
+        node-version: 18.x
 
     - name: Get the latest release
       id: latest-release
@@ -359,7 +359,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu", "macOS"]
-        arch: ["x86_64"]
+        arch: ["x86_64", "aarch64"]
         exclude:
         - os: macOS
           arch: aarch64


### PR DESCRIPTION
**Pull Request Summary**
Recover ubuntu aarch64 binary build in Release CI

Test build: https://github.com/AstarNetwork/Astar/actions/runs/4497253895

**Check list**
- [ ] added or updated unit tests
- [ ] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [ ] updated spec version
- [ ] updated semver
