### PR TITLE
FreeBalance as default dapp-staking reward destination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "astar-collator"
-version = "5.12.0"
+version = "5.13.0"
 dependencies = [
  "astar-primitives",
  "astar-runtime",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "astar-runtime"
-version = "5.12.0"
+version = "5.13.0"
 dependencies = [
  "array-bytes 6.1.0",
  "astar-primitives",
@@ -6917,7 +6917,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-dapps-staking"
-version = "3.9.0"
+version = "3.10.0"
 dependencies = [
  "astar-primitives",
  "frame-benchmarking",
@@ -12018,7 +12018,7 @@ dependencies = [
 
 [[package]]
 name = "shibuya-runtime"
-version = "5.12.0"
+version = "5.13.0"
 dependencies = [
  "array-bytes 6.1.0",
  "astar-primitives",
@@ -12126,7 +12126,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "5.12.0"
+version = "5.13.0"
 dependencies = [
  "array-bytes 6.1.0",
  "astar-primitives",

--- a/bin/collator/Cargo.toml
+++ b/bin/collator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-collator"
-version = "5.12.0"
+version = "5.13.0"
 description = "Astar collator implementation in Rust."
 build = "build.rs"
 default-run = "astar-collator"

--- a/pallets/dapps-staking/Cargo.toml
+++ b/pallets/dapps-staking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-dapps-staking"
-version = "3.9.0"
+version = "3.10.0"
 description = "FRAME pallet to staking for dapps"
 authors.workspace = true
 edition.workspace = true

--- a/pallets/dapps-staking/src/benchmarking.rs
+++ b/pallets/dapps-staking/src/benchmarking.rs
@@ -22,7 +22,7 @@ use super::*;
 use crate::Pallet as DappsStaking;
 
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite, whitelisted_caller};
-use frame_support::traits::{Get, OnFinalize, OnInitialize, Currency};
+use frame_support::traits::{Currency, Get, OnFinalize, OnInitialize};
 use frame_system::{Pallet as System, RawOrigin};
 use sp_runtime::traits::{One, TrailingZeroInput};
 

--- a/pallets/dapps-staking/src/benchmarking.rs
+++ b/pallets/dapps-staking/src/benchmarking.rs
@@ -22,7 +22,7 @@ use super::*;
 use crate::Pallet as DappsStaking;
 
 use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite, whitelisted_caller};
-use frame_support::traits::{Get, OnFinalize, OnInitialize};
+use frame_support::traits::{Get, OnFinalize, OnInitialize, Currency};
 use frame_system::{Pallet as System, RawOrigin};
 use sp_runtime::traits::{One, TrailingZeroInput};
 

--- a/pallets/dapps-staking/src/lib.rs
+++ b/pallets/dapps-staking/src/lib.rs
@@ -541,7 +541,7 @@ pub enum RewardDestination {
 
 impl Default for RewardDestination {
     fn default() -> Self {
-        RewardDestination::StakeBalance
+        RewardDestination::FreeBalance
     }
 }
 

--- a/pallets/dapps-staking/src/lib.rs
+++ b/pallets/dapps-staking/src/lib.rs
@@ -67,7 +67,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use astar_primitives::Balance;
-use frame_support::traits::Currency;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_runtime::{traits::Zero, RuntimeDebug};

--- a/pallets/dapps-staking/src/tests.rs
+++ b/pallets/dapps-staking/src/tests.rs
@@ -17,7 +17,11 @@
 // along with Astar. If not, see <http://www.gnu.org/licenses/>.
 
 use super::{pallet::pallet::Error, pallet::pallet::Event, *};
-use frame_support::{assert_noop, assert_ok, traits::{OnInitialize, Currency}, weights::Weight};
+use frame_support::{
+    assert_noop, assert_ok,
+    traits::{Currency, OnInitialize},
+    weights::Weight,
+};
 use mock::{Balance, Balances, MockSmartContract, *};
 use sp_core::H160;
 use sp_runtime::{

--- a/pallets/dapps-staking/src/tests.rs
+++ b/pallets/dapps-staking/src/tests.rs
@@ -1912,6 +1912,19 @@ fn changing_reward_destination_for_empty_ledger_is_not_ok() {
 }
 
 #[test]
+fn default_reward_destination_is_free_balance() {
+    ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+
+        let staker = 1;
+        assert_eq!(
+            DappsStaking::ledger(&staker).reward_destination,
+            RewardDestination::FreeBalance
+        );
+    });
+}
+
+#[test]
 fn claim_dapp_with_zero_stake_periods_is_ok() {
     ExternalityBuilder::build().execute_with(|| {
         initialize_first_block();

--- a/pallets/dapps-staking/src/tests.rs
+++ b/pallets/dapps-staking/src/tests.rs
@@ -17,7 +17,7 @@
 // along with Astar. If not, see <http://www.gnu.org/licenses/>.
 
 use super::{pallet::pallet::Error, pallet::pallet::Event, *};
-use frame_support::{assert_noop, assert_ok, traits::OnInitialize, weights::Weight};
+use frame_support::{assert_noop, assert_ok, traits::{OnInitialize, Currency}, weights::Weight};
 use mock::{Balance, Balances, MockSmartContract, *};
 use sp_core::H160;
 use sp_runtime::{

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-runtime"
-version = "5.12.0"
+version = "5.13.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -141,7 +141,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("astar"),
     impl_name: create_runtime_str!("astar"),
     authoring_version: 1,
-    spec_version: 62,
+    spec_version: 63,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "5.12.0"
+version = "5.13.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -164,7 +164,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shibuya"),
     impl_name: create_runtime_str!("shibuya"),
     authoring_version: 1,
-    spec_version: 102,
+    spec_version: 103,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "5.12.0"
+version = "5.13.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -143,7 +143,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shiden"),
     impl_name: create_runtime_str!("shiden"),
     authoring_version: 1,
-    spec_version: 102,
+    spec_version: 103,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/tests/xcm-simulator/src/tests/general.rs
+++ b/tests/xcm-simulator/src/tests/general.rs
@@ -207,6 +207,10 @@ fn remote_dapps_staking_staker_claim() {
             smart_contract.clone(),
             stake_amount,
         ));
+        assert_ok!(parachain::DappsStaking::set_reward_destination(
+            parachain::RuntimeOrigin::signed(ALICE),
+            pallet_dapps_staking::RewardDestination::StakeBalance,
+        ));
 
         // advance enough blocks so we at least get to era 4
         advance_parachain_block_to(20);


### PR DESCRIPTION
**Pull Request Summary**

Changes default reward destination from `StakeBalance` to `FreeBalance` for dApp staking.
Applies to all runtimes.

**Check list**
- [x] added or updated unit tests
- [x] updated spec version
- [x] updated semver
