### PR TITLE
chore: remove legacy terminated Astar's OnFinality bootnodes

### DIFF
--- a/bin/collator/res/astar.json
+++ b/bin/collator/res/astar.json
@@ -8,7 +8,7 @@
     "/ip4/35.197.38.107/tcp/30333/ws/p2p/12D3KooWHV4YxifTpBkLWPPaF8EfoMSXeGNWWxXqUokGsBGxwioK",
     "/dns/wss-bootnode-02.astar.network/tcp/443/wss/p2p/12D3KooWGrSwcPyA5V9qCR4RiiXZ7ErERiZ6jnpp1PhjYgxP8qSL",
     "/dns/wss-bootnode-03.astar.network/tcp/443/wss/p2p/12D3KooWHV4YxifTpBkLWPPaF8EfoMSXeGNWWxXqUokGsBGxwioK",
-    "/dns4/astar-bootnode-1.p2p.onfinality.io/tcp/29128/ws/p2p/12D3KooWERrQFE8ss7zYfcHp8ULVCc1N7gur7GqZ8ESuZB1Nmioh"
+    "/dns4/astar-bootnode-1-tls.p2p.onfinality.io/tcp/443/wss/p2p/12D3KooWERrQFE8ss7zYfcHp8ULVCc1N7gur7GqZ8ESuZB1Nmioh"
   ],
   "telemetryEndpoints": null,
   "protocolId": "astar",

--- a/bin/collator/res/astar.json
+++ b/bin/collator/res/astar.json
@@ -8,7 +8,7 @@
     "/ip4/35.197.38.107/tcp/30333/ws/p2p/12D3KooWHV4YxifTpBkLWPPaF8EfoMSXeGNWWxXqUokGsBGxwioK",
     "/dns/wss-bootnode-02.astar.network/tcp/443/wss/p2p/12D3KooWGrSwcPyA5V9qCR4RiiXZ7ErERiZ6jnpp1PhjYgxP8qSL",
     "/dns/wss-bootnode-03.astar.network/tcp/443/wss/p2p/12D3KooWHV4YxifTpBkLWPPaF8EfoMSXeGNWWxXqUokGsBGxwioK",
-    "/dns4/node-6877173614090539008-0.p2p.onfinality.io/tcp/29128/ws/p2p/12D3KooWERrQFE8ss7zYfcHp8ULVCc1N7gur7GqZ8ESuZB1Nmioh"
+    "/dns4/astar-bootnode-1.p2p.onfinality.io/tcp/29128/ws/p2p/12D3KooWERrQFE8ss7zYfcHp8ULVCc1N7gur7GqZ8ESuZB1Nmioh"
   ],
   "telemetryEndpoints": null,
   "protocolId": "astar",

--- a/bin/collator/res/astar.json
+++ b/bin/collator/res/astar.json
@@ -8,8 +8,6 @@
     "/ip4/35.197.38.107/tcp/30333/ws/p2p/12D3KooWHV4YxifTpBkLWPPaF8EfoMSXeGNWWxXqUokGsBGxwioK",
     "/dns/wss-bootnode-02.astar.network/tcp/443/wss/p2p/12D3KooWGrSwcPyA5V9qCR4RiiXZ7ErERiZ6jnpp1PhjYgxP8qSL",
     "/dns/wss-bootnode-03.astar.network/tcp/443/wss/p2p/12D3KooWHV4YxifTpBkLWPPaF8EfoMSXeGNWWxXqUokGsBGxwioK",
-    "/dns4/node-6877180792046243840-0.p2p.onfinality.io/tcp/19932/ws/p2p/12D3KooWARXaG1Ft65ZgCPK8isSg1UBLASQenrH9sJsjEYEDAvQf",
-    "/dns4/node-6877173450521071616-0.p2p.onfinality.io/tcp/12708/ws/p2p/12D3KooWFPbDQjtCXhRjsvu1HCqTrSc6KEazEnETLPQMS4gDpoQq",
     "/dns4/node-6877173614090539008-0.p2p.onfinality.io/tcp/29128/ws/p2p/12D3KooWERrQFE8ss7zYfcHp8ULVCc1N7gur7GqZ8ESuZB1Nmioh"
   ],
   "telemetryEndpoints": null,

--- a/bin/collator/res/astar.raw.json
+++ b/bin/collator/res/astar.raw.json
@@ -8,7 +8,7 @@
     "/ip4/35.197.38.107/tcp/30333/ws/p2p/12D3KooWHV4YxifTpBkLWPPaF8EfoMSXeGNWWxXqUokGsBGxwioK",
     "/dns/wss-bootnode-02.astar.network/tcp/443/wss/p2p/12D3KooWGrSwcPyA5V9qCR4RiiXZ7ErERiZ6jnpp1PhjYgxP8qSL",
     "/dns/wss-bootnode-03.astar.network/tcp/443/wss/p2p/12D3KooWHV4YxifTpBkLWPPaF8EfoMSXeGNWWxXqUokGsBGxwioK",
-    "/dns4/astar-bootnode-1.p2p.onfinality.io/tcp/29128/ws/p2p/12D3KooWERrQFE8ss7zYfcHp8ULVCc1N7gur7GqZ8ESuZB1Nmioh"
+    "/dns4/astar-bootnode-1-tls.p2p.onfinality.io/tcp/443/wss/p2p/12D3KooWERrQFE8ss7zYfcHp8ULVCc1N7gur7GqZ8ESuZB1Nmioh"
   ],
   "telemetryEndpoints": null,
   "protocolId": "astar",

--- a/bin/collator/res/astar.raw.json
+++ b/bin/collator/res/astar.raw.json
@@ -8,7 +8,7 @@
     "/ip4/35.197.38.107/tcp/30333/ws/p2p/12D3KooWHV4YxifTpBkLWPPaF8EfoMSXeGNWWxXqUokGsBGxwioK",
     "/dns/wss-bootnode-02.astar.network/tcp/443/wss/p2p/12D3KooWGrSwcPyA5V9qCR4RiiXZ7ErERiZ6jnpp1PhjYgxP8qSL",
     "/dns/wss-bootnode-03.astar.network/tcp/443/wss/p2p/12D3KooWHV4YxifTpBkLWPPaF8EfoMSXeGNWWxXqUokGsBGxwioK",
-    "/dns4/node-6877173614090539008-0.p2p.onfinality.io/tcp/29128/ws/p2p/12D3KooWERrQFE8ss7zYfcHp8ULVCc1N7gur7GqZ8ESuZB1Nmioh"
+    "/dns4/astar-bootnode-1.p2p.onfinality.io/tcp/29128/ws/p2p/12D3KooWERrQFE8ss7zYfcHp8ULVCc1N7gur7GqZ8ESuZB1Nmioh"
   ],
   "telemetryEndpoints": null,
   "protocolId": "astar",

--- a/bin/collator/res/astar.raw.json
+++ b/bin/collator/res/astar.raw.json
@@ -8,8 +8,6 @@
     "/ip4/35.197.38.107/tcp/30333/ws/p2p/12D3KooWHV4YxifTpBkLWPPaF8EfoMSXeGNWWxXqUokGsBGxwioK",
     "/dns/wss-bootnode-02.astar.network/tcp/443/wss/p2p/12D3KooWGrSwcPyA5V9qCR4RiiXZ7ErERiZ6jnpp1PhjYgxP8qSL",
     "/dns/wss-bootnode-03.astar.network/tcp/443/wss/p2p/12D3KooWHV4YxifTpBkLWPPaF8EfoMSXeGNWWxXqUokGsBGxwioK",
-    "/dns4/node-6877180792046243840-0.p2p.onfinality.io/tcp/19932/ws/p2p/12D3KooWARXaG1Ft65ZgCPK8isSg1UBLASQenrH9sJsjEYEDAvQf",
-    "/dns4/node-6877173450521071616-0.p2p.onfinality.io/tcp/12708/ws/p2p/12D3KooWFPbDQjtCXhRjsvu1HCqTrSc6KEazEnETLPQMS4gDpoQq",
     "/dns4/node-6877173614090539008-0.p2p.onfinality.io/tcp/29128/ws/p2p/12D3KooWERrQFE8ss7zYfcHp8ULVCc1N7gur7GqZ8ESuZB1Nmioh"
   ],
   "telemetryEndpoints": null,


### PR DESCRIPTION
**Pull Request Summary**


**Check list**
- [ ] added or updated unit tests
- [ ] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [ ] updated spec version
- [ ] updated semver
