### PR TITLE
dApp staking v3 - part 3

### DIFF
--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -535,6 +535,10 @@ pub mod pallet {
 
             // TODO: might require some modification later on, like additional checks to ensure contract can be unregistered.
 
+            // TODO2: we should remove staked amount from appropriate entries, since contract has been 'invalidated'
+
+            // TODO3: will need to add a call similar to what we have in DSv2, for stakers to 'unstake_from_unregistered_contract'
+
             Self::deposit_event(Event::<T>::DAppUnregistered {
                 smart_contract,
                 era: current_era,

--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -567,6 +567,44 @@ pub mod pallet {
 
             Ok(())
         }
+
+        /// TODO
+        #[pallet::call_index(9)]
+        #[pallet::weight(Weight::zero())]
+        pub fn stake(
+            origin: OriginFor<T>,
+            smart_contract: T::SmartContract,
+            #[pallet::compact] amount: Balance,
+        ) -> DispatchResult {
+            Self::ensure_pallet_enabled()?;
+            let account = ensure_signed(origin)?;
+
+            ensure!(
+                Self::is_active(&smart_contract),
+                Error::<T>::NotOperatedDApp
+            );
+
+            let protocol_state = ActiveProtocolState::<T>::get();
+            let mut ledger = Ledger::<T>::get(&account);
+
+            // is it voting or b&e period?
+            // how much does user have available for staking?
+            // has user claimed past rewards? Can we force them to do it before they start staking again?
+
+            Ok(())
+        }
+
+        /// TODO
+        #[pallet::call_index(10)]
+        #[pallet::weight(Weight::zero())]
+        pub fn unstake(
+            origin: OriginFor<T>,
+            smart_contract: T::SmartContract,
+            #[pallet::compact] amount: Balance,
+        ) -> DispatchResult {
+            Self::ensure_pallet_enabled()?;
+            Ok(())
+        }
     }
 
     impl<T: Config> Pallet<T> {
@@ -608,6 +646,12 @@ pub mod pallet {
                 );
                 Ledger::<T>::insert(account, ledger);
             }
+        }
+
+        /// `true` if smart contract is active, `false` if it has been unregistered.
+        fn is_active(smart_contract: &T::SmartContract) -> bool {
+            IntegratedDApps::<T>::get(smart_contract)
+                .map_or(false, |dapp_info| dapp_info.state == DAppState::Registered)
         }
     }
 }

--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -94,7 +94,7 @@ pub mod pallet {
         type StandardEraLength: Get<Self::BlockNumber>;
 
         /// Length of the `Voting` period in standard eras.
-        /// Although `Voting` period only consumes one 'era', we still measure it's length in standard eras
+        /// Although `Voting` period only consumes one 'era', we still measure its length in standard eras
         /// for the sake of simplicity & consistency.
         #[pallet::constant]
         type StandardErasPerVotingPeriod: Get<EraNumber>;
@@ -215,9 +215,9 @@ pub mod pallet {
         ZeroAmount,
         /// Total locked amount for staker is below minimum threshold.
         LockedAmountBelowThreshold,
-        /// Cannot add additional locked balance chunks due to size limit.
+        /// Cannot add additional locked balance chunks due to capacity limit.
         TooManyLockedBalanceChunks,
-        /// Cannot add additional unlocking chunks due to size limit
+        /// Cannot add additional unlocking chunks due to capacity limit.
         TooManyUnlockingChunks,
         /// Remaining stake prevents entire balance of starting the unlocking process.
         RemainingStakePreventsFullUnlock,
@@ -229,7 +229,7 @@ pub mod pallet {
         UnavailableStakeFunds,
         /// There are unclaimed rewards remaining from past periods. They should be claimed before staking again.
         UnclaimedRewardsFromPastPeriods,
-        /// Cannot add additional stake chunks due to size limit.
+        /// Cannot add additional stake chunks due to capacity limit.
         TooManyStakeChunks,
         /// An unexpected error occured while trying to stake.
         InternalStakeError,
@@ -675,7 +675,7 @@ pub mod pallet {
 
             // TODO: We should ensure user doesn't unlock everything if they still have storage leftovers (e.g. unclaimed rewards?)
 
-            // TODO2: to make it more  bounded, we could add a limit to how much distinct stake entries an user can have
+            // TODO2: to make it more  bounded, we could add a limit to how much distinct stake entries a user can have
 
             Self::deposit_event(Event::<T>::ClaimedUnlocked { account, amount });
 
@@ -752,6 +752,7 @@ pub mod pallet {
                     }
                     AccountLedgerError::UnavailableStakeFunds => Error::<T>::UnavailableStakeFunds,
                     AccountLedgerError::NoCapacity => Error::<T>::TooManyStakeChunks,
+                    // Defensive check, should never happen
                     _ => Error::<T>::InternalStakeError,
                 })?;
 
@@ -856,6 +857,7 @@ pub mod pallet {
                     _ => Error::<T>::InternalUnstakeError,
                 })?;
 
+            // TODO: if it's full unstake, entry must be removed!
             // 2.
             // Update `StakerInfo` storage with the reduced stake amount on the specified contract.
             let new_staking_info = match StakerInfo::<T>::get(&account, &smart_contract) {

--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -324,14 +324,13 @@ pub mod pallet {
                         // TODO: trigger reward calculation here. This will be implemented later.
 
                         // Switch to `Voting` period if conditions are met.
-                        if protocol_state.period_info.is_ending(next_era) {
+                        if protocol_state.period_info.is_next_period(next_era) {
                             // For the sake of consistency
                             let ending_era = next_era.saturating_add(1);
                             let voting_period_length = Self::blocks_per_voting_period();
                             let next_era_start_block = now.saturating_add(voting_period_length);
 
                             protocol_state.next_period_type(ending_era, next_era_start_block);
-                            protocol_state.period_info.number.saturating_accrue(1);
 
                             // TODO: trigger tier configuration calculation based on internal & external params.
 
@@ -721,7 +720,7 @@ pub mod pallet {
             // Staker always stakes from the NEXT era
             let stake_era = protocol_state.era.saturating_add(1);
             ensure!(
-                !protocol_state.period_info.is_ending(stake_era),
+                !protocol_state.period_info.is_next_period(stake_era),
                 Error::<T>::PeriodEndsInNextEra
             );
 

--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -857,7 +857,6 @@ pub mod pallet {
                     _ => Error::<T>::InternalUnstakeError,
                 })?;
 
-            // TODO: if it's full unstake, entry must be removed!
             // 2.
             // Update `StakerInfo` storage with the reduced stake amount on the specified contract.
             let new_staking_info = match StakerInfo::<T>::get(&account, &smart_contract) {
@@ -897,8 +896,13 @@ pub mod pallet {
             // 5.
             // Update remaining storage entries
             Self::update_ledger(&account, ledger);
-            StakerInfo::<T>::insert(&account, &smart_contract, new_staking_info);
             ContractStake::<T>::insert(&smart_contract, contract_stake_info);
+
+            if new_staking_info.is_empty() {
+                StakerInfo::<T>::remove(&account, &smart_contract);
+            } else {
+                StakerInfo::<T>::insert(&account, &smart_contract, new_staking_info);
+            }
 
             Self::deposit_event(Event::<T>::Unstake {
                 account,

--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -304,7 +304,7 @@ pub mod pallet {
                         let ending_era =
                             next_era.saturating_add(T::BuildAndEarnPeriodLength::get());
                         let build_and_earn_start_block = now.saturating_add(T::EraLength::get());
-                        protocol_state.next_period(ending_era, build_and_earn_start_block);
+                        protocol_state.next_period_type(ending_era, build_and_earn_start_block);
 
                         Some(Event::<T>::NewPeriod {
                             period_type: protocol_state.period_type(),
@@ -320,10 +320,11 @@ pub mod pallet {
                             let ending_era = next_era.saturating_add(1);
                             let voting_period_length = T::EraLength::get()
                                 .saturating_mul(T::VotingPeriodLength::get().into());
-                            let voting_start_block = now
+                            let next_era_start_block = now
                                 .saturating_add(voting_period_length)
                                 .saturating_add(One::one());
-                            protocol_state.next_period(ending_era, voting_start_block);
+                            protocol_state.next_period_type(ending_era, next_era_start_block);
+                            protocol_state.period_info.number.saturating_accrue(1);
 
                             // TODO: trigger tier configuration calculation based on internal & external params.
 

--- a/pallets/dapp-staking-v3/src/test/mock.rs
+++ b/pallets/dapp-staking-v3/src/test/mock.rs
@@ -227,7 +227,7 @@ pub(crate) fn advance_to_next_period() {
 }
 
 /// Advance blocks until next period type has been reached.
-pub(crate) fn _advance_to_next_period_type() {
+pub(crate) fn advance_to_next_period_type() {
     let period_type = ActiveProtocolState::<Test>::get().period_type();
     while ActiveProtocolState::<Test>::get().period_type() == period_type {
         run_for_blocks(1);

--- a/pallets/dapp-staking-v3/src/test/mock.rs
+++ b/pallets/dapp-staking-v3/src/test/mock.rs
@@ -227,7 +227,7 @@ pub(crate) fn advance_to_next_period() {
 }
 
 /// Advance blocks until next period type has been reached.
-pub(crate) fn advance_to_next_period_type() {
+pub(crate) fn _advance_to_next_period_type() {
     let period_type = ActiveProtocolState::<Test>::get().period_type();
     while ActiveProtocolState::<Test>::get().period_type() == period_type {
         run_for_blocks(1);

--- a/pallets/dapp-staking-v3/src/test/mock.rs
+++ b/pallets/dapp-staking-v3/src/test/mock.rs
@@ -157,8 +157,8 @@ impl ExtBuilder {
             pallet_dapp_staking::ActiveProtocolState::<Test>::put(ProtocolState {
                 era: 1,
                 next_era_start: BlockNumber::from(101_u32),
-                period: 1,
                 period_info: PeriodInfo {
+                    number: 1,
                     period_type: PeriodType::Voting,
                     ending_era: 16,
                 },
@@ -200,5 +200,5 @@ pub(crate) fn advance_to_era(era: EraNumber) {
 /// Function has no effect if period is already passed.
 pub(crate) fn advance_to_period(period: PeriodNumber) {
     // TODO: Properly implement this later when additional logic has been implemented
-    ActiveProtocolState::<Test>::mutate(|state| state.period = period);
+    ActiveProtocolState::<Test>::mutate(|state| state.period_info.number = period);
 }

--- a/pallets/dapp-staking-v3/src/test/mock.rs
+++ b/pallets/dapp-staking-v3/src/test/mock.rs
@@ -157,7 +157,10 @@ impl ExtBuilder {
                 era: 1,
                 next_era_start: BlockNumber::from(101_u32),
                 period: 1,
-                period_type: PeriodType::Voting(16),
+                period_type_and_ending_era: PeriodTypeAndEndingEra {
+                    period_type: PeriodType::Voting,
+                    ending_era: 16,
+                },
                 maintenance: false,
             });
         });

--- a/pallets/dapp-staking-v3/src/test/mock.rs
+++ b/pallets/dapp-staking-v3/src/test/mock.rs
@@ -157,7 +157,7 @@ impl ExtBuilder {
                 era: 1,
                 next_era_start: BlockNumber::from(101_u32),
                 period: 1,
-                period_type_and_ending_era: PeriodTypeAndEndingEra {
+                period_info: PeriodInfo {
                     period_type: PeriodType::Voting,
                     ending_era: 16,
                 },

--- a/pallets/dapp-staking-v3/src/test/mock.rs
+++ b/pallets/dapp-staking-v3/src/test/mock.rs
@@ -109,6 +109,9 @@ impl pallet_dapp_staking::Config for Test {
     type Currency = Balances;
     type SmartContract = MockSmartContract;
     type ManagerOrigin = frame_system::EnsureRoot<AccountId>;
+    type EraLength = ConstU64<8>;
+    type VotingPeriodLength = ConstU32<2>;
+    type BuildAndEarnPeriodLength = ConstU32<4>;
     type MaxNumberOfContracts = ConstU16<10>;
     type MaxLockedChunks = ConstU32<5>;
     type MaxUnlockingChunks = ConstU32<5>;

--- a/pallets/dapp-staking-v3/src/test/mock.rs
+++ b/pallets/dapp-staking-v3/src/test/mock.rs
@@ -115,6 +115,7 @@ impl pallet_dapp_staking::Config for Test {
     type MaxStakingChunks = ConstU32<8>;
     type MinimumLockedAmount = ConstU128<MINIMUM_LOCK_AMOUNT>;
     type UnlockingPeriod = ConstU64<20>;
+    type MinimumStakeAmount = ConstU128<3>;
 }
 
 // TODO: why not just change this to e.g. u32 for test?

--- a/pallets/dapp-staking-v3/src/test/mock.rs
+++ b/pallets/dapp-staking-v3/src/test/mock.rs
@@ -117,6 +117,7 @@ impl pallet_dapp_staking::Config for Test {
     type UnlockingPeriod = ConstU64<20>;
 }
 
+// TODO: why not just change this to e.g. u32 for test?
 #[derive(PartialEq, Eq, Copy, Clone, Encode, Decode, Debug, TypeInfo, MaxEncodedLen, Hash)]
 pub enum MockSmartContract {
     Wasm(AccountId),

--- a/pallets/dapp-staking-v3/src/test/mock.rs
+++ b/pallets/dapp-staking-v3/src/test/mock.rs
@@ -155,14 +155,14 @@ impl ExtBuilder {
             System::set_block_number(1);
             DappStaking::on_initialize(System::block_number());
 
-            // TODO: should pallet handle this?
-            // TODO2: not sure why the mess with type happens here, I can check it later
+            // TODO: not sure why the mess with type happens here, I can check it later
             let era_length: BlockNumber =
                 <<Test as pallet_dapp_staking::Config>::StandardEraLength as sp_core::Get<_>>::get();
             let voting_period_length_in_eras: EraNumber =
                 <<Test as pallet_dapp_staking::Config>::StandardErasPerVotingPeriod as sp_core::Get<_>>::get(
                 );
 
+            // TODO: handle this via GenesisConfig, and some helper functions to set the state
             pallet_dapp_staking::ActiveProtocolState::<Test>::put(ProtocolState {
                 era: 1,
                 next_era_start: era_length.saturating_mul(voting_period_length_in_eras.into()) + 1,

--- a/pallets/dapp-staking-v3/src/test/mock.rs
+++ b/pallets/dapp-staking-v3/src/test/mock.rs
@@ -195,10 +195,20 @@ pub(crate) fn advance_to_era(era: EraNumber) {
     ActiveProtocolState::<Test>::mutate(|state| state.era = era);
 }
 
+/// Advance blocks until next era has been reached.
+pub(crate) fn advance_to_next_era() {
+    advance_to_era(ActiveProtocolState::<Test>::get().era + 1);
+}
+
 /// Advance blocks until the specified period has been reached.
 ///
 /// Function has no effect if period is already passed.
 pub(crate) fn advance_to_period(period: PeriodNumber) {
     // TODO: Properly implement this later when additional logic has been implemented
     ActiveProtocolState::<Test>::mutate(|state| state.period_info.number = period);
+}
+
+/// Advance blocks until next period has been reached.
+pub(crate) fn advance_to_next_period() {
+    advance_to_period(ActiveProtocolState::<Test>::get().period_info.number + 1);
 }

--- a/pallets/dapp-staking-v3/src/test/mock.rs
+++ b/pallets/dapp-staking-v3/src/test/mock.rs
@@ -109,11 +109,10 @@ impl pallet_dapp_staking::Config for Test {
     type Currency = Balances;
     type SmartContract = MockSmartContract;
     type ManagerOrigin = frame_system::EnsureRoot<AccountId>;
-    type EraLength = ConstU64<10>;
-    type VotingPeriodLength = ConstU32<8>;
-    type BuildAndEarnPeriodLength = ConstU32<16>;
+    type StandardEraLength = ConstU64<10>;
+    type StandardErasPerVotingPeriod = ConstU32<8>;
+    type StandardErasPerBuildAndEarnPeriod = ConstU32<16>;
     type MaxNumberOfContracts = ConstU16<10>;
-    type MaxLockedChunks = ConstU32<5>;
     type MaxUnlockingChunks = ConstU32<5>;
     type MaxStakingChunks = ConstU32<8>;
     type MinimumLockedAmount = ConstU128<MINIMUM_LOCK_AMOUNT>;
@@ -159,14 +158,14 @@ impl ExtBuilder {
             // TODO: should pallet handle this?
             // TODO2: not sure why the mess with type happens here, I can check it later
             let era_length: BlockNumber =
-                <<Test as pallet_dapp_staking::Config>::EraLength as sp_core::Get<_>>::get();
+                <<Test as pallet_dapp_staking::Config>::StandardEraLength as sp_core::Get<_>>::get();
             let voting_period_length_in_eras: EraNumber =
-                <<Test as pallet_dapp_staking::Config>::VotingPeriodLength as sp_core::Get<_>>::get(
+                <<Test as pallet_dapp_staking::Config>::StandardErasPerVotingPeriod as sp_core::Get<_>>::get(
                 );
 
             pallet_dapp_staking::ActiveProtocolState::<Test>::put(ProtocolState {
                 era: 1,
-                next_era_start: era_length.saturating_mul(voting_period_length_in_eras.into()),
+                next_era_start: era_length.saturating_mul(voting_period_length_in_eras.into()) + 1,
                 period_info: PeriodInfo {
                     number: 1,
                     period_type: PeriodType::Voting,
@@ -225,4 +224,12 @@ pub(crate) fn advance_to_period(period: PeriodNumber) {
 /// Advance blocks until next period has been reached.
 pub(crate) fn advance_to_next_period() {
     advance_to_period(ActiveProtocolState::<Test>::get().period_number() + 1);
+}
+
+/// Advance blocks until next period type has been reached.
+pub(crate) fn _advance_to_next_period_type() {
+    let period_type = ActiveProtocolState::<Test>::get().period_type();
+    while ActiveProtocolState::<Test>::get().period_type() == period_type {
+        run_for_blocks(1);
+    }
 }

--- a/pallets/dapp-staking-v3/src/test/testing_utils.rs
+++ b/pallets/dapp-staking-v3/src/test/testing_utils.rs
@@ -232,7 +232,7 @@ pub(crate) fn assert_unlock(account: AccountId, amount: Balance) {
     let expected_unlock_amount = {
         // Cannot unlock more than is available
         let possible_unlock_amount = pre_ledger
-            .unlockable_amount(pre_snapshot.active_protocol_state.period)
+            .unlockable_amount(pre_snapshot.active_protocol_state.period_info.number)
             .min(amount);
 
         // When unlocking would take account below the minimum lock threshold, unlock everything
@@ -256,7 +256,7 @@ pub(crate) fn assert_unlock(account: AccountId, amount: Balance) {
     let post_snapshot = MemorySnapshot::new();
 
     // Verify ledger is as expected
-    let period_number = pre_snapshot.active_protocol_state.period;
+    let period_number = pre_snapshot.active_protocol_state.period_info.number;
     let post_ledger = &post_snapshot.ledger[&account];
     assert_eq!(
         pre_ledger.active_locked_amount(),

--- a/pallets/dapp-staking-v3/src/test/testing_utils.rs
+++ b/pallets/dapp-staking-v3/src/test/testing_utils.rs
@@ -529,7 +529,6 @@ pub(crate) fn assert_stake(
     // TODO: since default value is all zeros, maybe we can just skip the branching code and do it once?
     match pre_contract_stake.last_stake_period() {
         Some(last_stake_period) if last_stake_period == stake_period => {
-            assert_eq!(post_contract_stake.len(), pre_contract_stake.len());
             assert_eq!(
                 post_contract_stake.total_staked_amount(stake_period),
                 pre_contract_stake.total_staked_amount(stake_period) + amount,
@@ -557,6 +556,8 @@ pub(crate) fn assert_stake(
     }
     assert_eq!(post_contract_stake.last_stake_period(), Some(stake_period));
     assert_eq!(post_contract_stake.last_stake_era(), Some(stake_era));
+
+    // TODO: expand this check to compare inner slices as well!
 
     // 4. verify era info
     // =========================

--- a/pallets/dapp-staking-v3/src/test/testing_utils.rs
+++ b/pallets/dapp-staking-v3/src/test/testing_utils.rs
@@ -197,14 +197,6 @@ pub(crate) fn assert_lock(account: AccountId, amount: Balance) {
         locked_balance + expected_lock_amount,
         "Locked balance should be increased by the amount locked."
     );
-    assert_eq!(
-        post_snapshot
-            .ledger
-            .get(&account)
-            .expect("Ledger entry has to exist after succcessful lock call")
-            .lock_era(),
-        post_snapshot.active_protocol_state.era + 1
-    );
 
     assert_eq!(
         post_snapshot.current_era_info.total_locked,
@@ -381,10 +373,6 @@ pub(crate) fn assert_relock_unlocking(account: AccountId) {
     assert_eq!(
         post_ledger.active_locked_amount(),
         pre_snapshot.ledger[&account].active_locked_amount() + amount
-    );
-    assert_eq!(
-        post_ledger.lock_era(),
-        post_snapshot.active_protocol_state.era + 1
     );
 
     // Current era info

--- a/pallets/dapp-staking-v3/src/test/testing_utils.rs
+++ b/pallets/dapp-staking-v3/src/test/testing_utils.rs
@@ -237,7 +237,7 @@ pub(crate) fn assert_unlock(account: AccountId, amount: Balance) {
     let expected_unlock_amount = {
         // Cannot unlock more than is available
         let possible_unlock_amount = pre_ledger
-            .unlockable_amount(pre_snapshot.active_protocol_state.period_info.number)
+            .unlockable_amount(pre_snapshot.active_protocol_state.period_number())
             .min(amount);
 
         // When unlocking would take account below the minimum lock threshold, unlock everything
@@ -261,7 +261,7 @@ pub(crate) fn assert_unlock(account: AccountId, amount: Balance) {
     let post_snapshot = MemorySnapshot::new();
 
     // Verify ledger is as expected
-    let period_number = pre_snapshot.active_protocol_state.period_info.number;
+    let period_number = pre_snapshot.active_protocol_state.period_number();
     let post_ledger = &post_snapshot.ledger[&account];
     assert_eq!(
         pre_ledger.active_locked_amount(),
@@ -420,8 +420,8 @@ pub(crate) fn assert_stake(
     let pre_era_info = pre_snapshot.current_era_info;
 
     let stake_era = pre_snapshot.active_protocol_state.era + 1;
-    let stake_period = pre_snapshot.active_protocol_state.period_info.number;
-    let stake_period_type = pre_snapshot.active_protocol_state.period_info.period_type;
+    let stake_period = pre_snapshot.active_protocol_state.period_number();
+    let stake_period_type = pre_snapshot.active_protocol_state.period_type();
 
     // Stake on smart contract & verify event
     assert_ok!(DappStaking::stake(
@@ -596,8 +596,8 @@ pub(crate) fn assert_unstake(
     let pre_era_info = pre_snapshot.current_era_info;
 
     let _unstake_era = pre_snapshot.active_protocol_state.era;
-    let unstake_period = pre_snapshot.active_protocol_state.period_info.number;
-    let unstake_period_type = pre_snapshot.active_protocol_state.period_info.period_type;
+    let unstake_period = pre_snapshot.active_protocol_state.period_number();
+    let unstake_period_type = pre_snapshot.active_protocol_state.period_type();
 
     // Unstake from smart contract & verify event
     assert_ok!(DappStaking::unstake(

--- a/pallets/dapp-staking-v3/src/test/testing_utils.rs
+++ b/pallets/dapp-staking-v3/src/test/testing_utils.rs
@@ -675,9 +675,10 @@ pub(crate) fn assert_unstake(
             "Staked amount must decrease by the 'amount'"
         );
 
-        let is_loyal = !(unstake_period_type == PeriodType::BuildAndEarn
-            && post_staker_info.staked_amount(PeriodType::Voting)
-                < pre_staker_info.staked_amount(PeriodType::Voting));
+        let is_loyal = pre_staker_info.is_loyal()
+            && !(unstake_period_type == PeriodType::BuildAndEarn
+                && post_staker_info.staked_amount(PeriodType::Voting)
+                    < pre_staker_info.staked_amount(PeriodType::Voting));
         assert_eq!(
             post_staker_info.is_loyal(),
             is_loyal,
@@ -722,7 +723,9 @@ pub(crate) fn assert_unstake(
         "Total staked amount for the next era must decrease by 'amount'. No overflow is allowed."
     );
 
-    if pre_era_info.staked_amount_next_era(PeriodType::BuildAndEarn) < amount {
+    if unstake_period_type == PeriodType::BuildAndEarn
+        && pre_era_info.staked_amount_next_era(PeriodType::BuildAndEarn) < amount
+    {
         let overflow = amount - pre_era_info.staked_amount_next_era(PeriodType::BuildAndEarn);
 
         assert!(post_era_info
@@ -735,7 +738,7 @@ pub(crate) fn assert_unstake(
     } else {
         assert_eq!(
             post_era_info.staked_amount_next_era(unstake_period_type),
-            pre_era_info.staked_amount_next_era(unstake_period_type) + amount
+            pre_era_info.staked_amount_next_era(unstake_period_type) - amount
         );
     }
 }

--- a/pallets/dapp-staking-v3/src/test/tests.rs
+++ b/pallets/dapp-staking-v3/src/test/tests.rs
@@ -26,6 +26,9 @@ use crate::{
 use frame_support::{assert_noop, assert_ok, error::BadOrigin, traits::Get};
 use sp_runtime::traits::Zero;
 
+// TODO: test scenarios
+// 1. user is staking, period passes, they can unlock their funds which were previously staked
+
 #[test]
 fn maintenace_mode_works() {
     ExtBuilder::build().execute_with(|| {

--- a/pallets/dapp-staking-v3/src/test/tests.rs
+++ b/pallets/dapp-staking-v3/src/test/tests.rs
@@ -777,6 +777,22 @@ fn stake_basic_example_is_ok() {
 }
 
 #[test]
+fn stake_with_zero_amount_fails() {
+    ExtBuilder::build().execute_with(|| {
+        // Register smart contract & lock some amount
+        let smart_contract = MockSmartContract::default();
+        assert_register(1, &smart_contract);
+        let account = 2;
+        assert_lock(account, 300);
+
+        assert_noop!(
+            DappStaking::stake(RuntimeOrigin::signed(account), smart_contract, 0),
+            Error::<Test>::ZeroAmount,
+        );
+    })
+}
+
+#[test]
 fn stake_on_invalid_dapp_fails() {
     ExtBuilder::build().execute_with(|| {
         let account = 2;

--- a/pallets/dapp-staking-v3/src/test/tests.rs
+++ b/pallets/dapp-staking-v3/src/test/tests.rs
@@ -827,7 +827,7 @@ fn stake_in_final_era_fails() {
 
         // Force Build&Earn period
         ActiveProtocolState::<Test>::mutate(|state| {
-            state.period_type() = PeriodType::BuildAndEarn;
+            state.period_info.period_type = PeriodType::BuildAndEarn;
             state.period_info.ending_era = state.era + 1;
         });
 

--- a/pallets/dapp-staking-v3/src/test/tests.rs
+++ b/pallets/dapp-staking-v3/src/test/tests.rs
@@ -722,7 +722,7 @@ fn stake_basic_example_is_ok() {
         assert_stake(account, &smart_contract, stake_amount_3);
 
         // 3rd scenario - advance era again but create a gap, and then stake
-        advance_to_era(ActiveProtocolState::<Test>::get().era + 3);
+        advance_to_era(ActiveProtocolState::<Test>::get().era + 2);
         let stake_amount_4 = 19;
         assert_stake(account, &smart_contract, stake_amount_4);
 

--- a/pallets/dapp-staking-v3/src/test/tests.rs
+++ b/pallets/dapp-staking-v3/src/test/tests.rs
@@ -368,7 +368,7 @@ fn unlock_basic_example_is_ok() {
         assert_unlock(account, first_unlock_amount);
 
         // Advance era and unlock additional amount
-        advance_to_era(ActiveProtocolState::<Test>::get().era + 1);
+        advance_to_next_era();
         assert_unlock(account, first_unlock_amount);
 
         // Lock a bit more, and unlock again
@@ -384,7 +384,7 @@ fn unlock_with_remaining_amount_below_threshold_is_ok() {
         let account = 2;
         let lock_amount = 101;
         assert_lock(account, lock_amount);
-        advance_to_era(ActiveProtocolState::<Test>::get().era + 1);
+        advance_to_next_era();
         assert_lock(account, lock_amount);
         advance_to_era(ActiveProtocolState::<Test>::get().era + 3);
 
@@ -406,7 +406,7 @@ fn unlock_with_amount_higher_than_avaiable_is_ok() {
         let account = 2;
         let lock_amount = 101;
         assert_lock(account, lock_amount);
-        advance_to_era(ActiveProtocolState::<Test>::get().era + 1);
+        advance_to_next_era();
         assert_lock(account, lock_amount);
 
         // TODO: Hacky, maybe improve later when staking is implemented?
@@ -445,7 +445,7 @@ fn unlock_advanced_examples_are_ok() {
         assert_unlock(account, unlock_amount);
 
         // Advance era and unlock additional amount
-        advance_to_era(ActiveProtocolState::<Test>::get().era + 1);
+        advance_to_next_era();
         assert_unlock(account, unlock_amount * 2);
 
         // Advance few more eras, and unlock everything
@@ -456,7 +456,7 @@ fn unlock_advanced_examples_are_ok() {
             .is_zero());
 
         // Advance one more era and ensure we can still lock & unlock
-        advance_to_era(ActiveProtocolState::<Test>::get().era + 1);
+        advance_to_next_era();
         assert_lock(account, lock_amount);
         assert_unlock(account, unlock_amount);
     })
@@ -468,7 +468,7 @@ fn unlock_everything_with_active_stake_fails() {
         let account = 2;
         let lock_amount = 101;
         assert_lock(account, lock_amount);
-        advance_to_era(ActiveProtocolState::<Test>::get().era + 1);
+        advance_to_next_era();
 
         // We stake so the amount is just below the minimum locked amount, causing full unlock impossible.
         let minimum_locked_amount: Balance =
@@ -500,7 +500,7 @@ fn unlock_with_zero_amount_fails() {
         let account = 2;
         let lock_amount = 101;
         assert_lock(account, lock_amount);
-        advance_to_era(ActiveProtocolState::<Test>::get().era + 1);
+        advance_to_next_era();
 
         // Unlock with zero fails
         assert_noop!(
@@ -711,10 +711,27 @@ fn stake_basic_example_is_ok() {
         let lock_amount = 300;
         assert_lock(account, lock_amount);
 
-        // Stake some amount
-        let first_stake_amount = 100;
-        assert_stake(account, &smart_contract, first_stake_amount);
+        // 1st scenario - stake some amount, and then some more
+        let (stake_amount_1, stake_amount_2) = (31, 29);
+        assert_stake(account, &smart_contract, stake_amount_1);
+        assert_stake(account, &smart_contract, stake_amount_2);
 
-        // continue here
+        // 2nd scenario - stake in the next era
+        advance_to_next_era();
+        let stake_amount_3 = 23;
+        assert_stake(account, &smart_contract, stake_amount_3);
+
+        // 3rd scenario - advance era again but create a gap, and then stake
+        advance_to_era(ActiveProtocolState::<Test>::get().era + 3);
+        let stake_amount_4 = 19;
+        assert_stake(account, &smart_contract, stake_amount_4);
+
+        // 4th scenario - advance period, and stake
+        // TODO: Hacky! Improve this when proper era/period transition handling is implemented!
+        // advance_to_next_era();
+        // advance_to_next_period();
+        // let stake_amount_5 = 17;
+        // assert_stake(account, &smart_contract, stake_amount_5);
+        // TODO: this can only be tested after reward claiming has been implemented!!!
     })
 }

--- a/pallets/dapp-staking-v3/src/test/tests.rs
+++ b/pallets/dapp-staking-v3/src/test/tests.rs
@@ -83,6 +83,22 @@ fn maintenace_mode_call_filtering_works() {
             DappStaking::unlock(RuntimeOrigin::signed(1), 100),
             Error::<Test>::Disabled
         );
+        assert_noop!(
+            DappStaking::claim_unlocked(RuntimeOrigin::signed(1)),
+            Error::<Test>::Disabled
+        );
+        assert_noop!(
+            DappStaking::relock_unlocking(RuntimeOrigin::signed(1)),
+            Error::<Test>::Disabled
+        );
+        assert_noop!(
+            DappStaking::stake(RuntimeOrigin::signed(1), MockSmartContract::default(), 100),
+            Error::<Test>::Disabled
+        );
+        assert_noop!(
+            DappStaking::unstake(RuntimeOrigin::signed(1), MockSmartContract::default(), 100),
+            Error::<Test>::Disabled
+        );
     })
 }
 

--- a/pallets/dapp-staking-v3/src/test/tests.rs
+++ b/pallets/dapp-staking-v3/src/test/tests.rs
@@ -20,7 +20,7 @@ use crate::test::mock::*;
 use crate::test::testing_utils::*;
 use crate::{
     pallet as pallet_dapp_staking, ActiveProtocolState, DAppId, EraNumber, Error, IntegratedDApps,
-    Ledger, NextDAppId, PeriodType,
+    Ledger, NextDAppId, PeriodType, StakerInfo,
 };
 
 use frame_support::{assert_noop, assert_ok, error::BadOrigin, traits::Get};
@@ -993,6 +993,13 @@ fn unstake_basic_example_is_ok() {
         advance_to_era(ActiveProtocolState::<Test>::get().era + 3);
         assert_unstake(account, &smart_contract, unstake_amount_3);
         assert_unstake(account, &smart_contract, unstake_amount_2);
+
+        // 4th scenario - perform a full unstake
+        advance_to_next_era();
+        let full_unstake_amount = StakerInfo::<Test>::get(&account, &smart_contract)
+            .unwrap()
+            .total_staked_amount();
+        assert_unstake(account, &smart_contract, full_unstake_amount);
     })
 }
 

--- a/pallets/dapp-staking-v3/src/test/tests.rs
+++ b/pallets/dapp-staking-v3/src/test/tests.rs
@@ -448,7 +448,7 @@ fn unlock_with_amount_higher_than_avaiable_is_ok() {
                 }])
                 .expect("Only one chunk so creation should succeed."),
             );
-            ledger.staked_period = Some(ActiveProtocolState::<Test>::get().period);
+            ledger.staked_period = Some(ActiveProtocolState::<Test>::get().period_info.number);
         });
 
         // Try to unlock more than is available, due to active staked amount
@@ -456,7 +456,7 @@ fn unlock_with_amount_higher_than_avaiable_is_ok() {
 
         // Ensure there is no effect of staked amount once we move to the following period
         assert_lock(account, lock_amount - stake_amount); // restore previous state
-        advance_to_period(ActiveProtocolState::<Test>::get().period + 1);
+        advance_to_period(ActiveProtocolState::<Test>::get().period_info.number + 1);
         assert_unlock(account, lock_amount - stake_amount + 1);
     })
 }
@@ -512,7 +512,7 @@ fn unlock_everything_with_active_stake_fails() {
                 }])
                 .expect("Only one chunk so creation should succeed."),
             );
-            ledger.staked_period = Some(ActiveProtocolState::<Test>::get().period);
+            ledger.staked_period = Some(ActiveProtocolState::<Test>::get().period_info.number);
         });
 
         // Try to unlock more than is available, due to active staked amount
@@ -547,7 +547,7 @@ fn unlock_with_zero_amount_fails() {
                 }])
                 .expect("Only one chunk so creation should succeed."),
             );
-            ledger.staked_period = Some(ActiveProtocolState::<Test>::get().period);
+            ledger.staked_period = Some(ActiveProtocolState::<Test>::get().period_info.number);
         });
 
         // Try to unlock anything, expect zero amount error

--- a/pallets/dapp-staking-v3/src/test/tests.rs
+++ b/pallets/dapp-staking-v3/src/test/tests.rs
@@ -1007,6 +1007,27 @@ fn unstake_basic_example_is_ok() {
 }
 
 #[test]
+fn unstake_with_leftover_amount_below_minimum_works() {
+    ExtBuilder::build().execute_with(|| {
+        // Register smart contract & lock some amount
+        let dev_account = 1;
+        let smart_contract = MockSmartContract::default();
+        assert_register(dev_account, &smart_contract);
+
+        let account = 2;
+        assert_lock(account, 100);
+
+        // Prep step - stake exactly the minimum staking amount
+        let min_stake_amount: Balance =
+            <Test as pallet_dapp_staking::Config>::MinimumStakeAmount::get();
+        assert_stake(account, &smart_contract, min_stake_amount);
+
+        // Unstake 1, but it must prompt full unstake
+        assert_unstake(account, &smart_contract, 1);
+    })
+}
+
+#[test]
 fn unstake_with_zero_amount_fails() {
     ExtBuilder::build().execute_with(|| {
         // Register smart contract & lock some amount

--- a/pallets/dapp-staking-v3/src/test/tests.rs
+++ b/pallets/dapp-staking-v3/src/test/tests.rs
@@ -483,7 +483,7 @@ fn unlock_with_amount_higher_than_avaiable_is_ok() {
 
         // Ensure there is no effect of staked amount once we move to the following period
         assert_lock(account, lock_amount - stake_amount); // restore previous state
-        advance_to_period(ActiveProtocolState::<Test>::get().period_info.number + 1);
+        advance_to_period(ActiveProtocolState::<Test>::get().period_number() + 1);
         assert_unlock(account, lock_amount - stake_amount + 1);
     })
 }
@@ -827,7 +827,7 @@ fn stake_in_final_era_fails() {
 
         // Force Build&Earn period
         ActiveProtocolState::<Test>::mutate(|state| {
-            state.period_info.period_type = PeriodType::BuildAndEarn;
+            state.period_type() = PeriodType::BuildAndEarn;
             state.period_info.ending_era = state.era + 1;
         });
 
@@ -1137,7 +1137,7 @@ fn unstake_from_past_period_fails() {
         let account = 2;
         assert_lock(account, 300);
 
-        // 1st scenario - stake some amount on the first contract, and try to unstake more than was staked
+        // Stake some amount, and advance to the next period
         let stake_amount = 100;
         assert_stake(account, &smart_contract, stake_amount);
         advance_to_next_period();

--- a/pallets/dapp-staking-v3/src/test/tests.rs
+++ b/pallets/dapp-staking-v3/src/test/tests.rs
@@ -698,3 +698,23 @@ fn relock_unlocking_insufficient_lock_amount_fails() {
         );
     })
 }
+
+#[test]
+fn stake_basic_example_is_ok() {
+    ExtBuilder::build().execute_with(|| {
+        // Register smart contract & lock some amount
+        let dev_account = 1;
+        let smart_contract = MockSmartContract::default();
+        assert_register(dev_account, &smart_contract);
+
+        let account = 2;
+        let lock_amount = 300;
+        assert_lock(account, lock_amount);
+
+        // Stake some amount
+        let first_stake_amount = 100;
+        assert_stake(account, &smart_contract, first_stake_amount);
+
+        // continue here
+    })
+}

--- a/pallets/dapp-staking-v3/src/test/tests_types.rs
+++ b/pallets/dapp-staking-v3/src/test/tests_types.rs
@@ -865,19 +865,30 @@ fn era_info_stake_works() {
     // Add some voting period stake
     let vp_stake_amount = 7;
     era_info.add_stake_amount(vp_stake_amount, PeriodType::Voting);
-    assert_eq!(era_info.total_staked_amount(), vp_stake_amount);
-    assert_eq!(era_info.staked_amount(PeriodType::Voting), vp_stake_amount);
+    assert_eq!(era_info.total_staked_amount_next_era(), vp_stake_amount);
+    assert_eq!(
+        era_info.staked_amount_next_era(PeriodType::Voting),
+        vp_stake_amount
+    );
+    assert!(
+        era_info.total_staked_amount().is_zero(),
+        "Calling stake makes it available only from the next era."
+    );
 
     // Add some build&earn period stake
     let bep_stake_amount = 13;
     era_info.add_stake_amount(bep_stake_amount, PeriodType::BuildAndEarn);
     assert_eq!(
-        era_info.total_staked_amount(),
+        era_info.total_staked_amount_next_era(),
         vp_stake_amount + bep_stake_amount
     );
     assert_eq!(
-        era_info.staked_amount(PeriodType::BuildAndEarn),
+        era_info.staked_amount_next_era(PeriodType::BuildAndEarn),
         bep_stake_amount
+    );
+    assert!(
+        era_info.total_staked_amount().is_zero(),
+        "Calling stake makes it available only from the next era."
     );
 }
 
@@ -1200,28 +1211,28 @@ fn contract_staking_info_series_stake_is_ok() {
     assert_eq!(entry_4_3.total_staked_amount(), amount_3 + amount_4);
 }
 
-// #[test]
-// fn contract_staking_info_series_inconsistent_data_fails() {
-//     let mut series = ContractStakingInfoSeries::default();
+#[test]
+fn contract_staking_info_series_inconsistent_data_fails() {
+    let mut series = ContractStakingInfoSeries::default();
 
-//     // Create an entry with some staked amount
-//     let era = 5;
-//     let period_info = PeriodInfo {
-//         number: 7,
-//         period_type: PeriodType::Voting,
-//         ending_era: 31,
-//     };
-//     let amount = 37;
-//     assert!(series.stake(amount, period_info, era).is_ok());
+    // Create an entry with some staked amount
+    let era = 5;
+    let period_info = PeriodInfo {
+        number: 7,
+        period_type: PeriodType::Voting,
+        ending_era: 31,
+    };
+    let amount = 37;
+    assert!(series.stake(amount, period_info, era).is_ok());
 
-//     // 1st scenario - attempt to stake using old era
-//     assert!(series.stake(amount, period_info, era - 1).is_err());
+    // 1st scenario - attempt to stake using old era
+    assert!(series.stake(amount, period_info, era - 1).is_err());
 
-//     // 2nd scenario - attempt to stake using old period
-//     let period_info = PeriodInfo {
-//         number: period_info.number - 1,
-//         period_type: PeriodType::Voting,
-//         ending_era: 31,
-//     };
-//     assert!(series.stake(amount, period_info, era).is_err());
-// }
+    // 2nd scenario - attempt to stake using old period
+    let period_info = PeriodInfo {
+        number: period_info.number - 1,
+        period_type: PeriodType::Voting,
+        ending_era: 31,
+    };
+    assert!(series.stake(amount, period_info, era).is_err());
+}

--- a/pallets/dapp-staking-v3/src/test/tests_types.rs
+++ b/pallets/dapp-staking-v3/src/test/tests_types.rs
@@ -1133,10 +1133,10 @@ fn contract_staking_info_series_stake_is_ok() {
     assert_eq!(entry_2_2.era(), era_2);
     assert_eq!(entry_2_2.total_staked_amount(), amount * 3);
 
-    // 4th scenario - stake in the 3rd era, expect a cleanup
+    // 4th scenario - stake in the 3rd era
     let era_3 = era_2 + 1;
     assert!(series.stake(amount, period_info, era_3).is_ok());
-    assert_eq!(series.len(), 2, "Old entry should have been cleaned up.");
+    assert_eq!(series.len(), 3, "Old entry should have been cleaned up.");
     let entry_3_1 = *series.get_for_era(era_2).unwrap();
     let entry_3_2 = *series.get_for_era(era_3).unwrap();
     assert_eq!(entry_3_1, entry_2_2);

--- a/pallets/dapp-staking-v3/src/test/tests_types.rs
+++ b/pallets/dapp-staking-v3/src/test/tests_types.rs
@@ -1450,7 +1450,7 @@ fn contract_stake_info_is_ok() {
         bep_stake_amount_1 - bp_reduction
     );
 
-    // 4th scenario - unstake everyhting, and some more, from Build&Earn period, chiping away from the voting period.
+    // 4th scenario - unstake everything, and some more, from Build&Earn period, chiping away from the voting period.
     let overflow = 1;
     let overflow_reduction = contract_stake_info.staked_amount(PeriodType::BuildAndEarn) + overflow;
     contract_stake_info.unstake(overflow_reduction, PeriodType::BuildAndEarn);

--- a/pallets/dapp-staking-v3/src/test/tests_types.rs
+++ b/pallets/dapp-staking-v3/src/test/tests_types.rs
@@ -1012,7 +1012,7 @@ fn add_stake_amount_too_large_amount_fails() {
     // Sanity check
     assert_eq!(
         acc_ledger.add_stake_amount(10, 1, 1),
-        Err(AccountLedgerError::TooLargeStakeAmount)
+        Err(AccountLedgerError::UnavailableStakeFunds)
     );
 
     // Lock some amount, and try to stake more than that
@@ -1022,7 +1022,7 @@ fn add_stake_amount_too_large_amount_fails() {
     assert!(acc_ledger.add_lock_amount(lock_amount, first_era).is_ok());
     assert_eq!(
         acc_ledger.add_stake_amount(lock_amount + 1, first_era, first_period),
-        Err(AccountLedgerError::TooLargeStakeAmount)
+        Err(AccountLedgerError::UnavailableStakeFunds)
     );
 
     // Additional check - have some active stake, and then try to overstake
@@ -1031,12 +1031,12 @@ fn add_stake_amount_too_large_amount_fails() {
         .is_ok());
     assert_eq!(
         acc_ledger.add_stake_amount(3, first_era, first_period),
-        Err(AccountLedgerError::TooLargeStakeAmount)
+        Err(AccountLedgerError::UnavailableStakeFunds)
     );
 }
 
 #[test]
-fn add_stake_amount_exceeding_capacity_fails() {
+fn add_stake_amount_while_exceeding_capacity_fails() {
     get_u32_type!(LockedDummy, 5);
     get_u32_type!(UnlockingDummy, 5);
     get_u32_type!(StakingDummy, 8);

--- a/pallets/dapp-staking-v3/src/types.rs
+++ b/pallets/dapp-staking-v3/src/types.rs
@@ -257,7 +257,7 @@ impl PeriodInfo {
 
     /// `true` if period ends in the provided `era` argument, `false` otherwise
     pub fn is_ending(&self, era: EraNumber) -> bool {
-        self.ending_era == era
+        self.period_type == PeriodType::BuildAndEarn && self.ending_era == era
     }
 }
 

--- a/pallets/dapp-staking-v3/src/types.rs
+++ b/pallets/dapp-staking-v3/src/types.rs
@@ -962,8 +962,8 @@ impl ContractStakingInfoSeries {
 
     /// TODO
     #[cfg(test)]
-    pub fn into_inner(self) -> Vec<ContractStakingInfo> {
-        self.0.into_inner()
+    pub fn inner(&self) -> Vec<ContractStakingInfo> {
+        self.0.clone().into_inner()
     }
 
     /// Length of the series.

--- a/pallets/dapp-staking-v3/src/types.rs
+++ b/pallets/dapp-staking-v3/src/types.rs
@@ -235,6 +235,15 @@ pub enum PeriodType {
     BuildAndEarn,
 }
 
+impl PeriodType {
+    fn next(&self) -> Self {
+        match self {
+            PeriodType::Voting => PeriodType::BuildAndEarn,
+            PeriodType::BuildAndEarn => PeriodType::Voting,
+        }
+    }
+}
+
 /// Wrapper type around current `PeriodType` and era number when it's expected to end.
 #[derive(Encode, Decode, MaxEncodedLen, Clone, Copy, Debug, PartialEq, Eq, TypeInfo)]
 pub struct PeriodInfo {
@@ -303,6 +312,36 @@ where
             },
             maintenance: false,
         }
+    }
+}
+
+impl<BlockNumber> ProtocolState<BlockNumber>
+where
+    BlockNumber: AtLeast32BitUnsigned + MaxEncodedLen,
+{
+    /// TODO
+    pub fn period_type(&self) -> PeriodType {
+        self.period_info.period_type
+    }
+
+    /// TODO
+    pub fn period_number(&self) -> PeriodNumber {
+        self.period_info.number
+    }
+
+    /// TODO
+    pub fn is_new_era(&self, now: BlockNumber) -> bool {
+        self.next_era_start <= now
+    }
+
+    /// TODO
+    pub fn next_period(&mut self, ending_era: EraNumber, next_era_start: BlockNumber) {
+        self.period_info = PeriodInfo {
+            number: self.period_number(),
+            period_type: self.period_type().next(),
+            ending_era,
+        };
+        self.next_era_start = next_era_start;
     }
 }
 

--- a/pallets/dapp-staking-v3/src/types.rs
+++ b/pallets/dapp-staking-v3/src/types.rs
@@ -335,7 +335,7 @@ where
     }
 
     /// TODO
-    pub fn next_period(&mut self, ending_era: EraNumber, next_era_start: BlockNumber) {
+    pub fn next_period_type(&mut self, ending_era: EraNumber, next_era_start: BlockNumber) {
         self.period_info = PeriodInfo {
             number: self.period_number(),
             period_type: self.period_type().next(),

--- a/pallets/dapp-staking-v3/src/types.rs
+++ b/pallets/dapp-staking-v3/src/types.rs
@@ -238,7 +238,7 @@ pub enum PeriodType {
 
 /// Wrapper type around current `PeriodType` and era number when it's expected to end.
 #[derive(Encode, Decode, MaxEncodedLen, Clone, Copy, Debug, PartialEq, Eq, TypeInfo)]
-pub struct PeriodTypeAndEndingEra {
+pub struct PeriodInfo {
     pub period_type: PeriodType,
     #[codec(compact)]
     pub ending_era: EraNumber,
@@ -266,9 +266,10 @@ pub struct ProtocolState<BlockNumber: AtLeast32BitUnsigned + MaxEncodedLen> {
     pub next_era_start: BlockNumber,
     /// Ongoing period number.
     #[codec(compact)]
+    // TODO: move this under `PeriodInfo`?
     pub period: PeriodNumber,
     /// Ongoing period type and when is it expected to end.
-    pub period_type_and_ending_era: PeriodTypeAndEndingEra,
+    pub period_info: PeriodInfo,
     /// `true` if pallet is in maintenance mode (disabled), `false` otherwise.
     /// TODO: provide some configurable barrier to handle this on the runtime level instead? Make an item for this?
     pub maintenance: bool,
@@ -283,7 +284,7 @@ where
             era: 0,
             next_era_start: BlockNumber::from(1_u32),
             period: 0,
-            period_type_and_ending_era: PeriodTypeAndEndingEra {
+            period_info: PeriodInfo {
                 period_type: PeriodType::Voting,
                 ending_era: 2,
             },
@@ -725,10 +726,12 @@ pub struct SingularStakingInfo {
     bep_staked_amount: Balance,
     /// Period number for which this entry is relevant.
     #[codec(compact)]
+    // TODO: rename to period_number?
     period: PeriodNumber,
     /// Indicates whether a staker is a loyal staker or not.
     loyal_staker: bool,
     /// Indicates whether staker claimed rewards
+    // TODO: isn't this redundant?!
     reward_claimed: bool,
 }
 

--- a/pallets/dapp-staking-v3/src/types.rs
+++ b/pallets/dapp-staking-v3/src/types.rs
@@ -961,6 +961,11 @@ impl SingularStakingInfo {
     pub fn period_number(&self) -> PeriodNumber {
         self.period
     }
+
+    /// `true` if no stake exists, `false` otherwise.
+    pub fn is_empty(&self) -> bool {
+        self.vp_staked_amount.is_zero() && self.bep_staked_amount.is_zero()
+    }
 }
 
 /// Information about how much was staked on a contract during a specific era or period.

--- a/pallets/dapp-staking-v3/src/types.rs
+++ b/pallets/dapp-staking-v3/src/types.rs
@@ -733,6 +733,7 @@ impl StakeAmount {
         }
     }
 
+    // TODO: rename to add?
     /// Stake the specified `amount` for the specified `period_type`.
     pub fn stake(&mut self, amount: Balance, period_type: PeriodType) {
         match period_type {
@@ -741,6 +742,7 @@ impl StakeAmount {
         }
     }
 
+    // TODO: rename to subtract?
     /// Unstake the specified `amount` for the specified `period_type`.
     pub fn unstake(&mut self, amount: Balance, period_type: PeriodType) {
         match period_type {
@@ -1160,8 +1162,8 @@ impl ContractStakingInfoSeries {
     ) -> Result<(), ()> {
         // Defensive check to ensure we don't end up in a corrupted state. Should never happen.
         if let Some(last_element) = self.0.last() {
-            // It's possible last element refers to the upcoming era, hence the "+1" on the 'era' argument.
-            if last_element.era() > era.saturating_add(1)
+            // It's possible last element refers to the upcoming era, hence the "-1" on the 'era'.
+            if last_element.era().saturating_sub(1) > era
                 || last_element.period() > period_info.number
             {
                 return Err(());


### PR DESCRIPTION
**Pull Request Summary**

This is the **3rd part** of the `dApp staking v3` implementation.

## Major Features
* `stake` - covers staking locked funds on smart contracts
* `unstake` - covers unstaking staked funds from smart contracts
* `on_initialize` - covers `era` and `period` transitions (in the future might be replaced by `Scheduler`)

## PR Overview

## Approach
Given the functionality's complexity, the approach is taken to abstract as much of the _lower_ level
functionality into `structs` and `enums`.

### Removals
* removed no longer used `LockedChunk` since we decided to only reward stakers, not lockers

### Additions
* `ProtocolState` (holds general info about dApp staking) received various member functions/methods
* `AccountLedger` expanded with support for staking & unstaking
* `StakeAmount` enum is intended to encapsulate stake amount - will be more integrated in the future
* `SingularStakingInfo` struct is used to cover information about particular stakers stake on a specific smart contract
* `ContractStakingInfo` struct is used to cover information about total stake on contract in a particular era/period
* `ContractStakingInfoSeries` is a composite struct used to cover multiple era/period combinations
  * this is required since we need to keep track of how much was staked in total on a contract for reward calculation
  * we want to keep it efficient, hence the single struct to handle multiple eras

### Changes
* old `PeriodType` has been split into the enum of same name and struct `PeriodInfo` to cover more attributes

### Tests
* there is a huge amount of tests added to cover as much scenarios as possible
* reviewer is not expected to cover this, but is welcome
