### PR TITLE
feat: Additional Proxy Types on shiden

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "astar-collator"
-version = "5.5.0"
+version = "5.6.0"
 dependencies = [
  "astar-runtime",
  "async-trait",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "astar-runtime"
-version = "5.5.0"
+version = "5.6.0"
 dependencies = [
  "array-bytes 6.0.0",
  "cumulus-pallet-aura-ext",
@@ -5169,7 +5169,7 @@ checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "local-runtime"
-version = "5.5.0"
+version = "5.6.0"
 dependencies = [
  "array-bytes 6.0.0",
  "fp-rpc",
@@ -11605,7 +11605,7 @@ dependencies = [
 
 [[package]]
 name = "shibuya-runtime"
-version = "5.5.0"
+version = "5.6.0"
 dependencies = [
  "array-bytes 6.0.0",
  "cumulus-pallet-aura-ext",
@@ -11708,7 +11708,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "5.5.0"
+version = "5.6.0"
 dependencies = [
  "array-bytes 6.0.0",
  "cumulus-pallet-aura-ext",

--- a/bin/collator/Cargo.toml
+++ b/bin/collator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-collator"
-version = "5.5.0"
+version = "5.6.0"
 description = "Astar collator implementation in Rust."
 build = "build.rs"
 default-run = "astar-collator"

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-runtime"
-version = "5.5.0"
+version = "5.6.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/local/Cargo.toml
+++ b/runtime/local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-runtime"
-version = "5.5.0"
+version = "5.6.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "5.5.0"
+version = "5.6.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "5.5.0"
+version = "5.6.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -848,19 +848,67 @@ impl pallet_xc_asset_config::Config for Runtime {
     scale_info::TypeInfo,
 )]
 pub enum ProxyType {
+    Any,
+    NonTransfer,
+    Balances,
+    IdentityJudgement,
     CancelProxy,
     DappsStaking,
 }
 
 impl Default for ProxyType {
     fn default() -> Self {
-        Self::CancelProxy
+        Self::Any
     }
 }
 
 impl InstanceFilter<RuntimeCall> for ProxyType {
     fn filter(&self, c: &RuntimeCall) -> bool {
         match self {
+            // Always allowed RuntimeCall::Utility no matter type.
+            // Only transactions allowed by Proxy.filter can be executed
+            _ if matches!(c, RuntimeCall::Utility(..)) => true,
+            ProxyType::Any => true,
+            ProxyType::NonTransfer => {
+                matches!(
+                    c,
+                    RuntimeCall::System(..)
+                        | RuntimeCall::Utility(..)
+                        | RuntimeCall::Identity(..)
+                        | RuntimeCall::Timestamp(..)
+                        | RuntimeCall::Multisig(..)
+                        | RuntimeCall::Proxy(..)
+                        | RuntimeCall::ParachainSystem(..)
+                        | RuntimeCall::ParachainInfo(..)
+                        // Skip entire Balances pallet
+                        | RuntimeCall::Vesting(pallet_vesting::Call::vest{..})
+				        | RuntimeCall::Vesting(pallet_vesting::Call::vest_other{..})
+				        // Specifically omitting Vesting `vested_transfer`, and `force_vested_transfer`
+                        | RuntimeCall::DappsStaking(..)
+                        // Skip entire Assets pallet
+                        | RuntimeCall::CollatorSelection(..)
+                        | RuntimeCall::Session(..)
+                        | RuntimeCall::XcmpQueue(..)
+                        | RuntimeCall::PolkadotXcm(..)
+                        | RuntimeCall::CumulusXcm(..)
+                        | RuntimeCall::DmpQueue(..)
+                        | RuntimeCall::XcAssetConfig(..)
+                        // Skip entire EVM pallet
+                        // Skip entire Ethereum pallet
+                        // Skip entire EthCall pallet
+                        | RuntimeCall::BaseFee(..)
+                        // Skip entire Contracts pallet
+                )
+            },
+            ProxyType::Balances => {
+                matches!(c, RuntimeCall::Balances(..))
+            },
+            ProxyType::IdentityJudgement => {
+                matches!(
+                    c,
+                    RuntimeCall::Identity(pallet_identity::Call::provide_judgement { .. })
+                )
+            },
             ProxyType::CancelProxy => {
                 matches!(
                     c,
@@ -868,17 +916,19 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
                 )
             }
             ProxyType::DappsStaking => {
-                matches!(c, RuntimeCall::DappsStaking(..) | RuntimeCall::Utility(..))
+                matches!(c, RuntimeCall::DappsStaking(..))
             }
         }
     }
 
     fn is_superset(&self, o: &Self) -> bool {
-        match (self, o) {
-            (x, y) if x == y => true,
-            _ => false,
-        }
-    }
+		match (self, o) {
+			(x, y) if x == y => true,
+			(ProxyType::Any, _) => true,
+			(_, ProxyType::Any) => false,
+			_ => false,
+		}
+	}
 }
 
 parameter_types! {

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -848,12 +848,20 @@ impl pallet_xc_asset_config::Config for Runtime {
     scale_info::TypeInfo,
 )]
 pub enum ProxyType {
+    /// Allows all runtime calls for proxy account
     Any,
+    /// Allows only NonTransfer runtime calls for proxy account
+    /// To know exact calls check InstanceFilter inmplementation for ProxyTypes
     NonTransfer,
+    /// All Runtime calls from Pallet Balances allowed for proxy account
     Balances,
+    /// All Runtime calls from Pallet Assets allowed for proxy account
     Assets,
+    /// Only provide_judgement call from pallet identity allowed for proxy account
     IdentityJudgement,
+    /// Only reject_announcement call from pallet proxy allowed for proxy account
     CancelProxy,
+    /// All runtime calls from pallet DappStaking allowed for proxy account
     DappsStaking,
 }
 
@@ -869,10 +877,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
             // Always allowed RuntimeCall::Utility no matter type.
             // Only transactions allowed by Proxy.filter can be executed
             _ if matches!(c, RuntimeCall::Utility(..)) => true,
-
-            // Allows all runtime calls for proxy account
             ProxyType::Any => true,
-            // Allows only NonTransfer runtime calls for proxy account
             ProxyType::NonTransfer => {
                 matches!(
                     c,
@@ -902,29 +907,24 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
                         | RuntimeCall::BaseFee(..) // Skip entire Contracts pallet
                 )
             }
-            //All Runtime calls from Pallet Balances allowed for proxy account
             ProxyType::Balances => {
                 matches!(c, RuntimeCall::Balances(..))
             }
-            // All Runtime calls from Pallet Assets allowed for proxy account
             ProxyType::Assets => {
                 matches!(c, RuntimeCall::Assets(..))
             }
-            // Only provide_judgement call from pallet identity allowed for proxy account
             ProxyType::IdentityJudgement => {
                 matches!(
                     c,
                     RuntimeCall::Identity(pallet_identity::Call::provide_judgement { .. })
                 )
             }
-            // Only reject_announcement call from pallet proxy allowed for proxy account
             ProxyType::CancelProxy => {
                 matches!(
                     c,
                     RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement { .. })
                 )
             }
-            // All runtime calls from pallet DappStaking allowed for proxy account
             ProxyType::DappsStaking => {
                 matches!(c, RuntimeCall::DappsStaking(..))
             }

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -896,19 +896,18 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
                         // Skip entire EVM pallet
                         // Skip entire Ethereum pallet
                         // Skip entire EthCall pallet
-                        | RuntimeCall::BaseFee(..)
-                        // Skip entire Contracts pallet
+                        | RuntimeCall::BaseFee(..) // Skip entire Contracts pallet
                 )
-            },
+            }
             ProxyType::Balances => {
                 matches!(c, RuntimeCall::Balances(..))
-            },
+            }
             ProxyType::IdentityJudgement => {
                 matches!(
                     c,
                     RuntimeCall::Identity(pallet_identity::Call::provide_judgement { .. })
                 )
-            },
+            }
             ProxyType::CancelProxy => {
                 matches!(
                     c,
@@ -922,13 +921,13 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
     }
 
     fn is_superset(&self, o: &Self) -> bool {
-		match (self, o) {
-			(x, y) if x == y => true,
-			(ProxyType::Any, _) => true,
-			(_, ProxyType::Any) => false,
-			_ => false,
-		}
-	}
+        match (self, o) {
+            (x, y) if x == y => true,
+            (ProxyType::Any, _) => true,
+            (_, ProxyType::Any) => false,
+            _ => false,
+        }
+    }
 }
 
 parameter_types! {

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -139,7 +139,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shiden"),
     impl_name: create_runtime_str!("shiden"),
     authoring_version: 1,
-    spec_version: 96,
+    spec_version: 97,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,
@@ -851,6 +851,7 @@ pub enum ProxyType {
     Any,
     NonTransfer,
     Balances,
+    Assets,
     IdentityJudgement,
     CancelProxy,
     DappsStaking,
@@ -873,7 +874,6 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
                 matches!(
                     c,
                     RuntimeCall::System(..)
-                        | RuntimeCall::Utility(..)
                         | RuntimeCall::Identity(..)
                         | RuntimeCall::Timestamp(..)
                         | RuntimeCall::Multisig(..)
@@ -901,6 +901,9 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
             }
             ProxyType::Balances => {
                 matches!(c, RuntimeCall::Balances(..))
+            }
+            ProxyType::Assets => {
+                matches!(c, RuntimeCall::Assets(..))
             }
             ProxyType::IdentityJudgement => {
                 matches!(

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -869,7 +869,10 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
             // Always allowed RuntimeCall::Utility no matter type.
             // Only transactions allowed by Proxy.filter can be executed
             _ if matches!(c, RuntimeCall::Utility(..)) => true,
+
+            // Allows all runtime calls for proxy account
             ProxyType::Any => true,
+            // Allows only NonTransfer runtime calls for proxy account
             ProxyType::NonTransfer => {
                 matches!(
                     c,
@@ -899,24 +902,29 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
                         | RuntimeCall::BaseFee(..) // Skip entire Contracts pallet
                 )
             }
+            //All Runtime calls from Pallet Balances allowed for proxy account
             ProxyType::Balances => {
                 matches!(c, RuntimeCall::Balances(..))
             }
+            // All Runtime calls from Pallet Assets allowed for proxy account
             ProxyType::Assets => {
                 matches!(c, RuntimeCall::Assets(..))
             }
+            // Only provide_judgement call from pallet identity allowed for proxy account
             ProxyType::IdentityJudgement => {
                 matches!(
                     c,
                     RuntimeCall::Identity(pallet_identity::Call::provide_judgement { .. })
                 )
             }
+            // Only reject_announcement call from pallet proxy allowed for proxy account
             ProxyType::CancelProxy => {
                 matches!(
                     c,
                     RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement { .. })
                 )
             }
+            // All runtime calls from pallet DappStaking allowed for proxy account
             ProxyType::DappsStaking => {
                 matches!(c, RuntimeCall::DappsStaking(..))
             }

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -940,6 +940,201 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
         }
     }
 }
+#[cfg(test)]
+mod proxy_test {
+    use super::*;
+    use frame_support::*;
+    use pallet_balances::Call as BalancesCall;
+    use pallet_proxy::Event as ProxyEvent;
+    use pallet_utility::{Call as UtilityCall, Event as UtilityEvent};
+    use sp_runtime::AccountId32;
+
+    type SystemError = frame_system::Error<Runtime>;
+
+    const INITIAL_AMOUNT: u128 = 100_000_000_000_000_000_000;
+    const ALICE: AccountId32 = AccountId32::new([1_u8; 32]);
+    const BOB: AccountId32 = AccountId32::new([2_u8; 32]);
+    const CAT: AccountId32 = AccountId32::new([3_u8; 32]);
+
+    pub fn new_test_ext() -> sp_io::TestExternalities {
+        let mut t = frame_system::GenesisConfig::default()
+            .build_storage::<Runtime>()
+            .unwrap();
+        pallet_balances::GenesisConfig::<Runtime> {
+            balances: vec![
+                (ALICE, INITIAL_AMOUNT),
+                (BOB, INITIAL_AMOUNT),
+                (CAT, INITIAL_AMOUNT),
+            ],
+        }
+        .assimilate_storage(&mut t)
+        .unwrap();
+        let mut ext = sp_io::TestExternalities::new(t);
+        ext.execute_with(|| System::set_block_number(1));
+        ext
+    }
+
+    fn last_events(n: usize) -> Vec<RuntimeEvent> {
+        frame_system::Pallet::<Runtime>::events()
+            .into_iter()
+            .rev()
+            .take(n)
+            .rev()
+            .map(|e| e.event)
+            .collect()
+    }
+
+    fn expect_events(e: Vec<RuntimeEvent>) {
+        assert_eq!(last_events(e.len()), e);
+    }
+
+    #[test]
+    fn test_utility_call_pass_for_any() {
+        new_test_ext().execute_with(|| {
+            // Any proxy should be allowed to make balance transfer call
+            assert_ok!(Proxy::add_proxy(
+                RuntimeOrigin::signed(ALICE),
+                sp_runtime::MultiAddress::Id(BOB),
+                ProxyType::Any,
+                0
+            ));
+
+            // Preparing Utility call
+            let transfer_call = RuntimeCall::Balances(BalancesCall::transfer {
+                dest: sp_runtime::MultiAddress::Id(CAT),
+                value: 100_000_000_000,
+            });
+            let inner = Box::new(transfer_call);
+            let call = Box::new(RuntimeCall::Utility(UtilityCall::batch {
+                calls: vec![*inner],
+            }));
+
+            // Utility call passed through filter
+            assert_ok!(Proxy::proxy(
+                RuntimeOrigin::signed(BOB),
+                sp_runtime::MultiAddress::Id(ALICE),
+                None,
+                call.clone()
+            ));
+            expect_events(vec![
+                UtilityEvent::BatchCompleted.into(),
+                ProxyEvent::ProxyExecuted { result: Ok(()) }.into(),
+            ]);
+        });
+    }
+    #[test]
+    fn test_utility_call_pass_for_balances() {
+        new_test_ext().execute_with(|| {
+            // Balances proxy should be allowed to make balance transfer call
+            assert_ok!(Proxy::add_proxy(
+                RuntimeOrigin::signed(ALICE),
+                sp_runtime::MultiAddress::Id(BOB),
+                ProxyType::Balances,
+                0
+            ));
+
+            // Preparing Utility call
+            let transfer_call = RuntimeCall::Balances(BalancesCall::transfer {
+                dest: sp_runtime::MultiAddress::Id(CAT),
+                value: 100_000_000_000,
+            });
+            let inner = Box::new(transfer_call);
+            let call = Box::new(RuntimeCall::Utility(UtilityCall::batch {
+                calls: vec![*inner],
+            }));
+
+            // Utility call passed through filter
+            assert_ok!(Proxy::proxy(
+                RuntimeOrigin::signed(BOB),
+                sp_runtime::MultiAddress::Id(ALICE),
+                None,
+                call.clone()
+            ));
+            expect_events(vec![
+                UtilityEvent::BatchCompleted.into(),
+                ProxyEvent::ProxyExecuted { result: Ok(()) }.into(),
+            ]);
+        });
+    }
+
+    #[test]
+    fn test_utility_call_fail_non_transfer() {
+        new_test_ext().execute_with(|| {
+            // NonTransfer proxy shouldn't be allowed to make balance transfer call
+            assert_ok!(Proxy::add_proxy(
+                RuntimeOrigin::signed(ALICE),
+                sp_runtime::MultiAddress::Id(BOB),
+                ProxyType::NonTransfer,
+                0
+            ));
+
+            // Preparing Utility call
+            let transfer_call = RuntimeCall::Balances(BalancesCall::transfer {
+                dest: sp_runtime::MultiAddress::Id(CAT),
+                value: 100_000_000_000,
+            });
+            let inner = Box::new(transfer_call);
+            let call = Box::new(RuntimeCall::Utility(UtilityCall::batch {
+                calls: vec![*inner],
+            }));
+
+            assert_ok!(Proxy::proxy(
+                RuntimeOrigin::signed(BOB),
+                sp_runtime::MultiAddress::Id(ALICE),
+                None,
+                call.clone()
+            ));
+
+            // Utility call filtered out
+            expect_events(vec![
+                UtilityEvent::BatchInterrupted {
+                    index: 0,
+                    error: SystemError::CallFiltered.into(),
+                }
+                .into(),
+                ProxyEvent::ProxyExecuted { result: Ok(()) }.into(),
+            ]);
+        });
+    }
+    #[test]
+    fn test_utility_call_fail_for_dappstaking() {
+        new_test_ext().execute_with(|| {
+            // Dappstaking proxy shouldn't be allowed to make balance transfer call
+            assert_ok!(Proxy::add_proxy(
+                RuntimeOrigin::signed(ALICE),
+                sp_runtime::MultiAddress::Id(BOB),
+                ProxyType::DappsStaking,
+                0
+            ));
+
+            // Preparing Utility call
+            let transfer_call = RuntimeCall::Balances(BalancesCall::transfer {
+                dest: sp_runtime::MultiAddress::Id(CAT),
+                value: 100_000_000_000,
+            });
+            let inner = Box::new(transfer_call);
+            let call = Box::new(RuntimeCall::Utility(UtilityCall::batch {
+                calls: vec![*inner],
+            }));
+
+            assert_ok!(Proxy::proxy(
+                RuntimeOrigin::signed(BOB),
+                sp_runtime::MultiAddress::Id(ALICE),
+                None,
+                call.clone()
+            ));
+            // Utility call filtered out
+            expect_events(vec![
+                UtilityEvent::BatchInterrupted {
+                    index: 0,
+                    error: SystemError::CallFiltered.into(),
+                }
+                .into(),
+                ProxyEvent::ProxyExecuted { result: Ok(()) }.into(),
+            ]);
+        });
+    }
+}
 
 parameter_types! {
     // One storage item; key size 32, value size 8; .


### PR DESCRIPTION
# Pull Request Summary

This PR adds new proxy types on Shiden. Previous Iteration: #778 
Related #760 

## Previous Proxy Types
```
    CancelProxy,
    DappsStaking,
 ```
 
 ## Added Types
 ```
    Any,
    NonTransfer,
    Balances,
    IdentityJudgement,
 ```