### PR TITLE
Release v5.21.0 prep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "astar-collator"
-version = "5.20.0"
+version = "5.21.0"
 dependencies = [
  "astar-primitives",
  "astar-runtime",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "astar-runtime"
-version = "5.20.0"
+version = "5.21.0"
 dependencies = [
  "array-bytes 6.1.0",
  "astar-primitives",
@@ -5984,7 +5984,7 @@ checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "local-runtime"
-version = "5.20.0"
+version = "5.21.0"
 dependencies = [
  "array-bytes 6.1.0",
  "astar-primitives",
@@ -13017,7 +13017,7 @@ dependencies = [
 
 [[package]]
 name = "shibuya-runtime"
-version = "5.20.0"
+version = "5.21.0"
 dependencies = [
  "array-bytes 6.1.0",
  "astar-primitives",
@@ -13124,7 +13124,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "5.20.0"
+version = "5.21.0"
 dependencies = [
  "array-bytes 6.1.0",
  "astar-primitives",

--- a/bin/collator/Cargo.toml
+++ b/bin/collator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-collator"
-version = "5.20.0"
+version = "5.21.0"
 description = "Astar collator implementation in Rust."
 build = "build.rs"
 default-run = "astar-collator"

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-runtime"
-version = "5.20.0"
+version = "5.21.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -140,7 +140,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("astar"),
     impl_name: create_runtime_str!("astar"),
     authoring_version: 1,
-    spec_version: 67,
+    spec_version: 68,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/runtime/local/Cargo.toml
+++ b/runtime/local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-runtime"
-version = "5.20.0"
+version = "5.21.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "5.20.0"
+version = "5.21.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -166,7 +166,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shibuya"),
     impl_name: create_runtime_str!("shibuya"),
     authoring_version: 1,
-    spec_version: 110,
+    spec_version: 111,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "5.20.0"
+version = "5.21.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -143,7 +143,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shiden"),
     impl_name: create_runtime_str!("shiden"),
     authoring_version: 1,
-    spec_version: 107,
+    spec_version: 108,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,


### PR DESCRIPTION
**Pull Request Summary**

`v5.21.0` includes XCM v2 precompile and fee alignment, which is the same with `v5.20.0` but for Shiden and Astar.

**Check list**
- [x] Bump spec versions & crate version for Shibuya, Shiden and Astar
- [x] Bump crate version for Astar collator
- [x] Runtime upgrade Chopsticks test

~- [ ] Zombienet test~ will do after draft release.