### PR TITLE
feat: evm-tracing refactor

### DIFF
--- a/bin/collator/src/cli.rs
+++ b/bin/collator/src/cli.rs
@@ -55,7 +55,6 @@ pub struct Cli {
     pub proposer_soft_deadline_percent: u8,
 }
 
-
 /// Possible subcommands of the main binary.
 #[derive(Debug, clap::Subcommand)]
 pub enum Subcommand {
@@ -142,4 +141,3 @@ impl RelayChainCli {
         }
     }
 }
-

--- a/bin/collator/src/cli.rs
+++ b/bin/collator/src/cli.rs
@@ -19,6 +19,9 @@
 use clap::Parser;
 use std::path::PathBuf;
 
+#[cfg(feature = "evm-tracing")]
+use crate::evm_tracing_types::EthApiOptions;
+
 /// An overarching CLI command definition.
 #[derive(Debug, clap::Parser)]
 pub struct Cli {
@@ -30,54 +33,10 @@ pub struct Cli {
     #[clap(flatten)]
     pub run: cumulus_client_cli::RunCmd,
 
-    /// Enable EVM tracing module on a non-authority node.
+    #[allow(missing_docs)]
     #[cfg(feature = "evm-tracing")]
-    #[clap(
-        long,
-        conflicts_with = "collator",
-        conflicts_with = "validator",
-        value_delimiter = ','
-    )]
-    pub ethapi: Vec<EthApi>,
-
-    /// Number of concurrent tracing tasks. Meant to be shared by both "debug" and "trace" modules.
-    #[cfg(feature = "evm-tracing")]
-    #[clap(long, default_value = "10")]
-    pub ethapi_max_permits: u32,
-
-    /// Maximum number of trace entries a single request of `trace_filter` is allowed to return.
-    /// A request asking for more or an unbounded one going over this limit will both return an
-    /// error.
-    #[cfg(feature = "evm-tracing")]
-    #[clap(long, default_value = "500")]
-    pub ethapi_trace_max_count: u32,
-
-    /// Duration (in seconds) after which the cache of `trace_filter` for a given block will be
-    /// discarded.
-    #[cfg(feature = "evm-tracing")]
-    #[clap(long, default_value = "300")]
-    pub ethapi_trace_cache_duration: u64,
-
-    /// Size in bytes of the LRU cache for block data.
-    #[cfg(feature = "evm-tracing")]
-    #[clap(long, default_value = "300000000")]
-    pub eth_log_block_cache: usize,
-
-    /// Size in bytes of the LRU cache for transactions statuses data.
-    #[cfg(feature = "evm-tracing")]
-    #[clap(long, default_value = "300000000")]
-    pub eth_statuses_cache: usize,
-
-    /// Size in bytes of data a raw tracing request is allowed to use.
-    /// Bound the size of memory, stack and storage data.
-    #[cfg(feature = "evm-tracing")]
-    #[clap(long, default_value = "20000000")]
-    pub tracing_raw_max_memory_usage: usize,
-
-    /// Maximum number of logs in a query.
-    #[cfg(feature = "evm-tracing")]
-    #[clap(long, default_value = "10000")]
-    pub max_past_logs: u32,
+    #[clap(flatten)]
+    pub eth_api_options: EthApiOptions,
 
     /// Enable Ethereum compatible JSON-RPC servers (disabled by default).
     #[clap(name = "enable-evm-rpc", long)]
@@ -95,6 +54,7 @@ pub struct Cli {
     #[clap(long, default_value = "50")]
     pub proposer_soft_deadline_percent: u8,
 }
+
 
 /// Possible subcommands of the main binary.
 #[derive(Debug, clap::Subcommand)]
@@ -183,58 +143,3 @@ impl RelayChainCli {
     }
 }
 
-/// EVM tracing CLI flags.
-#[cfg(feature = "evm-tracing")]
-#[derive(Debug, PartialEq, Clone)]
-pub enum EthApi {
-    /// Enable EVM debug RPC methods.
-    Debug,
-    /// Enable EVM trace RPC methods.
-    Trace,
-    /// Enable pending transactions RPC methods.
-    TxPool,
-}
-
-#[cfg(feature = "evm-tracing")]
-impl std::str::FromStr for EthApi {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
-            "debug" => Self::Debug,
-            "trace" => Self::Trace,
-            "txpool" => Self::TxPool,
-            _ => {
-                return Err(format!(
-                    "`{}` is not recognized as a supported Ethereum Api",
-                    s
-                ))
-            }
-        })
-    }
-}
-
-/// EVM tracing CLI config.
-#[cfg(feature = "evm-tracing")]
-pub struct EvmTracingConfig {
-    /// Enabled EVM tracing flags.
-    pub ethapi: Vec<EthApi>,
-    /// Number of concurrent tracing tasks.
-    pub ethapi_max_permits: u32,
-    /// Maximum number of trace entries a single request of `trace_filter` is allowed to return.
-    /// A request asking for more or an unbounded one going over this limit will both return an
-    /// error.
-    pub ethapi_trace_max_count: u32,
-    /// Duration (in seconds) after which the cache of `trace_filter` for a given block will be
-    /// discarded.
-    pub ethapi_trace_cache_duration: u64,
-    /// Size in bytes of the LRU cache for block data.
-    pub eth_log_block_cache: usize,
-    /// Size in bytes of the LRU cache for transactions statuses data.
-    pub eth_statuses_cache: usize,
-    /// Maximum number of logs in a query.
-    pub max_past_logs: u32,
-    /// Size in bytes of data a raw tracing request is allowed to use.
-    /// Bound the size of memory, stack and storage data.
-    pub tracing_raw_max_memory_usage: usize,
-}

--- a/bin/collator/src/command.rs
+++ b/bin/collator/src/command.rs
@@ -927,7 +927,8 @@ pub fn run() -> Result<()> {
                         enable_evm_rpc: cli.enable_evm_rpc,
                         proposer_block_size_limit: cli.proposer_block_size_limit,
                         proposer_soft_deadline_percent: cli.proposer_soft_deadline_percent,
-                    },additional_config)
+                        additional_config
+                    })
                         .await
                         .map(|r| r.0)
                         .map_err(Into::into)
@@ -940,7 +941,8 @@ pub fn run() -> Result<()> {
                         enable_evm_rpc: cli.enable_evm_rpc,
                         proposer_block_size_limit: cli.proposer_block_size_limit,
                         proposer_soft_deadline_percent: cli.proposer_soft_deadline_percent,
-                    }, additional_config)
+                        additional_config
+                    })
                         .await
                         .map(|r| r.0)
                         .map_err(Into::into)
@@ -953,7 +955,8 @@ pub fn run() -> Result<()> {
                         enable_evm_rpc: cli.enable_evm_rpc,
                         proposer_block_size_limit: cli.proposer_block_size_limit,
                         proposer_soft_deadline_percent: cli.proposer_soft_deadline_percent,
-                    }, additional_config)
+                        additional_config
+                    })
                         .await
                         .map(|r| r.0)
                         .map_err(Into::into)

--- a/bin/collator/src/command.rs
+++ b/bin/collator/src/command.rs
@@ -21,8 +21,9 @@ use crate::{
     cli::{Cli, RelayChainCli, Subcommand},
     local::{self, development_config},
     parachain::{
-        self, astar, chain_spec, service::StartupConfiguration, shibuya, shiden, start_astar_node,
-        start_shibuya_node, start_shiden_node,
+        self, astar, chain_spec,
+        service::{AdditionalConfig, StartupConfiguration},
+        shibuya, shiden, start_astar_node, start_shibuya_node, start_shiden_node,
     },
     primitives::Block,
 };
@@ -845,6 +846,9 @@ pub fn run() -> Result<()> {
         None => {
             let runner = cli.create_runner(&cli.run.normalize())?;
             let collator_options = cli.run.collator_options();
+            let additional_config = AdditionalConfig {
+                evm_tracing_config: None,
+            };
 
             #[cfg(feature = "evm-tracing")]
             let evm_tracing_config = crate::evm_tracing_types::EvmTracingConfig {
@@ -910,91 +914,46 @@ pub fn run() -> Result<()> {
                 );
 
                 #[cfg(feature = "evm-tracing")]
-                if config.chain_spec.is_astar() {
-                    start_astar_node(StartupConfiguration {
-                            parachain_config: config,
-                            polkadot_config,
-                            evm_tracing_config,
-                            collator_options,
-                            id: para_id,
-                            enable_evm_rpc: cli.enable_evm_rpc,
-                            proposer_block_size_limit: cli.proposer_block_size_limit,
-                            proposer_soft_deadline_percent: cli.proposer_soft_deadline_percent,
-                        })
-                        .await
-                        .map(|r| r.0)
-                        .map_err(Into::into)
-                } else if config.chain_spec.is_shiden() {
-                    start_shiden_node(StartupConfiguration {
-                            parachain_config: config,
-                            polkadot_config,
-                            evm_tracing_config,
-                            collator_options,
-                            id: para_id,
-                            enable_evm_rpc: cli.enable_evm_rpc,
-                            proposer_block_size_limit: cli.proposer_block_size_limit,
-                            proposer_soft_deadline_percent: cli.proposer_soft_deadline_percent,
-                        })
-                        .await
-                        .map(|r| r.0)
-                        .map_err(Into::into)
-                } else if config.chain_spec.is_shibuya() {
-                    start_shibuya_node(StartupConfiguration {
-                            parachain_config: config,
-                            polkadot_config,
-                            evm_tracing_config,
-                            collator_options,
-                            id: para_id,
-                            enable_evm_rpc: cli.enable_evm_rpc,
-                            proposer_block_size_limit: cli.proposer_block_size_limit,
-                            proposer_soft_deadline_percent: cli.proposer_soft_deadline_percent,
-                        })
-                        .await
-                        .map(|r| r.0)
-                        .map_err(Into::into)
-                } else {
-                    let err_msg = "Unrecognized chain spec - name should start with one of: astar or shiden or shibuya";
-                    error!("{}", err_msg);
-                    Err(err_msg.into())
-                }
+                let additional_config = AdditionalConfig {
+                    evm_tracing_config: Some(evm_tracing_config),
+                };
 
-                #[cfg(not(feature = "evm-tracing"))]
                 if config.chain_spec.is_astar() {
-                    start_astar_node(StartupConfiguration {
-                            parachain_config: config,
-                            polkadot_config,
-                            collator_options,
-                            id: para_id,
-                            enable_evm_rpc: cli.enable_evm_rpc,
-                            proposer_block_size_limit: cli.proposer_block_size_limit,
-                            proposer_soft_deadline_percent: cli.proposer_soft_deadline_percent,
-                        })
+                    start_astar_node( StartupConfiguration {
+                        parachain_config: config,
+                        polkadot_config,
+                        collator_options,
+                        id: para_id,
+                        enable_evm_rpc: cli.enable_evm_rpc,
+                        proposer_block_size_limit: cli.proposer_block_size_limit,
+                        proposer_soft_deadline_percent: cli.proposer_soft_deadline_percent,
+                    },additional_config)
                         .await
                         .map(|r| r.0)
                         .map_err(Into::into)
                 } else if config.chain_spec.is_shiden() {
-                    start_shiden_node(StartupConfiguration {
-                            parachain_config: config,
-                            polkadot_config,
-                            collator_options,
-                            id: para_id,
-                            enable_evm_rpc: cli.enable_evm_rpc,
-                            proposer_block_size_limit: cli.proposer_block_size_limit,
-                            proposer_soft_deadline_percent: cli.proposer_soft_deadline_percent,
-                        })
+                    start_shiden_node( StartupConfiguration {
+                        parachain_config: config,
+                        polkadot_config,
+                        collator_options,
+                        id: para_id,
+                        enable_evm_rpc: cli.enable_evm_rpc,
+                        proposer_block_size_limit: cli.proposer_block_size_limit,
+                        proposer_soft_deadline_percent: cli.proposer_soft_deadline_percent,
+                    }, additional_config)
                         .await
                         .map(|r| r.0)
                         .map_err(Into::into)
                 } else if config.chain_spec.is_shibuya() {
-                    start_shibuya_node(StartupConfiguration {
-                            parachain_config: config,
-                            polkadot_config,
-                            collator_options,
-                            id: para_id,
-                            enable_evm_rpc: cli.enable_evm_rpc,
-                            proposer_block_size_limit: cli.proposer_block_size_limit,
-                            proposer_soft_deadline_percent: cli.proposer_soft_deadline_percent,
-                        })
+                    start_shibuya_node( StartupConfiguration {
+                        parachain_config: config,
+                        polkadot_config,
+                        collator_options,
+                        id: para_id,
+                        enable_evm_rpc: cli.enable_evm_rpc,
+                        proposer_block_size_limit: cli.proposer_block_size_limit,
+                        proposer_soft_deadline_percent: cli.proposer_soft_deadline_percent,
+                    }, additional_config)
                         .await
                         .map(|r| r.0)
                         .map_err(Into::into)

--- a/bin/collator/src/command.rs
+++ b/bin/collator/src/command.rs
@@ -846,12 +846,6 @@ pub fn run() -> Result<()> {
             let runner = cli.create_runner(&cli.run.normalize())?;
             let collator_options = cli.run.collator_options();
 
-            #[cfg(not(feature = "evm-tracing"))]
-            let additional_config = AdditionalConfig {
-                enable_evm_rpc: cli.enable_evm_rpc,
-                proposer_block_size_limit: cli.proposer_block_size_limit,
-                proposer_soft_deadline_percent: cli.proposer_soft_deadline_percent,
-            };
 
             #[cfg(feature = "evm-tracing")]
             let evm_tracing_config = crate::evm_tracing_types::EvmTracingConfig {
@@ -916,8 +910,9 @@ pub fn run() -> Result<()> {
                     }
                 );
 
-                #[cfg(feature = "evm-tracing")]
+                
                 let additional_config = AdditionalConfig {
+                    #[cfg(feature = "evm-tracing")]
                     evm_tracing_config: evm_tracing_config,
                     enable_evm_rpc: cli.enable_evm_rpc,
                     proposer_block_size_limit: cli.proposer_block_size_limit,

--- a/bin/collator/src/command.rs
+++ b/bin/collator/src/command.rs
@@ -847,15 +847,15 @@ pub fn run() -> Result<()> {
             let collator_options = cli.run.collator_options();
 
             #[cfg(feature = "evm-tracing")]
-            let evm_tracing_config = crate::cli::EvmTracingConfig {
-                ethapi: cli.ethapi,
-                ethapi_max_permits: cli.ethapi_max_permits,
-                ethapi_trace_max_count: cli.ethapi_trace_max_count,
-                ethapi_trace_cache_duration: cli.ethapi_trace_cache_duration,
-                eth_log_block_cache: cli.eth_log_block_cache,
-                eth_statuses_cache: cli.eth_statuses_cache,
-                max_past_logs: cli.max_past_logs,
-                tracing_raw_max_memory_usage: cli.tracing_raw_max_memory_usage,
+            let evm_tracing_config = crate::evm_tracing_types::EvmTracingConfig {
+                ethapi: cli.eth_api_options.ethapi,
+                ethapi_max_permits: cli.eth_api_options.ethapi_max_permits,
+                ethapi_trace_max_count: cli.eth_api_options.ethapi_trace_max_count,
+                ethapi_trace_cache_duration: cli.eth_api_options.ethapi_trace_cache_duration,
+                eth_log_block_cache: cli.eth_api_options.eth_log_block_cache,
+                eth_statuses_cache: cli.eth_api_options.eth_statuses_cache,
+                max_past_logs: cli.eth_api_options.max_past_logs,
+                tracing_raw_max_memory_usage: cli.eth_api_options.tracing_raw_max_memory_usage,
             };
 
             runner.run_node_until_exit(|config| async move {

--- a/bin/collator/src/command.rs
+++ b/bin/collator/src/command.rs
@@ -846,7 +846,6 @@ pub fn run() -> Result<()> {
             let runner = cli.create_runner(&cli.run.normalize())?;
             let collator_options = cli.run.collator_options();
 
-
             #[cfg(feature = "evm-tracing")]
             let evm_tracing_config = crate::evm_tracing_types::EvmTracingConfig {
                 ethapi: cli.eth_api_options.ethapi,
@@ -910,7 +909,6 @@ pub fn run() -> Result<()> {
                     }
                 );
 
-                
                 let additional_config = AdditionalConfig {
                     #[cfg(feature = "evm-tracing")]
                     evm_tracing_config: evm_tracing_config,

--- a/bin/collator/src/evm_tracing_types.rs
+++ b/bin/collator/src/evm_tracing_types.rs
@@ -29,7 +29,6 @@ pub enum EthApi {
     TxPool,
 }
 
-
 impl std::str::FromStr for EthApi {
     type Err = String;
 
@@ -72,48 +71,47 @@ pub struct EvmTracingConfig {
     pub tracing_raw_max_memory_usage: usize,
 }
 
-
 #[derive(Debug, Parser)]
 pub struct EthApiOptions {
-     /// Enable EVM tracing module on a non-authority node.
-     #[clap(
-         long,
-         conflicts_with = "collator",
-         conflicts_with = "validator",
-         value_delimiter = ','
-     )]
-     pub ethapi: Vec<EthApi>,
- 
-     /// Number of concurrent tracing tasks. Meant to be shared by both "debug" and "trace" modules.
-     #[clap(long, default_value = "10")]
-     pub ethapi_max_permits: u32,
- 
-     /// Maximum number of trace entries a single request of `trace_filter` is allowed to return.
-     /// A request asking for more or an unbounded one going over this limit will both return an
-     /// error.
-     
-     #[clap(long, default_value = "500")]
-     pub ethapi_trace_max_count: u32,
- 
-     /// Duration (in seconds) after which the cache of `trace_filter` for a given block will be
-     /// discarded.
-     #[clap(long, default_value = "300")]
-     pub ethapi_trace_cache_duration: u64,
- 
-     /// Size in bytes of the LRU cache for block data.
-     #[clap(long, default_value = "300000000")]
-     pub eth_log_block_cache: usize,
- 
-     /// Size in bytes of the LRU cache for transactions statuses data.
-     #[clap(long, default_value = "300000000")]
-     pub eth_statuses_cache: usize,
- 
-     /// Size in bytes of data a raw tracing request is allowed to use.
-     /// Bound the size of memory, stack and storage data.
-     #[clap(long, default_value = "20000000")]
-     pub tracing_raw_max_memory_usage: usize,
- 
-     /// Maximum number of logs in a query.
-     #[clap(long, default_value = "10000")]
-     pub max_past_logs: u32,
+    /// Enable EVM tracing module on a non-authority node.
+    #[clap(
+        long,
+        conflicts_with = "collator",
+        conflicts_with = "validator",
+        value_delimiter = ','
+    )]
+    pub ethapi: Vec<EthApi>,
+
+    /// Number of concurrent tracing tasks. Meant to be shared by both "debug" and "trace" modules.
+    #[clap(long, default_value = "10")]
+    pub ethapi_max_permits: u32,
+
+    /// Maximum number of trace entries a single request of `trace_filter` is allowed to return.
+    /// A request asking for more or an unbounded one going over this limit will both return an
+    /// error.
+
+    #[clap(long, default_value = "500")]
+    pub ethapi_trace_max_count: u32,
+
+    /// Duration (in seconds) after which the cache of `trace_filter` for a given block will be
+    /// discarded.
+    #[clap(long, default_value = "300")]
+    pub ethapi_trace_cache_duration: u64,
+
+    /// Size in bytes of the LRU cache for block data.
+    #[clap(long, default_value = "300000000")]
+    pub eth_log_block_cache: usize,
+
+    /// Size in bytes of the LRU cache for transactions statuses data.
+    #[clap(long, default_value = "300000000")]
+    pub eth_statuses_cache: usize,
+
+    /// Size in bytes of data a raw tracing request is allowed to use.
+    /// Bound the size of memory, stack and storage data.
+    #[clap(long, default_value = "20000000")]
+    pub tracing_raw_max_memory_usage: usize,
+
+    /// Maximum number of logs in a query.
+    #[clap(long, default_value = "10000")]
+    pub max_past_logs: u32,
 }

--- a/bin/collator/src/evm_tracing_types.rs
+++ b/bin/collator/src/evm_tracing_types.rs
@@ -1,0 +1,119 @@
+// This file is part of Astar.
+
+// Copyright (C) 2019-2023 Stake Technologies Pte.Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Astar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Astar is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Astar. If not, see <http://www.gnu.org/licenses/>.
+
+use clap::Parser;
+
+/// EVM tracing CLI flags.
+#[derive(Debug, PartialEq, Clone)]
+pub enum EthApi {
+    /// Enable EVM debug RPC methods.
+    Debug,
+    /// Enable EVM trace RPC methods.
+    Trace,
+    /// Enable pending transactions RPC methods.
+    TxPool,
+}
+
+
+impl std::str::FromStr for EthApi {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "debug" => Self::Debug,
+            "trace" => Self::Trace,
+            "txpool" => Self::TxPool,
+            _ => {
+                return Err(format!(
+                    "`{}` is not recognized as a supported Ethereum Api",
+                    s
+                ))
+            }
+        })
+    }
+}
+
+/// EVM tracing CLI config.
+pub struct EvmTracingConfig {
+    /// Enabled EVM tracing flags.
+    pub ethapi: Vec<EthApi>,
+    /// Number of concurrent tracing tasks.
+    pub ethapi_max_permits: u32,
+    /// Maximum number of trace entries a single request of `trace_filter` is allowed to return.
+    /// A request asking for more or an unbounded one going over this limit will both return an
+    /// error.
+    pub ethapi_trace_max_count: u32,
+    /// Duration (in seconds) after which the cache of `trace_filter` for a given block will be
+    /// discarded.
+    pub ethapi_trace_cache_duration: u64,
+    /// Size in bytes of the LRU cache for block data.
+    pub eth_log_block_cache: usize,
+    /// Size in bytes of the LRU cache for transactions statuses data.
+    pub eth_statuses_cache: usize,
+    /// Maximum number of logs in a query.
+    pub max_past_logs: u32,
+    /// Size in bytes of data a raw tracing request is allowed to use.
+    /// Bound the size of memory, stack and storage data.
+    pub tracing_raw_max_memory_usage: usize,
+}
+
+
+#[derive(Debug, Parser)]
+pub struct EthApiOptions {
+     /// Enable EVM tracing module on a non-authority node.
+     #[clap(
+         long,
+         conflicts_with = "collator",
+         conflicts_with = "validator",
+         value_delimiter = ','
+     )]
+     pub ethapi: Vec<EthApi>,
+ 
+     /// Number of concurrent tracing tasks. Meant to be shared by both "debug" and "trace" modules.
+     #[clap(long, default_value = "10")]
+     pub ethapi_max_permits: u32,
+ 
+     /// Maximum number of trace entries a single request of `trace_filter` is allowed to return.
+     /// A request asking for more or an unbounded one going over this limit will both return an
+     /// error.
+     
+     #[clap(long, default_value = "500")]
+     pub ethapi_trace_max_count: u32,
+ 
+     /// Duration (in seconds) after which the cache of `trace_filter` for a given block will be
+     /// discarded.
+     #[clap(long, default_value = "300")]
+     pub ethapi_trace_cache_duration: u64,
+ 
+     /// Size in bytes of the LRU cache for block data.
+     #[clap(long, default_value = "300000000")]
+     pub eth_log_block_cache: usize,
+ 
+     /// Size in bytes of the LRU cache for transactions statuses data.
+     #[clap(long, default_value = "300000000")]
+     pub eth_statuses_cache: usize,
+ 
+     /// Size in bytes of data a raw tracing request is allowed to use.
+     /// Bound the size of memory, stack and storage data.
+     #[clap(long, default_value = "20000000")]
+     pub tracing_raw_max_memory_usage: usize,
+ 
+     /// Maximum number of logs in a query.
+     #[clap(long, default_value = "10000")]
+     pub max_past_logs: u32,
+}

--- a/bin/collator/src/evm_tracing_types.rs
+++ b/bin/collator/src/evm_tracing_types.rs
@@ -47,6 +47,8 @@ impl std::str::FromStr for EthApi {
     }
 }
 
+#[allow(dead_code)]
+#[derive(Clone)]
 /// EVM tracing CLI config.
 pub struct EvmTracingConfig {
     /// Enabled EVM tracing flags.

--- a/bin/collator/src/lib.rs
+++ b/bin/collator/src/lib.rs
@@ -31,9 +31,9 @@ mod benchmarking;
 
 mod cli;
 mod command;
+mod evm_tracing_types;
 mod primitives;
 mod rpc;
-mod evm_tracing_types;
 
 pub use cli::*;
 pub use command::*;

--- a/bin/collator/src/lib.rs
+++ b/bin/collator/src/lib.rs
@@ -33,6 +33,7 @@ mod cli;
 mod command;
 mod primitives;
 mod rpc;
+mod evm_tracing_types;
 
 pub use cli::*;
 pub use command::*;

--- a/bin/collator/src/local/service.rs
+++ b/bin/collator/src/local/service.rs
@@ -184,9 +184,9 @@ pub fn new_partial(
 #[cfg(feature = "evm-tracing")]
 pub fn start_node(
     config: Configuration,
-    evm_tracing_config: crate::EvmTracingConfig,
+    evm_tracing_config: crate::evm_tracing_types::EvmTracingConfig,
 ) -> Result<TaskManager, ServiceError> {
-    use crate::cli::EthApi as EthApiCmd;
+    use crate::evm_tracing_types::EthApi as EthApiCmd;
     use crate::rpc::tracing;
 
     let sc_service::PartialComponents {

--- a/bin/collator/src/parachain/service.rs
+++ b/bin/collator/src/parachain/service.rs
@@ -49,7 +49,7 @@ use substrate_prometheus_endpoint::Registry;
 
 use super::shell_upgrade::*;
 #[cfg(feature = "evm-tracing")]
-use crate::cli::{EthApi as EthApiCmd, EvmTracingConfig};
+use crate::evm_tracing_types::{EthApi as EthApiCmd, EvmTracingConfig};
 use crate::primitives::*;
 #[cfg(feature = "evm-tracing")]
 use crate::rpc::tracing;
@@ -1153,7 +1153,7 @@ pub async fn start_astar_node(
 /// Start a parachain node for Astar.
 #[cfg(not(feature = "evm-tracing"))]
 pub async fn start_astar_node(
-    configuration: StartupConfiguration,
+    configuration: StartupConfiguration
 ) -> sc_service::error::Result<(
     TaskManager,
     Arc<TFullClient<Block, astar::RuntimeApi, NativeElseWasmExecutor<astar::Executor>>>,

--- a/bin/collator/src/parachain/service.rs
+++ b/bin/collator/src/parachain/service.rs
@@ -49,8 +49,7 @@ use substrate_prometheus_endpoint::Registry;
 
 use super::shell_upgrade::*;
 #[cfg(feature = "evm-tracing")]
-use crate::evm_tracing_types::EthApi as EthApiCmd;
-use crate::evm_tracing_types::EvmTracingConfig;
+use crate::evm_tracing_types::{EthApi as EthApiCmd, EvmTracingConfig};
 
 use crate::primitives::*;
 #[cfg(feature = "evm-tracing")]
@@ -311,7 +310,7 @@ async fn start_node_impl<RuntimeApi, Executor, BIQ, BIC>(
     polkadot_config: Configuration,
     collator_options: CollatorOptions,
     id: ParaId,
-    enable_evm_rpc: bool,
+    additional_config: AdditionalConfig,
     build_import_queue: BIQ,
     build_consensus: BIC,
 ) -> sc_service::error::Result<(
@@ -502,7 +501,7 @@ where
                 fee_history_cache: fee_history_cache.clone(),
                 block_data_cache: block_data_cache.clone(),
                 overrides: overrides.clone(),
-                enable_evm_rpc,
+                enable_evm_rpc: additional_config.enable_evm_rpc,
             };
 
             crate::rpc::create_full(deps, subscription).map_err(Into::into)
@@ -587,19 +586,12 @@ where
     Ok((task_manager, client))
 }
 
-/// Configuration used to start a node
-pub struct StartupConfiguration {
-    /// Parachain configuration
-    pub parachain_config: Configuration,
-
-    /// Relay chain configuration
-    pub polkadot_config: Configuration,
-
-    /// Options specific to collators
-    pub collator_options: CollatorOptions,
-
-    /// Parachain ID to collate
-    pub id: ParaId,
+#[derive(Clone)]
+/// To add additional config to start_xyz_node functions
+pub struct AdditionalConfig {
+    #[cfg(feature = "evm-tracing")]
+    /// EVM tracing configuration
+    pub evm_tracing_config: EvmTracingConfig,
 
     /// Whether EVM RPC be enabled
     pub enable_evm_rpc: bool,
@@ -609,15 +601,6 @@ pub struct StartupConfiguration {
 
     /// Soft deadline limit used by `Proposer`
     pub proposer_soft_deadline_percent: u8,
-
-    /// Additional config requirements
-    pub additional_config: AdditionalConfig,
-}
-
-/// To add additional config to start_xyz_node functions
-pub struct AdditionalConfig {
-    /// EVM tracing configuration
-    pub evm_tracing_config: Option<EvmTracingConfig>,
 }
 
 /// Start a node with the given parachain `Configuration` and relay chain `Configuration`.
@@ -628,10 +611,9 @@ pub struct AdditionalConfig {
 async fn start_node_impl<RuntimeApi, Executor, BIQ, BIC>(
     parachain_config: Configuration,
     polkadot_config: Configuration,
-    evm_tracing_config: EvmTracingConfig,
     collator_options: CollatorOptions,
     id: ParaId,
-    enable_evm_rpc: bool,
+    additional_config: AdditionalConfig,
     build_import_queue: BIQ,
     build_consensus: BIC,
 ) -> sc_service::error::Result<(
@@ -753,11 +735,11 @@ where
     let fee_history_cache: FeeHistoryCache = Arc::new(std::sync::Mutex::new(BTreeMap::new()));
     let overrides = fc_storage::overrides_handle(client.clone());
 
-    let ethapi_cmd = evm_tracing_config.ethapi.clone();
+    let ethapi_cmd = additional_config.evm_tracing_config.ethapi.clone();
     let tracing_requesters =
         if ethapi_cmd.contains(&EthApiCmd::Debug) || ethapi_cmd.contains(&EthApiCmd::Trace) {
             tracing::spawn_tracing_tasks(
-                &evm_tracing_config,
+                &additional_config.evm_tracing_config,
                 tracing::SpawnTasksParams {
                     task_manager: &task_manager,
                     client: client.clone(),
@@ -832,7 +814,7 @@ where
         let transaction_pool = transaction_pool.clone();
         let rpc_config = crate::rpc::EvmTracingConfig {
             tracing_requesters,
-            trace_filter_max_count: evm_tracing_config.ethapi_trace_max_count,
+            trace_filter_max_count: additional_config.evm_tracing_config.ethapi_trace_max_count,
             enable_txpool: ethapi_cmd.contains(&EthApiCmd::TxPool),
         };
 
@@ -850,7 +832,7 @@ where
                 fee_history_cache: fee_history_cache.clone(),
                 block_data_cache: block_data_cache.clone(),
                 overrides: overrides.clone(),
-                enable_evm_rpc,
+                enable_evm_rpc: additional_config.enable_evm_rpc,
             };
 
             crate::rpc::create_full(deps, subscription, rpc_config.clone()).map_err(Into::into)
@@ -1029,18 +1011,21 @@ where
 /// Start a parachain node for Astar.
 #[cfg(feature = "evm-tracing")]
 pub async fn start_astar_node(
-    configuration: StartupConfiguration,
+    parachain_config: Configuration,
+    polkadot_config: Configuration,
+    collator_options: CollatorOptions,
+    id: ParaId,
+    additional_config: AdditionalConfig,
 ) -> sc_service::error::Result<(
     TaskManager,
     Arc<TFullClient<Block, astar::RuntimeApi, NativeElseWasmExecutor<astar::Executor>>>,
 )> {
     start_node_impl::<astar::RuntimeApi, astar::Executor, _, _>(
-        configuration.parachain_config,
-        configuration.polkadot_config,
-        configuration.additional_config.evm_tracing_config.unwrap(),
-        configuration.collator_options,
-        configuration.id,
-        configuration.enable_evm_rpc,
+        parachain_config,
+        polkadot_config,
+        collator_options,
+        id,
+        additional_config.clone(),
         |client,
          block_import,
          config,
@@ -1099,8 +1084,8 @@ pub async fn start_astar_node(
                     telemetry.clone(),
                 );
 
-            proposer_factory.set_default_block_size_limit(configuration.proposer_block_size_limit);
-            proposer_factory.set_soft_deadline(Percent::from_percent(configuration.proposer_soft_deadline_percent));
+            proposer_factory.set_default_block_size_limit(additional_config.proposer_block_size_limit);
+            proposer_factory.set_soft_deadline(Percent::from_percent(additional_config.proposer_soft_deadline_percent));
 
             let relay_chain_for_aura = relay_chain_interface.clone();
 
@@ -1123,7 +1108,7 @@ pub async fn start_astar_node(
                                     relay_parent,
                                     &relay_chain_for_aura,
                                     &validation_data,
-                                    configuration.id,
+                                    id,
                                 ).await;
                             let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
                             let slot =
@@ -1160,17 +1145,21 @@ pub async fn start_astar_node(
 /// Start a parachain node for Astar.
 #[cfg(not(feature = "evm-tracing"))]
 pub async fn start_astar_node(
-    configuration: StartupConfiguration,
+    parachain_config: Configuration,
+    polkadot_config: Configuration,
+    collator_options: CollatorOptions,
+    id: ParaId,
+    additional_config: AdditionalConfig,
 ) -> sc_service::error::Result<(
     TaskManager,
     Arc<TFullClient<Block, astar::RuntimeApi, NativeElseWasmExecutor<astar::Executor>>>,
 )> {
     start_node_impl::<astar::RuntimeApi, astar::Executor, _, _>(
-        configuration.parachain_config,
-        configuration.polkadot_config,
-        configuration.collator_options,
-        configuration.id,
-        configuration.enable_evm_rpc,
+        parachain_config,
+        polkadot_config,
+        collator_options,
+        id,
+        additional_config.clone(),
         |client,
          block_import,
          config,
@@ -1229,8 +1218,8 @@ pub async fn start_astar_node(
                     telemetry.clone(),
                 );
 
-            proposer_factory.set_default_block_size_limit(configuration.proposer_block_size_limit);
-            proposer_factory.set_soft_deadline(Percent::from_percent(configuration.proposer_soft_deadline_percent));
+            proposer_factory.set_default_block_size_limit(additional_config.proposer_block_size_limit);
+            proposer_factory.set_soft_deadline(Percent::from_percent(additional_config.proposer_soft_deadline_percent));
 
             let relay_chain_for_aura = relay_chain_interface.clone();
 
@@ -1253,7 +1242,7 @@ pub async fn start_astar_node(
                                     relay_parent,
                                     &relay_chain_for_aura,
                                     &validation_data,
-                                    configuration.id,
+                                    id,
                                 ).await;
                             let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
                             let slot =
@@ -1290,18 +1279,21 @@ pub async fn start_astar_node(
 /// Start a parachain node for Shiden.
 #[cfg(feature = "evm-tracing")]
 pub async fn start_shiden_node(
-    configuration: StartupConfiguration,
+    parachain_config: Configuration,
+    polkadot_config: Configuration,
+    collator_options: CollatorOptions,
+    id: ParaId,
+    additional_config: AdditionalConfig,
 ) -> sc_service::error::Result<(
     TaskManager,
     Arc<TFullClient<Block, shiden::RuntimeApi, NativeElseWasmExecutor<shiden::Executor>>>,
 )> {
     start_node_impl::<shiden::RuntimeApi, shiden::Executor, _, _>(
-        configuration.parachain_config,
-        configuration.polkadot_config,
-        configuration.additional_config.evm_tracing_config.unwrap(),
-        configuration.collator_options,
-        configuration.id,
-        configuration.enable_evm_rpc,
+        parachain_config,
+        polkadot_config,
+        collator_options,
+        id,
+        additional_config.clone(),
         build_import_queue,
         |client,
          block_import,
@@ -1337,8 +1329,8 @@ pub async fn start_shiden_node(
                             telemetry2.clone(),
                         );
 
-                    proposer_factory.set_default_block_size_limit(configuration.proposer_block_size_limit);
-                    proposer_factory.set_soft_deadline(Percent::from_percent(configuration.proposer_soft_deadline_percent));
+                    proposer_factory.set_default_block_size_limit(additional_config.proposer_block_size_limit);
+                    proposer_factory.set_soft_deadline(Percent::from_percent(additional_config.proposer_soft_deadline_percent));
 
                     AuraConsensus::build::<
                         sp_consensus_aura::sr25519::AuthorityPair,
@@ -1359,7 +1351,7 @@ pub async fn start_shiden_node(
                                             relay_parent,
                                             &relay_chain_for_aura,
                                             &validation_data,
-                                            configuration.id,
+                                            id,
                                         ).await;
                                     let timestamp =
                                         sp_timestamp::InherentDataProvider::from_system_time();
@@ -1404,13 +1396,13 @@ pub async fn start_shiden_node(
                     telemetry.clone(),
                 );
 
-            proposer_factory.set_default_block_size_limit(configuration.proposer_block_size_limit);
-            proposer_factory.set_soft_deadline(Percent::from_percent(configuration.proposer_soft_deadline_percent));
+            proposer_factory.set_default_block_size_limit(additional_config.proposer_block_size_limit);
+            proposer_factory.set_soft_deadline(Percent::from_percent(additional_config.proposer_soft_deadline_percent));
 
             let relay_chain_consensus =
                 cumulus_client_consensus_relay_chain::build_relay_chain_consensus(
                     cumulus_client_consensus_relay_chain::BuildRelayChainConsensusParams {
-                        para_id: configuration.id,
+                        para_id: id,
                         proposer_factory,
                         block_import: block_import, //client.clone(),
                         relay_chain_interface: relay_chain_interface.clone(),
@@ -1423,7 +1415,7 @@ pub async fn start_shiden_node(
                                             relay_parent,
                                             &relay_chain_for_aura,
                                             &validation_data,
-                                            configuration.id,
+                                            id,
                                         ).await;
                                     let parachain_inherent =
                                         parachain_inherent.ok_or_else(|| {
@@ -1450,17 +1442,21 @@ pub async fn start_shiden_node(
 /// Start a parachain node for Shiden.
 #[cfg(not(feature = "evm-tracing"))]
 pub async fn start_shiden_node(
-    configuration: StartupConfiguration,
+    parachain_config: Configuration,
+    polkadot_config: Configuration,
+    collator_options: CollatorOptions,
+    id: ParaId,
+    additional_config: AdditionalConfig,
 ) -> sc_service::error::Result<(
     TaskManager,
     Arc<TFullClient<Block, shiden::RuntimeApi, NativeElseWasmExecutor<shiden::Executor>>>,
 )> {
     start_node_impl::<shiden::RuntimeApi, shiden::Executor, _, _>(
-        configuration.parachain_config,
-        configuration.polkadot_config,
-        configuration.collator_options,
-        configuration.id,
-        configuration.enable_evm_rpc,
+        parachain_config,
+        polkadot_config,
+        collator_options,
+        id,
+        additional_config.clone(),
         build_import_queue,
         |client,
          block_import,
@@ -1496,8 +1492,8 @@ pub async fn start_shiden_node(
                             telemetry2.clone(),
                         );
 
-                    proposer_factory.set_default_block_size_limit(configuration.proposer_block_size_limit);
-                    proposer_factory.set_soft_deadline(Percent::from_percent(configuration.proposer_soft_deadline_percent));
+                    proposer_factory.set_default_block_size_limit(additional_config.proposer_block_size_limit);
+                    proposer_factory.set_soft_deadline(Percent::from_percent(additional_config.proposer_soft_deadline_percent));
 
                     AuraConsensus::build::<
                         sp_consensus_aura::sr25519::AuthorityPair,
@@ -1518,7 +1514,7 @@ pub async fn start_shiden_node(
                                             relay_parent,
                                             &relay_chain_for_aura,
                                             &validation_data,
-                                            configuration.id,
+                                            id,
                                         ).await;
                                     let timestamp =
                                         sp_timestamp::InherentDataProvider::from_system_time();
@@ -1563,13 +1559,13 @@ pub async fn start_shiden_node(
                     telemetry.clone(),
                 );
 
-            proposer_factory.set_default_block_size_limit(configuration.proposer_block_size_limit);
-            proposer_factory.set_soft_deadline(Percent::from_percent(configuration.proposer_soft_deadline_percent));
+            proposer_factory.set_default_block_size_limit(additional_config.proposer_block_size_limit);
+            proposer_factory.set_soft_deadline(Percent::from_percent(additional_config.proposer_soft_deadline_percent));
 
             let relay_chain_consensus =
                 cumulus_client_consensus_relay_chain::build_relay_chain_consensus(
                     cumulus_client_consensus_relay_chain::BuildRelayChainConsensusParams {
-                        para_id: configuration.id,
+                        para_id: id,
                         proposer_factory,
                         block_import: block_import, //client.clone(),
                         relay_chain_interface: relay_chain_interface.clone(),
@@ -1582,7 +1578,7 @@ pub async fn start_shiden_node(
                                             relay_parent,
                                             &relay_chain_for_aura,
                                             &validation_data,
-                                            configuration.id,
+                                            id,
                                         ).await;
                                     let parachain_inherent =
                                         parachain_inherent.ok_or_else(|| {
@@ -1609,26 +1605,21 @@ pub async fn start_shiden_node(
 /// Start a parachain node for Shibuya.
 #[cfg(feature = "evm-tracing")]
 pub async fn start_shibuya_node(
-    configuration: StartupConfiguration,
-    // parachain_config: Configuration,
-    // polkadot_config: Configuration,
-    // evm_tracing_config: EvmTracingConfig,
-    // collator_options: CollatorOptions,
-    // id: ParaId,
-    // enable_evm_rpc: bool,
-    // proposer_block_size_limit: Option<usize>,
-    // proposer_soft_deadline_percent: Option<u8>,
+    parachain_config: Configuration,
+    polkadot_config: Configuration,
+    collator_options: CollatorOptions,
+    id: ParaId,
+    additional_config: AdditionalConfig,
 ) -> sc_service::error::Result<(
     TaskManager,
     Arc<TFullClient<Block, shibuya::RuntimeApi, NativeElseWasmExecutor<shibuya::Executor>>>,
 )> {
     start_node_impl::<shibuya::RuntimeApi, shibuya::Executor, _, _>(
-        configuration.parachain_config,
-        configuration.polkadot_config,
-        configuration.additional_config.evm_tracing_config.unwrap(),
-        configuration.collator_options,
-        configuration.id,
-        configuration.enable_evm_rpc,
+        parachain_config,
+        polkadot_config,
+        collator_options,
+        id,
+        additional_config.clone(),
         |client,
          block_import,
          config,
@@ -1687,8 +1678,8 @@ pub async fn start_shibuya_node(
                     telemetry.clone(),
                 );
 
-            proposer_factory.set_default_block_size_limit(configuration.proposer_block_size_limit);
-            proposer_factory.set_soft_deadline(Percent::from_percent(configuration.proposer_soft_deadline_percent));
+            proposer_factory.set_default_block_size_limit(additional_config.proposer_block_size_limit);
+            proposer_factory.set_soft_deadline(Percent::from_percent(additional_config.proposer_soft_deadline_percent));
 
             Ok(AuraConsensus::build::<
                 sp_consensus_aura::sr25519::AuthorityPair,
@@ -1709,7 +1700,7 @@ pub async fn start_shibuya_node(
                                     relay_parent,
                                     &relay_chain_for_aura,
                                     &validation_data,
-                                    configuration.id,
+                                    id,
                                 ).await;
                             let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
                             let slot =
@@ -1746,24 +1737,21 @@ pub async fn start_shibuya_node(
 /// Start a parachain node for Shibuya.
 #[cfg(not(feature = "evm-tracing"))]
 pub async fn start_shibuya_node(
-    configuration: StartupConfiguration,
-    // parachain_config: Configuration,
-    // polkadot_config: Configuration,
-    // collator_options: CollatorOptions,
-    // id: ParaId,
-    // enable_evm_rpc: bool,
-    // proposer_block_size_limit: Option<usize>,
-    // proposer_soft_deadline_percent: Option<u8>,
+    parachain_config: Configuration,
+    polkadot_config: Configuration,
+    collator_options: CollatorOptions,
+    id: ParaId,
+    additional_config: AdditionalConfig,
 ) -> sc_service::error::Result<(
     TaskManager,
     Arc<TFullClient<Block, shibuya::RuntimeApi, NativeElseWasmExecutor<shibuya::Executor>>>,
 )> {
-    start_node_impl::<shibuya::RuntimeApi, shibuya::Executor, _, _>(
-        configuration.parachain_config,
-        configuration.polkadot_config,
-        configuration.collator_options,
-        configuration.id,
-        configuration.enable_evm_rpc,
+       start_node_impl::<shibuya::RuntimeApi, shibuya::Executor, _, _>(
+        parachain_config,
+        polkadot_config,
+        collator_options,
+        id,
+        additional_config.clone(),
         |client,
          block_import,
          config,
@@ -1822,8 +1810,8 @@ pub async fn start_shibuya_node(
                     telemetry.clone(),
                 );
 
-            proposer_factory.set_default_block_size_limit(configuration.proposer_block_size_limit);
-            proposer_factory.set_soft_deadline(Percent::from_percent(configuration.proposer_soft_deadline_percent));
+            proposer_factory.set_default_block_size_limit(additional_config.proposer_block_size_limit);
+            proposer_factory.set_soft_deadline(Percent::from_percent(additional_config.proposer_soft_deadline_percent));
 
             Ok(AuraConsensus::build::<
                 sp_consensus_aura::sr25519::AuthorityPair,
@@ -1844,7 +1832,7 @@ pub async fn start_shibuya_node(
                                     relay_parent,
                                     &relay_chain_for_aura,
                                     &validation_data,
-                                    configuration.id,
+                                    id,
                                 ).await;
                             let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
                             let slot =

--- a/bin/collator/src/parachain/service.rs
+++ b/bin/collator/src/parachain/service.rs
@@ -49,7 +49,9 @@ use substrate_prometheus_endpoint::Registry;
 
 use super::shell_upgrade::*;
 #[cfg(feature = "evm-tracing")]
-use crate::evm_tracing_types::{EthApi as EthApiCmd, EvmTracingConfig};
+use crate::evm_tracing_types::EthApi as EthApiCmd;
+use crate::evm_tracing_types::EvmTracingConfig;
+
 use crate::primitives::*;
 #[cfg(feature = "evm-tracing")]
 use crate::rpc::tracing;
@@ -607,12 +609,15 @@ pub struct StartupConfiguration {
 
     /// Soft deadline limit used by `Proposer`
     pub proposer_soft_deadline_percent: u8,
+
+    /// Additional config requirements
+    pub additional_config: AdditionalConfig,
 }
 
 /// To add additional config to start_xyz_node functions
 pub struct AdditionalConfig {
     /// EVM tracing configuration
-    pub evm_tracing_config: Option<crate::evm_tracing_types::EvmTracingConfig>,
+    pub evm_tracing_config: Option<EvmTracingConfig>,
 }
 
 /// Start a node with the given parachain `Configuration` and relay chain `Configuration`.
@@ -1025,7 +1030,6 @@ where
 #[cfg(feature = "evm-tracing")]
 pub async fn start_astar_node(
     configuration: StartupConfiguration,
-    additional_config: AdditionalConfig,
 ) -> sc_service::error::Result<(
     TaskManager,
     Arc<TFullClient<Block, astar::RuntimeApi, NativeElseWasmExecutor<astar::Executor>>>,
@@ -1033,7 +1037,7 @@ pub async fn start_astar_node(
     start_node_impl::<astar::RuntimeApi, astar::Executor, _, _>(
         configuration.parachain_config,
         configuration.polkadot_config,
-        additional_config.evm_tracing_config.unwrap(),
+        configuration.additional_config.evm_tracing_config.unwrap(),
         configuration.collator_options,
         configuration.id,
         configuration.enable_evm_rpc,
@@ -1157,7 +1161,6 @@ pub async fn start_astar_node(
 #[cfg(not(feature = "evm-tracing"))]
 pub async fn start_astar_node(
     configuration: StartupConfiguration,
-    _additional_config: AdditionalConfig,
 ) -> sc_service::error::Result<(
     TaskManager,
     Arc<TFullClient<Block, astar::RuntimeApi, NativeElseWasmExecutor<astar::Executor>>>,
@@ -1288,7 +1291,6 @@ pub async fn start_astar_node(
 #[cfg(feature = "evm-tracing")]
 pub async fn start_shiden_node(
     configuration: StartupConfiguration,
-    additional_config: AdditionalConfig,
 ) -> sc_service::error::Result<(
     TaskManager,
     Arc<TFullClient<Block, shiden::RuntimeApi, NativeElseWasmExecutor<shiden::Executor>>>,
@@ -1296,7 +1298,7 @@ pub async fn start_shiden_node(
     start_node_impl::<shiden::RuntimeApi, shiden::Executor, _, _>(
         configuration.parachain_config,
         configuration.polkadot_config,
-        additional_config.evm_tracing_config.unwrap(),
+        configuration.additional_config.evm_tracing_config.unwrap(),
         configuration.collator_options,
         configuration.id,
         configuration.enable_evm_rpc,
@@ -1449,7 +1451,6 @@ pub async fn start_shiden_node(
 #[cfg(not(feature = "evm-tracing"))]
 pub async fn start_shiden_node(
     configuration: StartupConfiguration,
-    _additional_config: AdditionalConfig,
 ) -> sc_service::error::Result<(
     TaskManager,
     Arc<TFullClient<Block, shiden::RuntimeApi, NativeElseWasmExecutor<shiden::Executor>>>,
@@ -1617,7 +1618,6 @@ pub async fn start_shibuya_node(
     // enable_evm_rpc: bool,
     // proposer_block_size_limit: Option<usize>,
     // proposer_soft_deadline_percent: Option<u8>,
-    additional_config: AdditionalConfig,
 ) -> sc_service::error::Result<(
     TaskManager,
     Arc<TFullClient<Block, shibuya::RuntimeApi, NativeElseWasmExecutor<shibuya::Executor>>>,
@@ -1625,7 +1625,7 @@ pub async fn start_shibuya_node(
     start_node_impl::<shibuya::RuntimeApi, shibuya::Executor, _, _>(
         configuration.parachain_config,
         configuration.polkadot_config,
-        additional_config.evm_tracing_config.unwrap(),
+        configuration.additional_config.evm_tracing_config.unwrap(),
         configuration.collator_options,
         configuration.id,
         configuration.enable_evm_rpc,
@@ -1754,7 +1754,6 @@ pub async fn start_shibuya_node(
     // enable_evm_rpc: bool,
     // proposer_block_size_limit: Option<usize>,
     // proposer_soft_deadline_percent: Option<u8>,
-    _additional_config: AdditionalConfig,
 ) -> sc_service::error::Result<(
     TaskManager,
     Arc<TFullClient<Block, shibuya::RuntimeApi, NativeElseWasmExecutor<shibuya::Executor>>>,

--- a/bin/collator/src/parachain/service.rs
+++ b/bin/collator/src/parachain/service.rs
@@ -1746,7 +1746,7 @@ pub async fn start_shibuya_node(
     TaskManager,
     Arc<TFullClient<Block, shibuya::RuntimeApi, NativeElseWasmExecutor<shibuya::Executor>>>,
 )> {
-       start_node_impl::<shibuya::RuntimeApi, shibuya::Executor, _, _>(
+    start_node_impl::<shibuya::RuntimeApi, shibuya::Executor, _, _>(
         parachain_config,
         polkadot_config,
         collator_options,

--- a/bin/collator/src/parachain/service.rs
+++ b/bin/collator/src/parachain/service.rs
@@ -593,10 +593,6 @@ pub struct StartupConfiguration {
     /// Relay chain configuration
     pub polkadot_config: Configuration,
 
-    /// EVM tracing configuration
-    #[cfg(feature = "evm-tracing")]
-    pub evm_tracing_config: EvmTracingConfig,
-
     /// Options specific to collators
     pub collator_options: CollatorOptions,
 
@@ -611,6 +607,12 @@ pub struct StartupConfiguration {
 
     /// Soft deadline limit used by `Proposer`
     pub proposer_soft_deadline_percent: u8,
+}
+
+/// To add additional config to start_xyz_node functions
+pub struct AdditionalConfig {
+    /// EVM tracing configuration
+    pub evm_tracing_config: Option<crate::evm_tracing_types::EvmTracingConfig>,
 }
 
 /// Start a node with the given parachain `Configuration` and relay chain `Configuration`.
@@ -1023,6 +1025,7 @@ where
 #[cfg(feature = "evm-tracing")]
 pub async fn start_astar_node(
     configuration: StartupConfiguration,
+    additional_config: AdditionalConfig,
 ) -> sc_service::error::Result<(
     TaskManager,
     Arc<TFullClient<Block, astar::RuntimeApi, NativeElseWasmExecutor<astar::Executor>>>,
@@ -1030,7 +1033,7 @@ pub async fn start_astar_node(
     start_node_impl::<astar::RuntimeApi, astar::Executor, _, _>(
         configuration.parachain_config,
         configuration.polkadot_config,
-        configuration.evm_tracing_config,
+        additional_config.evm_tracing_config.unwrap(),
         configuration.collator_options,
         configuration.id,
         configuration.enable_evm_rpc,
@@ -1153,7 +1156,8 @@ pub async fn start_astar_node(
 /// Start a parachain node for Astar.
 #[cfg(not(feature = "evm-tracing"))]
 pub async fn start_astar_node(
-    configuration: StartupConfiguration
+    configuration: StartupConfiguration,
+    _additional_config: AdditionalConfig,
 ) -> sc_service::error::Result<(
     TaskManager,
     Arc<TFullClient<Block, astar::RuntimeApi, NativeElseWasmExecutor<astar::Executor>>>,
@@ -1284,6 +1288,7 @@ pub async fn start_astar_node(
 #[cfg(feature = "evm-tracing")]
 pub async fn start_shiden_node(
     configuration: StartupConfiguration,
+    additional_config: AdditionalConfig,
 ) -> sc_service::error::Result<(
     TaskManager,
     Arc<TFullClient<Block, shiden::RuntimeApi, NativeElseWasmExecutor<shiden::Executor>>>,
@@ -1291,7 +1296,7 @@ pub async fn start_shiden_node(
     start_node_impl::<shiden::RuntimeApi, shiden::Executor, _, _>(
         configuration.parachain_config,
         configuration.polkadot_config,
-        configuration.evm_tracing_config,
+        additional_config.evm_tracing_config.unwrap(),
         configuration.collator_options,
         configuration.id,
         configuration.enable_evm_rpc,
@@ -1444,6 +1449,7 @@ pub async fn start_shiden_node(
 #[cfg(not(feature = "evm-tracing"))]
 pub async fn start_shiden_node(
     configuration: StartupConfiguration,
+    _additional_config: AdditionalConfig,
 ) -> sc_service::error::Result<(
     TaskManager,
     Arc<TFullClient<Block, shiden::RuntimeApi, NativeElseWasmExecutor<shiden::Executor>>>,
@@ -1611,6 +1617,7 @@ pub async fn start_shibuya_node(
     // enable_evm_rpc: bool,
     // proposer_block_size_limit: Option<usize>,
     // proposer_soft_deadline_percent: Option<u8>,
+    additional_config: AdditionalConfig,
 ) -> sc_service::error::Result<(
     TaskManager,
     Arc<TFullClient<Block, shibuya::RuntimeApi, NativeElseWasmExecutor<shibuya::Executor>>>,
@@ -1618,7 +1625,7 @@ pub async fn start_shibuya_node(
     start_node_impl::<shibuya::RuntimeApi, shibuya::Executor, _, _>(
         configuration.parachain_config,
         configuration.polkadot_config,
-        configuration.evm_tracing_config,
+        additional_config.evm_tracing_config.unwrap(),
         configuration.collator_options,
         configuration.id,
         configuration.enable_evm_rpc,
@@ -1747,6 +1754,7 @@ pub async fn start_shibuya_node(
     // enable_evm_rpc: bool,
     // proposer_block_size_limit: Option<usize>,
     // proposer_soft_deadline_percent: Option<u8>,
+    _additional_config: AdditionalConfig,
 ) -> sc_service::error::Result<(
     TaskManager,
     Arc<TFullClient<Block, shibuya::RuntimeApi, NativeElseWasmExecutor<shibuya::Executor>>>,

--- a/bin/collator/src/rpc/tracing.rs
+++ b/bin/collator/src/rpc/tracing.rs
@@ -17,7 +17,7 @@
 // along with Astar. If not, see <http://www.gnu.org/licenses/>.
 
 ///! EVM tracing RPC support.
-use crate::evm_tracing_types::EthApi as EthApiCmd;
+use crate::evm_tracing_types::{EthApi as EthApiCmd, EvmTracingConfig};
 
 use fc_rpc::OverrideHandle;
 use fc_rpc_core::types::FilterPool;
@@ -53,7 +53,7 @@ pub struct SpawnTasksParams<'a, B: BlockT, C, BE> {
 
 /// Spawn the tasks that are required to run a EVM tracing.
 pub fn spawn_tracing_tasks<B, C, BE>(
-    rpc_config: &crate::evm_tracing_types::EvmTracingConfig,
+    rpc_config: &EvmTracingConfig,
     params: SpawnTasksParams<B, C, BE>,
 ) -> RpcRequesters
 where

--- a/bin/collator/src/rpc/tracing.rs
+++ b/bin/collator/src/rpc/tracing.rs
@@ -17,7 +17,7 @@
 // along with Astar. If not, see <http://www.gnu.org/licenses/>.
 
 ///! EVM tracing RPC support.
-use crate::cli::EthApi as EthApiCmd;
+use crate::evm_tracing_types::EthApi as EthApiCmd;
 
 use fc_rpc::OverrideHandle;
 use fc_rpc_core::types::FilterPool;
@@ -53,7 +53,7 @@ pub struct SpawnTasksParams<'a, B: BlockT, C, BE> {
 
 /// Spawn the tasks that are required to run a EVM tracing.
 pub fn spawn_tracing_tasks<B, C, BE>(
-    rpc_config: &crate::cli::EvmTracingConfig,
+    rpc_config: &crate::evm_tracing_types::EvmTracingConfig,
     params: SpawnTasksParams<B, C, BE>,
 ) -> RpcRequesters
 where


### PR DESCRIPTION
# Pull Request Summary

This PR refactors some of the logic related to `evm-tracing` added in #883  

**Changes**
1.  utilize #[clap(flatten)] to organize EVM tracing related arguments into a single struct `EthApiOptions`
2.  move all `evm-tracing` related type into a separate module `evm-tracing-types.rs`
3. introduce `AdditionalConfiguration` struct for passing on additional arguments to the start_xyz_node functions.
