### PR TITLE
fix: update spec_version

### DIFF
--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -169,7 +169,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shibuya"),
     impl_name: create_runtime_str!("shibuya"),
     authoring_version: 1,
-    spec_version: 98,
+    spec_version: 99,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,


### PR DESCRIPTION
# Pull Request Summary

Updates `spec_version` for Shibuya which should have been included in https://github.com/AstarNetwork/Astar/pull/921
