### PR TITLE
Fix for incorrect freeze amount

### DIFF
--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -1528,7 +1528,7 @@ pub mod pallet {
                 T::Currency::set_freeze(
                     &FreezeReason::DAppStaking.into(),
                     account,
-                    ledger.active_locked_amount(),
+                    ledger.total_locked_amount(),
                 )?;
                 Ledger::<T>::insert(account, ledger);
             }

--- a/pallets/dapp-staking-v3/src/test/testing_utils.rs
+++ b/pallets/dapp-staking-v3/src/test/testing_utils.rs
@@ -326,8 +326,9 @@ pub(crate) fn assert_unlock(account: AccountId, amount: Balance) {
     );
 
     assert_eq!(
-        init_frozen_balance - expected_unlock_amount,
-        Balances::balance_frozen(&FreezeReason::DAppStaking.into(), &account)
+        init_frozen_balance ,
+        Balances::balance_frozen(&FreezeReason::DAppStaking.into(), &account),
+        "Frozen balance must remain the same since the funds are still locked/frozen, only undergoing the unlocking process."
     );
 }
 


### PR DESCRIPTION
**Pull Request Summary**

Fix for an issue where `update_ledger` function would incorrectly set the _freeze_ for active locked amount,
instead of total locked amount.

This essentially meant that the unlocking chunks were not considered _locked_ or _frozen_.

Updated test utils that check this (many tests started failing immediately after that, without the fix of course).
