### PR TITLE
docker image allows `--chain` param + shell

### DIFF
--- a/third-party/docker/Dockerfile
+++ b/third-party/docker/Dockerfile
@@ -34,4 +34,4 @@ RUN ["astar-collator", "--version"]
 EXPOSE 30333 30334 9933 9944
 VOLUME ["/data"]
 
-CMD ["/usr/local/bin/astar-collator","-d","/data"]
+ENTRYPOINT ["/usr/local/bin/astar-collator","-d","/data"]

--- a/third-party/docker/Dockerfile
+++ b/third-party/docker/Dockerfile
@@ -19,8 +19,7 @@ ENV RUST_BACKTRACE 1
 # add user
 RUN useradd -m -u 1000 -U -s /bin/sh -d /astar astar && \
    	mkdir /data && \
-    	chown -R astar:astar /data && \
-    	rm -rf /usr/bin /usr/sbin
+    	chown -R astar:astar /data 
 
 ARG PROFILE=release
 # add binary to docker image


### PR DESCRIPTION
The execution of the Astar collator image via Docker is encountering an error:
``` 
➜  ~ docker run staketechnologies/astar-collator:v5.23.0 --chain astar
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "--chain": executable file not found in $PATH: unknown.
ERRO[0000] error waiting for container:            
``` 

This patch corrects the issue, making the Docker image compatible with the ParityTech Helm charts, as detailed here:
_https://github.com/paritytech/helm-charts/tree/main/charts/node_
