### PR TITLE
XVM CE: Sufficient charged gas check before XVM execution.

### DIFF
--- a/chain-extensions/types/xvm/src/lib.rs
+++ b/chain-extensions/types/xvm/src/lib.rs
@@ -48,6 +48,7 @@ impl From<FailureReason> for XvmExecutionResult {
             FailureReason::Error(FailureError::SameVmCallDenied) => 129,
             FailureReason::Error(FailureError::ReentranceDenied) => 130,
             FailureReason::Error(FailureError::VmError(_)) => 131,
+            FailureReason::Error(FailureError::OutOfGas) => 132,
         };
         Self::Err(error_code)
     }

--- a/primitives/src/xvm.rs
+++ b/primitives/src/xvm.rs
@@ -131,6 +131,8 @@ pub enum FailureError {
     ReentranceDenied,
     /// The call failed with error on EVM or WASM execution.
     VmError(Vec<u8>),
+    /// Out of gas.
+    OutOfGas,
 }
 
 /// XVM call result.


### PR DESCRIPTION
**Pull Request Summary**

Closes #1070

I tried to add an integration test to cover the checks, but the out-of-gas check in `pallet-contracts` has a big margin. i.e. it requires the weight limit to be much higher than the actual used weight, or the `OutOfGas` error is returned. @PierreOssun might have some info on this?

In addition to the issue above, the charged weight at the beginning of the CE is updated to all the gas left, instead of the gas left with a `30KB` dummy value.

**Check list**
- [ ] added or updated unit tests
- [ ] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [ ] updated spec version
- [ ] updated semver
