### PR TITLE
tests: fix typos

### DIFF
--- a/tests/integration/src/unified_accounts.rs
+++ b/tests/integration/src/unified_accounts.rs
@@ -38,7 +38,7 @@ fn transfer_to_h160_via_lookup() {
             UNIT,
         ));
 
-        // evm account should have recieved the funds
+        // evm account should have received the funds
         let (account, _) = EVM::account_basic(&eth_address);
         assert_eq!(account.balance, (UNIT - ExistentialDeposit::get()).into());
     });

--- a/tests/integration/src/xvm.rs
+++ b/tests/integration/src/xvm.rs
@@ -315,8 +315,8 @@ fn calling_wasm_payable_from_evm_works() {
             None,
             vec![],
         ));
-        let recieved = Balances::free_balance(&wasm_payable_callee_addr) - prev_wasm_payable_balance;
-        assert_eq!(recieved, value);
+        let received = Balances::free_balance(&wasm_payable_callee_addr) - prev_wasm_payable_balance;
+        assert_eq!(received, value);
     });
 }
 

--- a/tests/xcm-simulator/src/mocks/parachain.rs
+++ b/tests/xcm-simulator/src/mocks/parachain.rs
@@ -172,7 +172,7 @@ impl pallet_insecure_randomness_collective_flip::Config for Runtime {}
 /// Constant values used within the runtime.
 pub const MICROSDN: Balance = 1_000_000_000_000;
 pub const MILLISDN: Balance = 1_000 * MICROSDN;
-/// We assume that ~10% of the block weight is consumed by `on_initalize` handlers.
+/// We assume that ~10% of the block weight is consumed by `on_initialize` handlers.
 /// This is used to limit the maximal weight of a single extrinsic.
 const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);
 /// We allow `Normal` extrinsics to fill up the block up to 75%, the rest can be used


### PR DESCRIPTION
fix some typos in `tests/`