### PR TITLE
feat: add StakerRewardClaim proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "astar-collator"
-version = "5.8.0"
+version = "5.9.0"
 dependencies = [
  "astar-runtime",
  "async-trait",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "astar-runtime"
-version = "5.8.0"
+version = "5.9.0"
 dependencies = [
  "array-bytes 6.0.0",
  "cumulus-pallet-aura-ext",
@@ -5177,7 +5177,7 @@ checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "local-runtime"
-version = "5.8.0"
+version = "5.9.0"
 dependencies = [
  "array-bytes 6.0.0",
  "fp-rpc",
@@ -11613,7 +11613,7 @@ dependencies = [
 
 [[package]]
 name = "shibuya-runtime"
-version = "5.8.0"
+version = "5.9.0"
 dependencies = [
  "array-bytes 6.0.0",
  "cumulus-pallet-aura-ext",
@@ -11718,7 +11718,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "5.8.0"
+version = "5.9.0"
 dependencies = [
  "array-bytes 6.0.0",
  "cumulus-pallet-aura-ext",

--- a/bin/collator/Cargo.toml
+++ b/bin/collator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-collator"
-version = "5.8.0"
+version = "5.9.0"
 description = "Astar collator implementation in Rust."
 build = "build.rs"
 default-run = "astar-collator"

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-runtime"
-version = "5.8.0"
+version = "5.9.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/local/Cargo.toml
+++ b/runtime/local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-runtime"
-version = "5.8.0"
+version = "5.9.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -91,7 +91,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("local"),
     impl_name: create_runtime_str!("local"),
     authoring_version: 1,
-    spec_version: 1,
+    spec_version: 2,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,
@@ -831,9 +831,12 @@ impl pallet_sudo::Config for Runtime {
 pub enum ProxyType {
     Any,
     NonTransfer,
+    Balances,
+    Assets,
     Governance,
     CancelProxy,
     DappsStaking,
+    StakerRewardClaim,
 }
 
 impl Default for ProxyType {
@@ -845,33 +848,44 @@ impl Default for ProxyType {
 impl InstanceFilter<RuntimeCall> for ProxyType {
     fn filter(&self, c: &RuntimeCall) -> bool {
         match self {
+            // Always allowed RuntimeCall::Utility no matter type.
+            // Only transactions allowed by Proxy.filter can be executed
+            _ if matches!(c, RuntimeCall::Utility(..)) => true,
+            // Allows all runtime calls for proxy account
             ProxyType::Any => true,
+            // Allows only NonTransfer runtime calls for proxy account
             ProxyType::NonTransfer => {
                 matches!(
                     c,
                     RuntimeCall::System(..)
-                        | RuntimeCall::Utility(..)
                         | RuntimeCall::Timestamp(..)
+                        | RuntimeCall::Scheduler(..)
+                        | RuntimeCall::Proxy(..)
                         | RuntimeCall::Grandpa(..)
                         // Skip entire Balances pallet
                         | RuntimeCall::Vesting(pallet_vesting::Call::vest{..})
-                        | RuntimeCall::Vesting(pallet_vesting::Call::vest_other{..})
-                        // Specifically omitting Vesting `vested_transfer`, and `force_vested_transfer`
+				        | RuntimeCall::Vesting(pallet_vesting::Call::vest_other{..})
+				        // Specifically omitting Vesting `vested_transfer`, and `force_vested_transfer`
                         | RuntimeCall::DappsStaking(..)
                         // Skip entire EVM pallet
                         // Skip entire Ethereum pallet
                         // Skip entire EthCall pallet
                         | RuntimeCall::BaseFee(..)
                         // Skip entire Contracts pallet
-                        // Skip entire Assets pallet
-                        | RuntimeCall::Scheduler(..)
                         | RuntimeCall::Democracy(..)
                         | RuntimeCall::Council(..)
                         | RuntimeCall::TechnicalCommittee(..)
                         | RuntimeCall::Treasury(..)
-                        | RuntimeCall::Proxy(..)
                         | RuntimeCall::Xvm(..)
                 )
+            }
+            // All Runtime calls from Pallet Balances allowed for proxy account
+            ProxyType::Balances => {
+                matches!(c, RuntimeCall::Balances(..))
+            }
+            // All Runtime calls from Pallet Assets allowed for proxy account
+            ProxyType::Assets => {
+                matches!(c, RuntimeCall::Assets(..))
             }
             ProxyType::Governance => {
                 matches!(
@@ -880,17 +894,24 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
                         | RuntimeCall::Council(..)
                         | RuntimeCall::TechnicalCommittee(..)
                         | RuntimeCall::Treasury(..)
-                        | RuntimeCall::Utility(..)
                 )
             }
+            // Only reject_announcement call from pallet proxy allowed for proxy account
             ProxyType::CancelProxy => {
                 matches!(
                     c,
                     RuntimeCall::Proxy(pallet_proxy::Call::reject_announcement { .. })
                 )
             }
+            // All runtime calls from pallet DappStaking allowed for proxy account
             ProxyType::DappsStaking => {
-                matches!(c, RuntimeCall::DappsStaking(..) | RuntimeCall::Utility(..))
+                matches!(c, RuntimeCall::DappsStaking(..))
+            }
+            ProxyType::StakerRewardClaim => {
+                matches!(
+                    c,
+                    RuntimeCall::DappsStaking(pallet_dapps_staking::Call::claim_staker { .. })
+                )
             }
         }
     }
@@ -901,6 +922,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
             (ProxyType::Any, _) => true,
             (_, ProxyType::Any) => false,
             (ProxyType::NonTransfer, _) => true,
+            (ProxyType::DappsStaking, ProxyType::StakerRewardClaim) => true,
             _ => false,
         }
     }

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -91,7 +91,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("local"),
     impl_name: create_runtime_str!("local"),
     authoring_version: 1,
-    spec_version: 2,
+    spec_version: 1,
     impl_version: 1,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -829,13 +829,23 @@ impl pallet_sudo::Config for Runtime {
     scale_info::TypeInfo,
 )]
 pub enum ProxyType {
+    /// Allows all runtime calls for proxy account
     Any,
+    /// Allows only NonTransfer runtime calls for proxy account
+    /// To know exact calls check InstanceFilter implementation for ProxyTypes
     NonTransfer,
+    /// All Runtime calls from Pallet Balances allowed for proxy account
     Balances,
+    /// All Runtime calls from Pallet Assets allowed for proxy account
     Assets,
+    /// Only Runtime Calls related to goverance for proxy account
+    /// To know exact calls check InstanceFilter implementation for ProxyTypes
     Governance,
+    /// Only reject_announcement call from pallet proxy allowed for proxy account
     CancelProxy,
+    /// All runtime calls from pallet DappStaking allowed for proxy account
     DappsStaking,
+    /// Only claim_staker call from pallet DappStaking allowed for proxy account
     StakerRewardClaim,
 }
 

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "5.8.0"
+version = "5.9.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -169,7 +169,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shibuya"),
     impl_name: create_runtime_str!("shibuya"),
     authoring_version: 1,
-    spec_version: 100,
+    spec_version: 101,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,
@@ -1048,6 +1048,7 @@ pub enum ProxyType {
     IdentityJudgement,
     CancelProxy,
     DappsStaking,
+    StakerRewardClaim,
 }
 
 impl Default for ProxyType {
@@ -1136,6 +1137,12 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
             ProxyType::DappsStaking => {
                 matches!(c, RuntimeCall::DappsStaking(..))
             }
+            ProxyType::StakerRewardClaim => {
+                matches!(
+                    c,
+                    RuntimeCall::DappsStaking(pallet_dapps_staking::Call::claim_staker { .. })
+                )
+            }
         }
     }
 
@@ -1145,6 +1152,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
             (ProxyType::Any, _) => true,
             (_, ProxyType::Any) => false,
             (ProxyType::NonTransfer, _) => true,
+            (ProxyType::DappsStaking, ProxyType::StakerRewardClaim) => true,
             _ => false,
         }
     }

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -1940,14 +1940,13 @@ cumulus_pallet_parachain_system::register_validate_block! {
 #[cfg(test)]
 mod proxy_test {
     use super::*;
+    use crate::sp_api_hidden_includes_construct_runtime::hidden_include::traits::Hooks;
     use frame_support::*;
     use pallet_balances::Call as BalancesCall;
     use pallet_dapps_staking as DappStakingCall;
     use pallet_proxy::Event as ProxyEvent;
     use pallet_utility::{Call as UtilityCall, Event as UtilityEvent};
     use sp_runtime::AccountId32;
-    use crate::sp_api_hidden_includes_construct_runtime::hidden_include::traits::Hooks;
-
 
     type SystemError = frame_system::Error<Runtime>;
 
@@ -1987,12 +1986,16 @@ mod proxy_test {
     fn expect_events(e: Vec<RuntimeEvent>) {
         assert_eq!(last_events(e.len()), e);
     }
-    
+
     pub fn run_to_block(n: u32) {
         while System::block_number() < n {
-            <pallet_dapps_staking::Pallet<Runtime> as Hooks<BlockNumber>>::on_finalize(System::block_number());
+            <pallet_dapps_staking::Pallet<Runtime> as Hooks<BlockNumber>>::on_finalize(
+                System::block_number(),
+            );
             System::set_block_number(System::block_number() + 1);
-            <pallet_dapps_staking::Pallet<Runtime> as Hooks<BlockNumber>>::on_initialize(System::block_number());
+            <pallet_dapps_staking::Pallet<Runtime> as Hooks<BlockNumber>>::on_initialize(
+                System::block_number(),
+            );
         }
     }
 
@@ -2154,7 +2157,10 @@ mod proxy_test {
             ));
 
             let contract = SmartContract::Evm(H160::repeat_byte(0x01));
-            let staker_reward_claim_call = RuntimeCall::DappsStaking(DappStakingCall::Call::claim_staker { contract_id: contract.clone() });
+            let staker_reward_claim_call =
+                RuntimeCall::DappsStaking(DappStakingCall::Call::claim_staker {
+                    contract_id: contract.clone(),
+                });
             let call = Box::new(staker_reward_claim_call);
 
             // contract must be registered
@@ -2180,11 +2186,7 @@ mod proxy_test {
                 call.clone()
             ));
 
-            expect_events(vec![
-                ProxyEvent::ProxyExecuted { result: Ok(()) }.into(),
-            ]);
+            expect_events(vec![ProxyEvent::ProxyExecuted { result: Ok(()) }.into()]);
         })
     }
-    
-
 }

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -1937,3 +1937,254 @@ cumulus_pallet_parachain_system::register_validate_block! {
     BlockExecutor = cumulus_pallet_aura_ext::BlockExecutor::<Runtime, Executive>,
     CheckInherents = CheckInherents,
 }
+#[cfg(test)]
+mod proxy_test {
+    use super::*;
+    use frame_support::*;
+    use pallet_balances::Call as BalancesCall;
+    use pallet_dapps_staking as DappStakingCall;
+    use pallet_proxy::Event as ProxyEvent;
+    use pallet_utility::{Call as UtilityCall, Event as UtilityEvent};
+    use sp_runtime::AccountId32;
+    use crate::sp_api_hidden_includes_construct_runtime::hidden_include::traits::Hooks;
+
+
+    type SystemError = frame_system::Error<Runtime>;
+
+    const INITIAL_AMOUNT: u128 = 100_000 * SBY;
+    const ALICE: AccountId32 = AccountId32::new([1_u8; 32]);
+    const BOB: AccountId32 = AccountId32::new([2_u8; 32]);
+    const CAT: AccountId32 = AccountId32::new([3_u8; 32]);
+
+    pub fn new_test_ext() -> sp_io::TestExternalities {
+        let mut t = frame_system::GenesisConfig::default()
+            .build_storage::<Runtime>()
+            .unwrap();
+        pallet_balances::GenesisConfig::<Runtime> {
+            balances: vec![
+                (ALICE, INITIAL_AMOUNT),
+                (BOB, INITIAL_AMOUNT),
+                (CAT, INITIAL_AMOUNT),
+            ],
+        }
+        .assimilate_storage(&mut t)
+        .unwrap();
+        let mut ext = sp_io::TestExternalities::new(t);
+        ext.execute_with(|| System::set_block_number(1));
+        ext
+    }
+
+    fn last_events(n: usize) -> Vec<RuntimeEvent> {
+        frame_system::Pallet::<Runtime>::events()
+            .into_iter()
+            .rev()
+            .take(n)
+            .rev()
+            .map(|e| e.event)
+            .collect()
+    }
+
+    fn expect_events(e: Vec<RuntimeEvent>) {
+        assert_eq!(last_events(e.len()), e);
+    }
+    
+    pub fn run_to_block(n: u32) {
+        while System::block_number() < n {
+            <pallet_dapps_staking::Pallet<Runtime> as Hooks<BlockNumber>>::on_finalize(System::block_number());
+            System::set_block_number(System::block_number() + 1);
+            <pallet_dapps_staking::Pallet<Runtime> as Hooks<BlockNumber>>::on_initialize(System::block_number());
+        }
+    }
+
+    #[test]
+    fn test_utility_call_pass_for_any() {
+        new_test_ext().execute_with(|| {
+            // Any proxy should be allowed to make balance transfer call
+            assert_ok!(Proxy::add_proxy(
+                RuntimeOrigin::signed(ALICE),
+                sp_runtime::MultiAddress::Id(BOB),
+                ProxyType::Any,
+                0
+            ));
+
+            // Preparing Utility call
+            let transfer_call = RuntimeCall::Balances(BalancesCall::transfer {
+                dest: sp_runtime::MultiAddress::Id(CAT),
+                value: 100_000_000_000,
+            });
+            let inner = Box::new(transfer_call);
+            let call = Box::new(RuntimeCall::Utility(UtilityCall::batch {
+                calls: vec![*inner],
+            }));
+
+            // Utility call passed through filter
+            assert_ok!(Proxy::proxy(
+                RuntimeOrigin::signed(BOB),
+                sp_runtime::MultiAddress::Id(ALICE),
+                None,
+                call.clone()
+            ));
+            expect_events(vec![
+                UtilityEvent::BatchCompleted.into(),
+                ProxyEvent::ProxyExecuted { result: Ok(()) }.into(),
+            ]);
+        });
+    }
+    #[test]
+    fn test_utility_call_pass_for_balances() {
+        new_test_ext().execute_with(|| {
+            // Balances proxy should be allowed to make balance transfer call
+            assert_ok!(Proxy::add_proxy(
+                RuntimeOrigin::signed(ALICE),
+                sp_runtime::MultiAddress::Id(BOB),
+                ProxyType::Balances,
+                0
+            ));
+
+            // Preparing Utility call
+            let transfer_call = RuntimeCall::Balances(BalancesCall::transfer {
+                dest: sp_runtime::MultiAddress::Id(CAT),
+                value: 100_000_000_000,
+            });
+            let inner = Box::new(transfer_call);
+            let call = Box::new(RuntimeCall::Utility(UtilityCall::batch {
+                calls: vec![*inner],
+            }));
+
+            // Utility call passed through filter
+            assert_ok!(Proxy::proxy(
+                RuntimeOrigin::signed(BOB),
+                sp_runtime::MultiAddress::Id(ALICE),
+                None,
+                call.clone()
+            ));
+            expect_events(vec![
+                UtilityEvent::BatchCompleted.into(),
+                ProxyEvent::ProxyExecuted { result: Ok(()) }.into(),
+            ]);
+        });
+    }
+
+    #[test]
+    fn test_utility_call_fail_non_transfer() {
+        new_test_ext().execute_with(|| {
+            // NonTransfer proxy shouldn't be allowed to make balance transfer call
+            assert_ok!(Proxy::add_proxy(
+                RuntimeOrigin::signed(ALICE),
+                sp_runtime::MultiAddress::Id(BOB),
+                ProxyType::NonTransfer,
+                0
+            ));
+
+            // Preparing Utility call
+            let transfer_call = RuntimeCall::Balances(BalancesCall::transfer {
+                dest: sp_runtime::MultiAddress::Id(CAT),
+                value: 100_000_000_000,
+            });
+            let inner = Box::new(transfer_call);
+            let call = Box::new(RuntimeCall::Utility(UtilityCall::batch {
+                calls: vec![*inner],
+            }));
+
+            assert_ok!(Proxy::proxy(
+                RuntimeOrigin::signed(BOB),
+                sp_runtime::MultiAddress::Id(ALICE),
+                None,
+                call.clone()
+            ));
+
+            // Utility call filtered out
+            expect_events(vec![
+                UtilityEvent::BatchInterrupted {
+                    index: 0,
+                    error: SystemError::CallFiltered.into(),
+                }
+                .into(),
+                ProxyEvent::ProxyExecuted { result: Ok(()) }.into(),
+            ]);
+        });
+    }
+    #[test]
+    fn test_utility_call_fail_for_dappstaking() {
+        new_test_ext().execute_with(|| {
+            // Dappstaking proxy shouldn't be allowed to make balance transfer call
+            assert_ok!(Proxy::add_proxy(
+                RuntimeOrigin::signed(ALICE),
+                sp_runtime::MultiAddress::Id(BOB),
+                ProxyType::DappsStaking,
+                0
+            ));
+
+            // Preparing Utility call
+            let transfer_call = RuntimeCall::Balances(BalancesCall::transfer {
+                dest: sp_runtime::MultiAddress::Id(CAT),
+                value: 100_000_000_000,
+            });
+            let inner = Box::new(transfer_call);
+            let call = Box::new(RuntimeCall::Utility(UtilityCall::batch {
+                calls: vec![*inner],
+            }));
+
+            assert_ok!(Proxy::proxy(
+                RuntimeOrigin::signed(BOB),
+                sp_runtime::MultiAddress::Id(ALICE),
+                None,
+                call.clone()
+            ));
+            // Utility call filtered out
+            expect_events(vec![
+                UtilityEvent::BatchInterrupted {
+                    index: 0,
+                    error: SystemError::CallFiltered.into(),
+                }
+                .into(),
+                ProxyEvent::ProxyExecuted { result: Ok(()) }.into(),
+            ]);
+        });
+    }
+    #[test]
+    fn test_staker_reward_claim_proxy_works() {
+        new_test_ext().execute_with(|| {
+            // Make CAT delegate for StakerRewardClaim proxy
+            assert_ok!(Proxy::add_proxy(
+                RuntimeOrigin::signed(BOB),
+                sp_runtime::MultiAddress::Id(CAT),
+                ProxyType::StakerRewardClaim,
+                0
+            ));
+
+            let contract = SmartContract::Evm(H160::repeat_byte(0x01));
+            let staker_reward_claim_call = RuntimeCall::DappsStaking(DappStakingCall::Call::claim_staker { contract_id: contract.clone() });
+            let call = Box::new(staker_reward_claim_call);
+
+            // contract must be registered
+            assert_ok!(DappsStaking::register(
+                RuntimeOrigin::root(),
+                ALICE.clone(),
+                contract.clone()
+            ));
+
+            // some amount must be staked
+            assert_ok!(DappsStaking::bond_and_stake(
+                RuntimeOrigin::signed(BOB),
+                contract.clone(),
+                20 * SBY
+            ));
+            run_to_block(10);
+
+            // CAT making proxy call on behalf of staker (BOB)
+            assert_ok!(Proxy::proxy(
+                RuntimeOrigin::signed(CAT),
+                sp_runtime::MultiAddress::Id(BOB),
+                None,
+                call.clone()
+            ));
+
+            expect_events(vec![
+                ProxyEvent::ProxyExecuted { result: Ok(()) }.into(),
+            ]);
+        })
+    }
+    
+
+}

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -1040,14 +1040,25 @@ parameter_types! {
     scale_info::TypeInfo,
 )]
 pub enum ProxyType {
+    /// Allows all runtime calls for proxy account
     Any,
+    /// Allows only NonTransfer runtime calls for proxy account
+    /// To know exact calls check InstanceFilter implementation for ProxyTypes
     NonTransfer,
+    /// All Runtime calls from Pallet Balances allowed for proxy account
     Balances,
+    /// All Runtime calls from Pallet Assets allowed for proxy account
     Assets,
+    /// Only Runtime Calls related to goverance for proxy account
+    /// To know exact calls check InstanceFilter implementation for ProxyTypes
     Governance,
+    /// Only provide_judgement call from pallet identity allowed for proxy account
     IdentityJudgement,
+    /// Only reject_announcement call from pallet proxy allowed for proxy account
     CancelProxy,
+    /// All runtime calls from pallet DappStaking allowed for proxy account
     DappsStaking,
+    /// Only claim_staker call from pallet DappStaking allowed for proxy account
     StakerRewardClaim,
 }
 
@@ -1937,6 +1948,7 @@ cumulus_pallet_parachain_system::register_validate_block! {
     BlockExecutor = cumulus_pallet_aura_ext::BlockExecutor::<Runtime, Executive>,
     CheckInherents = CheckInherents,
 }
+
 #[cfg(test)]
 mod proxy_test {
     use super::*;

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "5.8.0"
+version = "5.9.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -1709,13 +1709,13 @@ cumulus_pallet_parachain_system::register_validate_block! {
 #[cfg(test)]
 mod proxy_test {
     use super::*;
+    use crate::sp_api_hidden_includes_construct_runtime::hidden_include::traits::Hooks;
     use frame_support::*;
     use pallet_balances::Call as BalancesCall;
     use pallet_dapps_staking as DappStakingCall;
     use pallet_proxy::Event as ProxyEvent;
     use pallet_utility::{Call as UtilityCall, Event as UtilityEvent};
     use sp_runtime::AccountId32;
-    use crate::sp_api_hidden_includes_construct_runtime::hidden_include::traits::Hooks;
 
     type SystemError = frame_system::Error<Runtime>;
 
@@ -1758,9 +1758,13 @@ mod proxy_test {
 
     pub fn run_to_block(n: u32) {
         while System::block_number() < n {
-            <pallet_dapps_staking::Pallet<Runtime> as Hooks<BlockNumber>>::on_finalize(System::block_number());
+            <pallet_dapps_staking::Pallet<Runtime> as Hooks<BlockNumber>>::on_finalize(
+                System::block_number(),
+            );
             System::set_block_number(System::block_number() + 1);
-            <pallet_dapps_staking::Pallet<Runtime> as Hooks<BlockNumber>>::on_initialize(System::block_number());
+            <pallet_dapps_staking::Pallet<Runtime> as Hooks<BlockNumber>>::on_initialize(
+                System::block_number(),
+            );
         }
     }
 
@@ -1922,7 +1926,10 @@ mod proxy_test {
             ));
 
             let contract = SmartContract::Evm(H160::repeat_byte(0x01));
-            let staker_reward_claim_call = RuntimeCall::DappsStaking(DappStakingCall::Call::claim_staker { contract_id: contract.clone() });
+            let staker_reward_claim_call =
+                RuntimeCall::DappsStaking(DappStakingCall::Call::claim_staker {
+                    contract_id: contract.clone(),
+                });
             let call = Box::new(staker_reward_claim_call);
 
             // contract must be registered
@@ -1948,10 +1955,7 @@ mod proxy_test {
                 call.clone()
             ));
 
-            expect_events(vec![
-                ProxyEvent::ProxyExecuted { result: Ok(()) }.into(),
-            ]);
+            expect_events(vec![ProxyEvent::ProxyExecuted { result: Ok(()) }.into()]);
         })
     }
-    
 }

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -851,7 +851,7 @@ pub enum ProxyType {
     /// Allows all runtime calls for proxy account
     Any,
     /// Allows only NonTransfer runtime calls for proxy account
-    /// To know exact calls check InstanceFilter inmplementation for ProxyTypes
+    /// To know exact calls check InstanceFilter implementation for ProxyTypes
     NonTransfer,
     /// All Runtime calls from Pallet Balances allowed for proxy account
     Balances,

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -1711,13 +1711,15 @@ mod proxy_test {
     use super::*;
     use frame_support::*;
     use pallet_balances::Call as BalancesCall;
+    use pallet_dapps_staking as DappStakingCall;
     use pallet_proxy::Event as ProxyEvent;
     use pallet_utility::{Call as UtilityCall, Event as UtilityEvent};
     use sp_runtime::AccountId32;
+    use crate::sp_api_hidden_includes_construct_runtime::hidden_include::traits::Hooks;
 
     type SystemError = frame_system::Error<Runtime>;
 
-    const INITIAL_AMOUNT: u128 = 100_000_000_000_000_000_000;
+    const INITIAL_AMOUNT: u128 = 100_000 * SDN;
     const ALICE: AccountId32 = AccountId32::new([1_u8; 32]);
     const BOB: AccountId32 = AccountId32::new([2_u8; 32]);
     const CAT: AccountId32 = AccountId32::new([3_u8; 32]);
@@ -1752,6 +1754,14 @@ mod proxy_test {
 
     fn expect_events(e: Vec<RuntimeEvent>) {
         assert_eq!(last_events(e.len()), e);
+    }
+
+    pub fn run_to_block(n: u32) {
+        while System::block_number() < n {
+            <pallet_dapps_staking::Pallet<Runtime> as Hooks<BlockNumber>>::on_finalize(System::block_number());
+            System::set_block_number(System::block_number() + 1);
+            <pallet_dapps_staking::Pallet<Runtime> as Hooks<BlockNumber>>::on_initialize(System::block_number());
+        }
     }
 
     #[test]
@@ -1900,4 +1910,48 @@ mod proxy_test {
             ]);
         });
     }
+    #[test]
+    fn test_staker_reward_claim_proxy_works() {
+        new_test_ext().execute_with(|| {
+            // Make CAT delegate for StakerRewardClaim proxy
+            assert_ok!(Proxy::add_proxy(
+                RuntimeOrigin::signed(BOB),
+                sp_runtime::MultiAddress::Id(CAT),
+                ProxyType::StakerRewardClaim,
+                0
+            ));
+
+            let contract = SmartContract::Evm(H160::repeat_byte(0x01));
+            let staker_reward_claim_call = RuntimeCall::DappsStaking(DappStakingCall::Call::claim_staker { contract_id: contract.clone() });
+            let call = Box::new(staker_reward_claim_call);
+
+            // contract must be registered
+            assert_ok!(DappsStaking::register(
+                RuntimeOrigin::root(),
+                ALICE.clone(),
+                contract.clone()
+            ));
+
+            // some amount must be staked
+            assert_ok!(DappsStaking::bond_and_stake(
+                RuntimeOrigin::signed(BOB),
+                contract.clone(),
+                100 * SDN
+            ));
+            run_to_block(10);
+
+            // CAT making proxy call on behalf of staker (BOB)
+            assert_ok!(Proxy::proxy(
+                RuntimeOrigin::signed(CAT),
+                sp_runtime::MultiAddress::Id(BOB),
+                None,
+                call.clone()
+            ));
+
+            expect_events(vec![
+                ProxyEvent::ProxyExecuted { result: Ok(()) }.into(),
+            ]);
+        })
+    }
+    
 }

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -139,7 +139,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shiden"),
     impl_name: create_runtime_str!("shiden"),
     authoring_version: 1,
-    spec_version: 98,
+    spec_version: 99,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,
@@ -863,6 +863,8 @@ pub enum ProxyType {
     CancelProxy,
     /// All runtime calls from pallet DappStaking allowed for proxy account
     DappsStaking,
+    /// Only claim_staker call from pallet DappStaking allowed for proxy account
+    StakerRewardClaim,
 }
 
 impl Default for ProxyType {
@@ -928,6 +930,12 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
             ProxyType::DappsStaking => {
                 matches!(c, RuntimeCall::DappsStaking(..))
             }
+            ProxyType::StakerRewardClaim => {
+                matches!(
+                    c,
+                    RuntimeCall::DappsStaking(pallet_dapps_staking::Call::claim_staker { .. })
+                )
+            }
         }
     }
 
@@ -936,6 +944,7 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
             (x, y) if x == y => true,
             (ProxyType::Any, _) => true,
             (_, ProxyType::Any) => false,
+            (ProxyType::DappsStaking, ProxyType::StakerRewardClaim) => true,
             _ => false,
         }
     }


### PR DESCRIPTION
## Pull Request Summary
Added a new proxy type StakerRewardClaim.
Only allows claim_staker call (and pallet-utility calls) to be executed.
This is less permissive than existing DappsStaking proxy type and is more appropriate for remote reward claim.

related to #856 


**Check list**
- [ ] updated Astar official documentation
- [X] updated spec version
- [X] updated semver
