### PR TITLE
fix: storage item typo in unified accounts

### DIFF
--- a/pallets/unified-accounts/src/tests.rs
+++ b/pallets/unified-accounts/src/tests.rs
@@ -134,8 +134,8 @@ fn on_killed_account_hook() {
         )));
 
         // make sure mapping is removed
-        assert_eq!(EvmToNative::<TestRuntime>::get(ALICE), None);
-        assert_eq!(NativeToEvm::<TestRuntime>::get(alice_eth), None);
+        assert_eq!(NativeToEvm::<TestRuntime>::get(ALICE), None);
+        assert_eq!(EvmToNative::<TestRuntime>::get(alice_eth), None);
     });
 }
 
@@ -175,10 +175,10 @@ fn account_claim_should_work() {
 
         // make sure mappings are in place
         assert_eq!(
-			NativeToEvm::<TestRuntime>::get(alice_eth).unwrap(), ALICE
+			EvmToNative::<TestRuntime>::get(alice_eth).unwrap(), ALICE
 		);
         assert_eq!(
-            EvmToNative::<TestRuntime>::get(ALICE).unwrap(), alice_eth
+            NativeToEvm::<TestRuntime>::get(ALICE).unwrap(), alice_eth
         )
     });
 }
@@ -229,8 +229,8 @@ fn account_default_claim_should_not_work_if_collision() {
 
         // create mapping of alice native with bob's default address
         // in real world possibilty of this happening is minuscule
-        NativeToEvm::<TestRuntime>::insert(&bob_default_h160, &ALICE);
-        EvmToNative::<TestRuntime>::insert(&ALICE, &bob_default_h160);
+        EvmToNative::<TestRuntime>::insert(&bob_default_h160, &ALICE);
+        NativeToEvm::<TestRuntime>::insert(&ALICE, &bob_default_h160);
 
         // bob try claiming default h160 address, it should fail since alice already
         // has mapping in place with it.

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -1339,12 +1339,12 @@ pub struct ClearCorruptedUnifiedMappings;
 impl OnRuntimeUpgrade for ClearCorruptedUnifiedMappings {
     fn on_runtime_upgrade() -> Weight {
         let maybe_limit = pallet_unified_accounts::EvmToNative::<Runtime>::iter().count();
-        let total_w = maybe_limit as u64 * 2;
+        let total_rw = maybe_limit as u64 * 2;
         // remove all items
         let _ = pallet_unified_accounts::EvmToNative::<Runtime>::clear(maybe_limit as u32, None);
         let _ = pallet_unified_accounts::NativeToEvm::<Runtime>::clear(maybe_limit as u32, None);
 
-        <Runtime as frame_system::Config>::DbWeight::get().writes(total_w)
+        <Runtime as frame_system::Config>::DbWeight::get().reads_writes(total_rw, total_rw)
     }
 }
 

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -1333,12 +1333,28 @@ impl OnRuntimeUpgrade for DynamicEvmBaseFeeMigration {
     }
 }
 
+/// Simple `OnRuntimeUpgrade` logic to remove all corrupted mappings
+/// after the fixing the typo in mapping names in pallet.
+pub struct ClearCorruptedUnifiedMappings;
+impl OnRuntimeUpgrade for ClearCorruptedUnifiedMappings {
+    fn on_runtime_upgrade() -> Weight {
+        let maybe_limit = pallet_unified_accounts::EvmToNative::<Runtime>::iter().count();
+        let total_w = maybe_limit as u64 * 2;
+        // remove all items
+        let _ = pallet_unified_accounts::EvmToNative::<Runtime>::clear(maybe_limit as u32, None);
+        let _ = pallet_unified_accounts::NativeToEvm::<Runtime>::clear(maybe_limit as u32, None);
+
+        <Runtime as frame_system::Config>::DbWeight::get().writes(total_w)
+    }
+}
+
 /// All migrations that will run on the next runtime upgrade.
 ///
 /// Once done, migrations should be removed from the tuple.
 pub type Migrations = (
     frame_support::migrations::RemovePallet<BaseFeeStr, RocksDbWeight>,
     DynamicEvmBaseFeeMigration,
+    ClearCorruptedUnifiedMappings,
 );
 
 type EventRecord = frame_system::EventRecord<


### PR DESCRIPTION
**Pull Request Summary**
Fix the typo in mapping storage names.

Since it's already deployed in Shibuya testnet, we have two options.
1. Add migrations for this
2. Clear the pallet storage using sudo call, since it's only being used internally and total mappings are around 10

EDIT: using `OnRuntimeUpgrade` hook to clear the storage in Shibuya for corrupted mappings after the renaming.

**Check list**
- [ ] added or updated unit tests
- [ ] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [ ] updated spec version
- [ ] updated semver
