### PR TITLE
Remove txpool from non-tracing build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "astar-collator"
-version = "5.16.0"
+version = "5.16.1"
 dependencies = [
  "astar-primitives",
  "astar-runtime",
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "astar-runtime"
-version = "5.16.0"
+version = "5.16.1"
 dependencies = [
  "array-bytes 6.1.0",
  "astar-primitives",
@@ -5475,7 +5475,7 @@ checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "local-runtime"
-version = "5.16.0"
+version = "5.16.1"
 dependencies = [
  "array-bytes 6.1.0",
  "astar-primitives",
@@ -12299,7 +12299,7 @@ dependencies = [
 
 [[package]]
 name = "shibuya-runtime"
-version = "5.16.0"
+version = "5.16.1"
 dependencies = [
  "array-bytes 6.1.0",
  "astar-primitives",
@@ -12407,7 +12407,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "5.16.0"
+version = "5.16.1"
 dependencies = [
  "array-bytes 6.1.0",
  "astar-primitives",

--- a/bin/collator/Cargo.toml
+++ b/bin/collator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-collator"
-version = "5.16.0"
+version = "5.16.1"
 description = "Astar collator implementation in Rust."
 build = "build.rs"
 default-run = "astar-collator"

--- a/bin/collator/src/rpc.rs
+++ b/bin/collator/src/rpc.rs
@@ -20,8 +20,7 @@
 
 use fc_rpc::{
     Eth, EthApiServer, EthBlockDataCacheTask, EthFilter, EthFilterApiServer, EthPubSub,
-    EthPubSubApiServer, Net, NetApiServer, OverrideHandle, TxPool, TxPoolApiServer, Web3,
-    Web3ApiServer,
+    EthPubSubApiServer, Net, NetApiServer, OverrideHandle, TxPool, Web3, Web3ApiServer,
 };
 use fc_rpc_core::types::{FeeHistoryCache, FilterPool};
 use jsonrpsee::RpcModule;
@@ -331,8 +330,6 @@ where
         )
         .into_rpc(),
     )?;
-
-    io.merge(tx_pool.into_rpc())?;
 
     Ok(io)
 }

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-runtime"
-version = "5.16.0"
+version = "5.16.1"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/local/Cargo.toml
+++ b/runtime/local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-runtime"
-version = "5.16.0"
+version = "5.16.1"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "5.16.0"
+version = "5.16.1"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "5.16.0"
+version = "5.16.1"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
**Pull Request Summary**

Removes `tx-pool` when EVM tracing feature flag isn't used.
Otherwise we end up with two tx pool RPCs being created, which causes errors.

**Check list**
- [x] updated semver
