### PR TITLE
Feat/more xcm simulator tests

### DIFF
--- a/tests/xcm-simulator/src/mocks/mod.rs
+++ b/tests/xcm-simulator/src/mocks/mod.rs
@@ -34,6 +34,7 @@ type ContractBalanceOf<T> = <<T as pallet_contracts::Config>::Currency as Curren
 >>::Balance;
 
 pub const ALICE: sp_runtime::AccountId32 = sp_runtime::AccountId32::new([0xFAu8; 32]);
+pub const BOB: sp_runtime::AccountId32 = sp_runtime::AccountId32::new([0xFBu8; 32]);
 pub const INITIAL_BALANCE: u128 = 1_000_000_000_000_000_000_000_000;
 pub const DAPP_STAKER_REWARD_PER_BLOCK: parachain::Balance = 1_000;
 pub const DAPP_STAKER_DEV_PER_BLOCK: parachain::Balance = 250;

--- a/tests/xcm-simulator/src/mocks/parachain.rs
+++ b/tests/xcm-simulator/src/mocks/parachain.rs
@@ -45,7 +45,7 @@ use sp_runtime::{
 };
 use sp_std::prelude::*;
 
-use super::msg_queue::*;
+use super::{msg_queue::*, relay_chain::XcmPallet};
 use xcm::latest::prelude::{AssetId as XcmAssetId, *};
 use xcm_builder::{
     Account32Hash, AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
@@ -515,8 +515,8 @@ impl xcm_executor::Config for XcmConfig {
         FixedRateOfForeignAsset<XcAssetConfig, ShidenXcmFungibleFeeHandler>,
     );
     type ResponseHandler = ();
-    type AssetTrap = ();
-    type AssetClaims = ();
+    type AssetTrap = XcmPallet;
+    type AssetClaims = XcmPallet;
     type SubscriptionService = ();
 
     type PalletInstancesInfo = AllPalletsWithSystem;

--- a/tests/xcm-simulator/src/mocks/parachain.rs
+++ b/tests/xcm-simulator/src/mocks/parachain.rs
@@ -45,7 +45,7 @@ use sp_runtime::{
 };
 use sp_std::prelude::*;
 
-use super::{msg_queue::*, relay_chain::XcmPallet};
+use super::msg_queue::*;
 use xcm::latest::prelude::{AssetId as XcmAssetId, *};
 use xcm_builder::{
     Account32Hash, AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
@@ -515,8 +515,8 @@ impl xcm_executor::Config for XcmConfig {
         FixedRateOfForeignAsset<XcAssetConfig, ShidenXcmFungibleFeeHandler>,
     );
     type ResponseHandler = ();
-    type AssetTrap = XcmPallet;
-    type AssetClaims = XcmPallet;
+    type AssetTrap = PolkadotXcm;
+    type AssetClaims = PolkadotXcm;
     type SubscriptionService = ();
 
     type PalletInstancesInfo = AllPalletsWithSystem;

--- a/tests/xcm-simulator/src/tests/experimental.rs
+++ b/tests/xcm-simulator/src/tests/experimental.rs
@@ -139,6 +139,10 @@ fn basic_xcmp_transact_outcome_query_response() {
     ParaB::execute_with(|| {
         use parachain::{RuntimeEvent, System};
         // check queue failed events
+        for event in System::events() {
+            println!("{:?}\n", event);
+        }
+
         assert!(System::events().iter().any(|r| matches!(
             r.event,
             RuntimeEvent::MsgQueue(mock_msg_queue::Event::Fail(..))

--- a/tests/xcm-simulator/src/tests/experimental.rs
+++ b/tests/xcm-simulator/src/tests/experimental.rs
@@ -139,10 +139,6 @@ fn basic_xcmp_transact_outcome_query_response() {
     ParaB::execute_with(|| {
         use parachain::{RuntimeEvent, System};
         // check queue failed events
-        for event in System::events() {
-            println!("{:?}\n", event);
-        }
-
         assert!(System::events().iter().any(|r| matches!(
             r.event,
             RuntimeEvent::MsgQueue(mock_msg_queue::Event::Fail(..))

--- a/tests/xcm-simulator/src/tests/fungible_assets.rs
+++ b/tests/xcm-simulator/src/tests/fungible_assets.rs
@@ -870,11 +870,8 @@ fn para_asset_trap_and_claim() {
             parachain::Balances::free_balance(ALICE),
             INITIAL_BALANCE - send_amount
         );
+        // Making sure that Bob doesn't have any free balance before transfer
         assert_eq!(parachain::Balances::free_balance(BOB), 0);
-        println!(
-            "Asset Trapped: {:?}",
-            AssetTraps::<parachain::Runtime>::iter().collect::<Vec<_>>()
-        );
     });
 
     ParaA::execute_with(|| {

--- a/tests/xcm-simulator/src/tests/fungible_assets.rs
+++ b/tests/xcm-simulator/src/tests/fungible_assets.rs
@@ -135,7 +135,7 @@ fn para_to_para_reserve_transfer_and_back_with_extra_native() {
     let para_b_native: MultiLocation = (Parent, Parachain(2)).into();
     let para_b_native_on_para_a = 456;
 
-    let mint_amount = 300000000000000;
+    let mint_amount = 300_000_000_000_000;
 
     let alice = AccountId32 {
         network: None,
@@ -182,13 +182,7 @@ fn para_to_para_reserve_transfer_and_back_with_extra_native() {
         assert_ok!(ParachainPalletXcm::reserve_transfer_assets(
             parachain::RuntimeOrigin::signed(ALICE.into()),
             Box::new((Parent, Parachain(2)).into()),
-            Box::new(
-                AccountId32 {
-                    network: None,
-                    id: ALICE.into(),
-                }
-                .into(),
-            ),
+            Box::new(alice.clone().into(),),
             Box::new((local_asset, send_amount).into()),
             0,
         ));
@@ -244,7 +238,7 @@ fn para_to_para_reserve_transfer_and_back_with_extra_native() {
                     },
                     DepositAsset {
                         assets: All.into(),
-                        beneficiary: alice.clone().into(),
+                        beneficiary: alice.into(),
                     },
                 ]),
             },

--- a/tests/xcm-simulator/src/tests/fungible_assets.rs
+++ b/tests/xcm-simulator/src/tests/fungible_assets.rs
@@ -17,9 +17,7 @@
 // along with Astar. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::mocks::{parachain, relay_chain, *};
-
 use frame_support::{assert_ok, weights::Weight};
-pub use pallet_xcm::AssetTraps;
 use xcm::prelude::*;
 use xcm_simulator::TestExt;
 


### PR DESCRIPTION
# Pull Request Summary
This PR adds more scenarios to current set of XCM simulator tests. Some of them are experimental to explore the PoC with other chains. This is an extension of #903 

**Stable**
- [X] `para_to_para_reserve_transfer_and_back_with_extra_native`
- [X] `add send_relay_asset_to_para_b_with_extra_native`
-  [x] `para_asset_trap_and_claim`
