### PR TITLE
Introduce Tinkernet multisig XCM configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4189,6 +4189,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "invarch-xcm-builder"
+version = "0.1.0"
+source = "git+https://github.com/InvArch/InvArch-XCM-Builder?branch=polkadot-v0.9.39#c704c0f2d4c436f96eff10d06c197527b46b3536"
+dependencies = [
+ "frame-support",
+ "log",
+ "parity-scale-codec",
+ "sp-core",
+ "sp-io",
+ "xcm",
+ "xcm-executor",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11624,6 +11638,7 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
+ "invarch-xcm-builder",
  "log",
  "moonbeam-evm-tracer",
  "moonbeam-rpc-primitives-debug",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,7 +235,7 @@ moonbeam-rpc-debug = { git = "https://github.com/AstarNetwork/astar-frame", bran
 moonbeam-rpc-trace = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.39" }
 moonbeam-rpc-txpool = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.39" }
 
-# InvArch Tinkernet Multisig dependencies
+# InvArch Tinkernet Multisig dependencies - NOTE: should only be used for Shibuya
 # (wasm)
 invarch-xcm-builder = { git = "https://github.com/InvArch/InvArch-XCM-Builder", branch = "polkadot-v0.9.39", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ sc-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v
 try-runtime-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.39" }
 frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.39" }
 
-# Substrate pallets 
+# Substrate pallets
 # (wasm)
 pallet-assets = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.39", default-features = false }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.39", default-features = false }
@@ -234,6 +234,10 @@ moonbeam-primitives-ext = { git = "https://github.com/AstarNetwork/astar-frame",
 moonbeam-rpc-debug = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.39" }
 moonbeam-rpc-trace = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.39" }
 moonbeam-rpc-txpool = { git = "https://github.com/AstarNetwork/astar-frame", branch = "polkadot-v0.9.39" }
+
+# InvArch Tinkernet Multisig dependencies
+# (wasm)
+invarch-xcm-builder = { git = "https://github.com/InvArch/InvArch-XCM-Builder", branch = "polkadot-v0.9.39", default-features = false }
 
 # Build deps
 substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.39" }

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -126,6 +126,9 @@ frame-try-runtime = { workspace = true, optional = true }
 # TODO: remove this once we get rid of `pallet-xcm` fork & double dep
 polkadot-runtime = { workspace = true, optional = true }
 
+# InvArch Tinkernet Multisig dependencies
+invarch-xcm-builder = { workspace = true }
+
 [build-dependencies]
 substrate-wasm-builder = { workspace = true, optional = true }
 

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -126,7 +126,7 @@ frame-try-runtime = { workspace = true, optional = true }
 # TODO: remove this once we get rid of `pallet-xcm` fork & double dep
 polkadot-runtime = { workspace = true, optional = true }
 
-# InvArch Tinkernet Multisig dependencies
+# InvArch Tinkernet Multisig dependencies - NOTE: should only be used for Shibuya
 invarch-xcm-builder = { workspace = true }
 
 [build-dependencies]

--- a/runtime/shibuya/src/xcm_config.rs
+++ b/runtime/shibuya/src/xcm_config.rs
@@ -63,6 +63,8 @@ pub type LocationToAccountId = (
     SiblingParachainConvertsVia<polkadot_parachain::primitives::Sibling, AccountId>,
     // Straight up local `AccountId32` origins just alias directly to `AccountId`.
     AccountId32Aliases<RelayNetwork, AccountId>,
+    // Mapping Tinkernet multisig to the correctly derived AccountId32.
+    invarch_xcm_builder::TinkernetMultisigAsAccountId<AccountId>,
     // Derives a private `Account32` by hashing `("multiloc", received multilocation)`
     Account32Hash<RelayNetwork, AccountId>,
 );
@@ -122,6 +124,8 @@ pub type XcmOriginToTransactDispatchOrigin = (
     // Native signed account converter; this just converts an `AccountId32` origin into a normal
     // `Origin::Signed` origin of the same 32-byte value.
     SignedAccountId32AsNative<RelayNetwork, RuntimeOrigin>,
+    // Derives signed AccountId32 origins for Tinkernet multisigs.
+    invarch_xcm_builder::DeriveOriginFromTinkernetMultisig<RuntimeOrigin>,
 );
 
 parameter_types! {


### PR DESCRIPTION
This PR adds the XCM configs necessary to allow Tinkernet multisigs to transact on Shibuya.

Tinkernet multisigs have the following MultiLocation pattern:
```rust
MultiLocation {
    parents: _, // ancestry depends on the point of reference. 0 if from parent, 1 if from sibling.
    interior: Junctions::X3(
        Junction::Parachain(2125), // Tinkernet ParaId in Kusama/Rococo.
        Junction::PalletInstance(71), // Pallet INV4, from which the multisigs originate.
        Junction::GeneralIndex(_) // Index from which the multisig account is derived.
    )
}
```
A custom barrier is not needed as Shibuya already has `WithComputedOrigin<AllowTopLevelPaidExecution<Everything>>`, which allows for our multisig XCM messages to pass through.

The following are the configs added by this PR to give the multisigs accounts and origins in Shibuya:



### In LocationToAccountId
```rust
invarch_xcm_builder::TinkernetMultisigAsAccountId<AccountId>,
```
This MultiLocation converter derives an AccountId for locations matching the one described above, it does so by using the same exact derivation function used in Tinkernet, this is important to make sure the multisigs maintain the same address across all chains, providing the best UX possible.
Because this derivation happens in Shibuya, it means the whole process is trustless and removes any possibility of account impersonation!

Observation: This has to be placed before `Account32Hash` as that converter is a catch-all and will prevent any converters placed after it to trigger.

### In XcmOriginToTransactDispatchOrigin
```rust
invarch_xcm_builder::DeriveOriginFromTinkernetMultisig<RuntimeOrigin>,
```
Same as explained above, except here we need to derive the AccountId and wrap it with a RawOrigin::Signed origin so this account can use the `Transact` XCM instruction and thus call extrinsics in the Shibuya runtime's pallets.