### PR TITLE
Reduce default PoV size for XCM instructions

### DIFF
--- a/runtime/astar/src/xcm_config.rs
+++ b/runtime/astar/src/xcm_config.rs
@@ -135,8 +135,8 @@ pub type XcmOriginToTransactDispatchOrigin = (
 
 parameter_types! {
     // One XCM operation is 1_000_000_000 weight - almost certainly a conservative estimate.
-    // For the PoV size, we estimate 64 kB per instruction - which will is once again very conservative.
-    pub UnitWeightCost: Weight = Weight::from_parts(1_000_000_000, 64 * 1024);
+    // For the PoV size, we estimate 4 kB per instruction. This will be changed when we benchmark the instructions.
+    pub UnitWeightCost: Weight = Weight::from_parts(1_000_000_000, 4 * 1024);
     pub const MaxInstructions: u32 = 100;
 }
 

--- a/runtime/shibuya/src/xcm_config.rs
+++ b/runtime/shibuya/src/xcm_config.rs
@@ -137,8 +137,8 @@ pub type XcmOriginToTransactDispatchOrigin = (
 
 parameter_types! {
     // One XCM operation is 1_000_000_000 weight - almost certainly a conservative estimate.
-    // For the PoV size, we estimate 64 kB per instruction - which will is once again very conservative.
-    pub UnitWeightCost: Weight = Weight::from_parts(1_000_000_000, 64 * 1024);
+    // For the PoV size, we estimate 4 kB per instruction. This will be changed when we benchmark the instructions.
+    pub UnitWeightCost: Weight = Weight::from_parts(1_000_000_000, 4 * 1024);
     pub const MaxInstructions: u32 = 100;
 }
 

--- a/runtime/shiden/src/xcm_config.rs
+++ b/runtime/shiden/src/xcm_config.rs
@@ -137,8 +137,8 @@ pub type XcmOriginToTransactDispatchOrigin = (
 
 parameter_types! {
     // One XCM operation is 1_000_000_000 weight - almost certainly a conservative estimate.
-    // For the PoV size, we estimate 64 kB per instruction - which will is once again very conservative.
-    pub UnitWeightCost: Weight = Weight::from_parts(1_000_000_000, 64 * 1024);
+    // For the PoV size, we estimate 4 kB per instruction. This will be changed when we benchmark the instructions.
+    pub UnitWeightCost: Weight = Weight::from_parts(1_000_000_000, 4 * 1024);
     pub const MaxInstructions: u32 = 100;
 }
 


### PR DESCRIPTION
**Pull Request Summary**

Reduce default PoV size for XCM instructions.
This will soon be updated again with benchmarked values.
