### PR TITLE
Exempt project items from stale check

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,3 +16,4 @@ jobs:
           days-before-pr-stale: 60
           days-before-issue-close: 7
           days-before-pr-close: 14
+          exempt-issue-labels: 'project'


### PR DESCRIPTION
**Pull Request Summary**

Exempts project items from stale check to avoid them being deleted if not worked on for more than a month.

