### PR TITLE
fix(AU): [AST-1] prevent account from being reaped while charging fee

### DIFF
--- a/pallets/unified-accounts/src/lib.rs
+++ b/pallets/unified-accounts/src/lib.rs
@@ -28,7 +28,7 @@
 //! ## Overview
 //!
 //! The Unified Accounts module provide functionality for native account holders to
-//! connect their evm address to have a unified experence across the different VMs.
+//! connect their evm address to have a unified experience across the different VMs.
 //! - Connect evm address you control
 //! - Connect default evm address
 //!
@@ -271,7 +271,7 @@ impl<T: Config> Pallet<T> {
         Ok(evm_address)
     }
 
-    /// Charge the (exact) storage fee (polietly) from the user and burn it
+    /// Charge the (exact) storage fee (politely) from the user and burn it
     /// while preserving the account from being reaped.
     fn charge_storage_fee(who: &T::AccountId) -> Result<Balance, DispatchError> {
         let balance = T::Currency::reducible_balance(who, Preserve, Polite);
@@ -373,7 +373,7 @@ impl<T: Config> AddressMapping<T::AccountId> for Pallet<T> {
     }
 }
 
-/// OnKilledAccout hooks implementation for removing storage mapping
+/// OnKilledAccount hooks implementation for removing storage mapping
 /// for killed accounts
 pub struct KillAccountMapping<T>(PhantomData<T>);
 impl<T: Config> OnKilledAccount<T::AccountId> for KillAccountMapping<T> {

--- a/pallets/unified-accounts/src/mock.rs
+++ b/pallets/unified-accounts/src/mock.rs
@@ -24,7 +24,7 @@ use astar_primitives::evm::HashedDefaultMappings;
 use frame_support::{
     construct_runtime, parameter_types,
     sp_io::TestExternalities,
-    traits::{ConstU128, ConstU64, FindAuthor},
+    traits::{ConstU64, FindAuthor},
     weights::Weight,
 };
 use pallet_ethereum::PostLogContent;
@@ -39,6 +39,7 @@ use sp_runtime::{
 parameter_types! {
     pub BlockWeights: frame_system::limits::BlockWeights =
         frame_system::limits::BlockWeights::simple_max(Weight::from_parts(1024, 0));
+    pub const ExistentialDeposit: u128 = 100;
 }
 
 impl frame_system::Config for TestRuntime {
@@ -75,7 +76,7 @@ impl pallet_balances::Config for TestRuntime {
     type Balance = Balance;
     type RuntimeEvent = RuntimeEvent;
     type DustRemoval = ();
-    type ExistentialDeposit = ConstU128<2>;
+    type ExistentialDeposit = ExistentialDeposit;
     type AccountStore = System;
     type WeightInfo = ();
     type HoldIdentifier = ();


### PR DESCRIPTION
**Pull Request Summary**
This PR adds an additional check to make sure user has enough funds while charging AU storage fee while claiming accounts, so that account is not reaped.
This is required before `Mutate::burn_from()` as it burn user holdings with `Expendable` flag thus discarding the requirement to `Preserve` account from being repead.

**Check list**
- [ ] added or updated unit tests
- [ ] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [ ] added benchmarks & weights for any modified runtime logics.
