### PR TITLE
Derived remote account scheme update

### DIFF
--- a/runtime/shibuya/src/xcm_config.rs
+++ b/runtime/shibuya/src/xcm_config.rs
@@ -152,7 +152,6 @@ match_types! {
 
 pub type XcmBarrier = (
     TakeWeightCredit,
-    AllowTopLevelPaidExecutionFrom<Everything>,
     // This will first calculate the derived origin, before checking it against the barrier implementation
     WithComputedOrigin<AllowTopLevelPaidExecutionFrom<Everything>, UniversalLocation, ConstU32<8>>,
     // Parent and its plurality get free execution

--- a/runtime/shiden/src/xcm_config.rs
+++ b/runtime/shiden/src/xcm_config.rs
@@ -224,7 +224,6 @@ impl Contains<RuntimeCall> for SafeCallFilter {
 
 pub type XcmBarrier = (
     TakeWeightCredit,
-    AllowTopLevelPaidExecutionFrom<Everything>,
     // This will first calculate the derived origin, before checking it against the barrier implementation
     WithComputedOrigin<AllowTopLevelPaidExecutionFrom<Everything>, UniversalLocation, ConstU32<8>>,
     // Parent and its plurality get free execution


### PR DESCRIPTION
**Pull Request Summary**

Adds new remote account derivation scheme to **Astar**, as well as support for `DescendOrigin` instruction for arbitrary senders.

Also removes duplicated `AllowTopLevelPaidExecutionFrom` config from **Shiden** and **Shibuya**.
