### PR TITLE
dApps Staking v2 - claimStakerFor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7703,6 +7703,7 @@ dependencies = [
 name = "pallet-dapps-staking"
 version = "3.10.0"
 dependencies = [
+ "assert_matches",
  "astar-primitives",
  "frame-benchmarking",
  "frame-support",

--- a/pallets/dapps-staking/Cargo.toml
+++ b/pallets/dapps-staking/Cargo.toml
@@ -26,10 +26,10 @@ sp-std = { workspace = true }
 frame-benchmarking = { workspace = true, optional = true }
 
 [dev-dependencies]
+assert_matches = { workspace = true }
 pallet-balances = { workspace = true }
 pallet-session = { workspace = true }
 pallet-timestamp = { workspace = true }
-assert_matches = { workspace = true }
 
 [features]
 default = ["std"]

--- a/pallets/dapps-staking/Cargo.toml
+++ b/pallets/dapps-staking/Cargo.toml
@@ -29,6 +29,7 @@ frame-benchmarking = { workspace = true, optional = true }
 pallet-balances = { workspace = true }
 pallet-session = { workspace = true }
 pallet-timestamp = { workspace = true }
+assert_matches = { workspace = true }
 
 [features]
 default = ["std"]

--- a/pallets/dapps-staking/src/pallet/mod.rs
+++ b/pallets/dapps-staking/src/pallet/mod.rs
@@ -630,6 +630,7 @@ pub mod pallet {
         #[pallet::weight(T::WeightInfo::withdraw_unbonded())]
         pub fn withdraw_unbonded(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
             Self::ensure_pallet_enabled()?;
+            Self::ensure_not_in_decommission()?;
             let staker = ensure_signed(origin)?;
 
             let mut ledger = Self::ledger(&staker);
@@ -870,6 +871,7 @@ pub mod pallet {
             #[pallet::compact] era: EraIndex,
         ) -> DispatchResultWithPostInfo {
             Self::ensure_pallet_enabled()?;
+            Self::ensure_not_in_decommission()?;
             ensure_root(origin)?;
 
             let dapp_info =

--- a/pallets/dapps-staking/src/pallet/mod.rs
+++ b/pallets/dapps-staking/src/pallet/mod.rs
@@ -132,6 +132,11 @@ pub mod pallet {
     #[pallet::getter(fn pallet_disabled)]
     pub type PalletDisabled<T: Config> = StorageValue<_, bool, ValueQuery>;
 
+    /// Denotes whether pallet decomissioning has started or not.
+    #[pallet::storage]
+    #[pallet::whitelist_storage]
+    pub type DecomissionStarted<T: Config> = StorageValue<_, bool, ValueQuery>;
+
     /// General information about the staker (non-smart-contract specific).
     #[pallet::storage]
     #[pallet::getter(fn ledger)]
@@ -244,6 +249,8 @@ pub mod pallet {
         ///
         /// \(developer account, smart contract, era, amount burned\)
         StaleRewardBurned(T::AccountId, T::SmartContract, EraIndex, Balance),
+        /// Pallet is being decomissioned.
+        Decomission,
     }
 
     #[pallet::error]
@@ -296,6 +303,8 @@ pub mod pallet {
         NotActiveStaker,
         /// Transfering nomination to the same contract
         NominationTransferToSameContract,
+        /// Pallet decomission hasn't been started yet so this call is not allowed.
+        DecomissionNotStarted,
     }
 
     #[pallet::hooks]
@@ -709,8 +718,6 @@ pub mod pallet {
             Ok(().into())
         }
 
-        // TODO: do we need to add force methods or at least methods that allow others to claim for someone else?
-
         /// Claim earned staker rewards for the oldest unclaimed era.
         /// In order to claim multiple eras, this call has to be called multiple times.
         ///
@@ -725,94 +732,7 @@ pub mod pallet {
             Self::ensure_pallet_enabled()?;
             let staker = ensure_signed(origin)?;
 
-            // Ensure we have something to claim
-            let mut staker_info = Self::staker_info(&staker, &contract_id);
-            let (era, staked) = staker_info.claim();
-            ensure!(staked > Zero::zero(), Error::<T>::NotStakedContract);
-
-            let dapp_info =
-                RegisteredDapps::<T>::get(&contract_id).ok_or(Error::<T>::NotOperatedContract)?;
-
-            if let DAppState::Unregistered(unregister_era) = dapp_info.state {
-                ensure!(era < unregister_era, Error::<T>::NotOperatedContract);
-            }
-
-            let current_era = Self::current_era();
-            ensure!(era < current_era, Error::<T>::EraOutOfBounds);
-
-            let staking_info = Self::contract_stake_info(&contract_id, era).unwrap_or_default();
-            let reward_and_stake =
-                Self::general_era_info(era).ok_or(Error::<T>::UnknownEraReward)?;
-
-            let (_, stakers_joint_reward) =
-                Self::dev_stakers_split(&staking_info, &reward_and_stake);
-            let staker_reward =
-                Perbill::from_rational(staked, staking_info.total) * stakers_joint_reward;
-
-            let mut ledger = Self::ledger(&staker);
-
-            let should_restake_reward = Self::should_restake_reward(
-                ledger.reward_destination,
-                dapp_info.state,
-                staker_info.latest_staked_value(),
-            );
-
-            if should_restake_reward {
-                staker_info
-                    .stake(current_era, staker_reward)
-                    .map_err(|_| Error::<T>::UnexpectedStakeInfoEra)?;
-
-                // Restaking will, in the worst case, remove one, and add one record,
-                // so it's fine if the vector is full
-                ensure!(
-                    staker_info.len() <= T::MaxEraStakeValues::get(),
-                    Error::<T>::TooManyEraStakeValues
-                );
-            }
-
-            // Withdraw reward funds from the dapps staking pot
-            let reward_imbalance = T::Currency::withdraw(
-                &Self::account_id(),
-                staker_reward,
-                WithdrawReasons::TRANSFER,
-                ExistenceRequirement::AllowDeath,
-            )?;
-
-            if should_restake_reward {
-                ledger.locked = ledger.locked.saturating_add(staker_reward);
-                Self::update_ledger(&staker, ledger);
-
-                // Update storage
-                GeneralEraInfo::<T>::mutate(&current_era, |value| {
-                    if let Some(x) = value {
-                        x.staked = x.staked.saturating_add(staker_reward);
-                        x.locked = x.locked.saturating_add(staker_reward);
-                    }
-                });
-
-                ContractEraStake::<T>::mutate(contract_id.clone(), current_era, |staking_info| {
-                    if let Some(x) = staking_info {
-                        x.total = x.total.saturating_add(staker_reward);
-                    }
-                });
-
-                Self::deposit_event(Event::<T>::BondAndStake(
-                    staker.clone(),
-                    contract_id.clone(),
-                    staker_reward,
-                ));
-            }
-
-            T::Currency::resolve_creating(&staker, reward_imbalance);
-            Self::update_staker_info(&staker, &contract_id, staker_info);
-            Self::deposit_event(Event::<T>::Reward(staker, contract_id, era, staker_reward));
-
-            Ok(Some(if should_restake_reward {
-                T::WeightInfo::claim_staker_with_restake()
-            } else {
-                T::WeightInfo::claim_staker_without_restake()
-            })
-            .into())
+            Self::claim_staker_rewards_for(staker, contract_id, true)
         }
 
         /// Claim earned dapp rewards for the specified era.
@@ -985,6 +905,42 @@ pub mod pallet {
                 era,
                 dapp_reward,
             ));
+
+            Ok(().into())
+        }
+
+        /// Claim earned staker rewards for the given staker, and the oldest unclaimed era.
+        /// In order to claim multiple eras, this call has to be called multiple times.
+        ///
+        /// The rewards are always deposited into the staker's free balance.
+        #[pallet::call_index(14)]
+        #[pallet::weight(T::WeightInfo::claim_staker_with_restake().max(T::WeightInfo::claim_staker_without_restake()))]
+        pub fn claim_staker_for(
+            origin: OriginFor<T>,
+            staker: T::AccountId,
+            contract_id: T::SmartContract,
+        ) -> DispatchResultWithPostInfo {
+            Self::ensure_pallet_enabled()?;
+            ensure!(
+                DecomissionStarted::<T>::get(),
+                Error::<T>::DecomissionNotStarted
+            );
+            ensure_signed(origin)?;
+
+            // Reward restaking is forbidden for this call.
+            Self::claim_staker_rewards_for(staker, contract_id, false)
+        }
+
+        /// Enable the `decomission` flag for the pallet.
+        ///
+        /// The dispatch origin must be Root.
+        #[pallet::call_index(15)]
+        #[pallet::weight(T::WeightInfo::maintenance_mode())] // Good enough approximation
+        pub fn decomission(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
+            Self::ensure_pallet_enabled()?;
+            ensure_root(origin)?;
+            DecomissionStarted::<T>::put(true);
+            Self::deposit_event(Event::<T>::Decomission);
 
             Ok(().into())
         }
@@ -1297,6 +1253,103 @@ pub mod pallet {
                 // Should never happen since era info for current era must always exist
                 Zero::zero()
             }
+        }
+
+        /// Claim earned staker rewards for the given staker, and the oldest unclaimed era.
+        fn claim_staker_rewards_for(
+            staker: T::AccountId,
+            contract_id: T::SmartContract,
+            restake_allowed: bool,
+        ) -> DispatchResultWithPostInfo {
+            // Ensure we have something to claim
+            let mut staker_info = Self::staker_info(&staker, &contract_id);
+            let (era, staked) = staker_info.claim();
+            ensure!(staked > Zero::zero(), Error::<T>::NotStakedContract);
+
+            let dapp_info =
+                RegisteredDapps::<T>::get(&contract_id).ok_or(Error::<T>::NotOperatedContract)?;
+
+            if let DAppState::Unregistered(unregister_era) = dapp_info.state {
+                ensure!(era < unregister_era, Error::<T>::NotOperatedContract);
+            }
+
+            let current_era = Self::current_era();
+            ensure!(era < current_era, Error::<T>::EraOutOfBounds);
+
+            let staking_info = Self::contract_stake_info(&contract_id, era).unwrap_or_default();
+            let reward_and_stake =
+                Self::general_era_info(era).ok_or(Error::<T>::UnknownEraReward)?;
+
+            let (_, stakers_joint_reward) =
+                Self::dev_stakers_split(&staking_info, &reward_and_stake);
+            let staker_reward =
+                Perbill::from_rational(staked, staking_info.total) * stakers_joint_reward;
+
+            let mut ledger = Self::ledger(&staker);
+
+            let should_restake_reward = restake_allowed
+                && Self::should_restake_reward(
+                    ledger.reward_destination,
+                    dapp_info.state,
+                    staker_info.latest_staked_value(),
+                );
+
+            if should_restake_reward {
+                staker_info
+                    .stake(current_era, staker_reward)
+                    .map_err(|_| Error::<T>::UnexpectedStakeInfoEra)?;
+
+                // Restaking will, in the worst case, remove one, and add one record,
+                // so it's fine if the vector is full
+                ensure!(
+                    staker_info.len() <= T::MaxEraStakeValues::get(),
+                    Error::<T>::TooManyEraStakeValues
+                );
+            }
+
+            // Withdraw reward funds from the dapps staking pot
+            let reward_imbalance = T::Currency::withdraw(
+                &Self::account_id(),
+                staker_reward,
+                WithdrawReasons::TRANSFER,
+                ExistenceRequirement::AllowDeath,
+            )?;
+
+            if should_restake_reward {
+                ledger.locked = ledger.locked.saturating_add(staker_reward);
+                Self::update_ledger(&staker, ledger);
+
+                // Update storage
+                GeneralEraInfo::<T>::mutate(&current_era, |value| {
+                    if let Some(x) = value {
+                        x.staked = x.staked.saturating_add(staker_reward);
+                        x.locked = x.locked.saturating_add(staker_reward);
+                    }
+                });
+
+                ContractEraStake::<T>::mutate(contract_id.clone(), current_era, |staking_info| {
+                    if let Some(x) = staking_info {
+                        x.total = x.total.saturating_add(staker_reward);
+                    }
+                });
+
+                Self::deposit_event(Event::<T>::BondAndStake(
+                    staker.clone(),
+                    contract_id.clone(),
+                    staker_reward,
+                ));
+            }
+
+            T::Currency::resolve_creating(&staker, reward_imbalance);
+            Self::update_staker_info(&staker, &contract_id, staker_info);
+            Self::deposit_event(Event::<T>::Reward(staker, contract_id, era, staker_reward));
+
+            Ok(Some(if should_restake_reward {
+                T::WeightInfo::claim_staker_with_restake()
+            } else {
+                T::WeightInfo::claim_staker_without_restake()
+            })
+            .into())
         }
     }
 }

--- a/pallets/dapps-staking/src/pallet/mod.rs
+++ b/pallets/dapps-staking/src/pallet/mod.rs
@@ -318,12 +318,12 @@ pub mod pallet {
             // a new era is triggered. This code is just a safety net to ensure nothing is broken
             // if we fail to do that.
             if PalletDisabled::<T>::get() || T::ForcePalletDisabled::get() {
-                return T::DbWeight::get().reads(5);
+                return T::DbWeight::get().reads(3);
             }
 
             // In case decomissioning has started, we don't allow eras to change anymore.
             if DecomissionStarted::<T>::get() {
-                return T::DbWeight::get().reads(5);
+                return T::DbWeight::get().reads(3);
             }
 
             let force_new_era = Self::force_era().eq(&Forcing::ForceNew);
@@ -348,7 +348,7 @@ pub mod pallet {
 
                 Self::deposit_event(Event::<T>::NewDappStakingEra(next_era));
 
-                consumed_weight + T::DbWeight::get().reads_writes(58, 3)
+                consumed_weight + T::DbWeight::get().reads_writes(8, 3)
             } else {
                 T::DbWeight::get().reads(7)
             }

--- a/pallets/dapps-staking/src/tests.rs
+++ b/pallets/dapps-staking/src/tests.rs
@@ -18,8 +18,8 @@
 
 use super::{pallet::pallet::Error, pallet::pallet::Event, *};
 use frame_support::{
-    assert_noop, assert_ok,
-    traits::{Currency, OnInitialize},
+    assert_noop, assert_ok, assert_storage_noop,
+    traits::{Currency, OnFinalize, OnInitialize},
     weights::Weight,
 };
 use mock::{Balance, Balances, MockSmartContract, *};
@@ -2112,6 +2112,74 @@ fn maintenance_mode_no_change() {
 }
 
 #[test]
+fn decommision_is_ok() {
+    ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+
+        // Init sanity check
+        assert_ok!(DappsStaking::ensure_not_in_decommision());
+        assert!(!DecomissionStarted::<TestRuntime>::exists());
+
+        // Enable decomission mode
+        assert_ok!(DappsStaking::decomission(RuntimeOrigin::root()));
+        assert!(DecomissionStarted::<TestRuntime>::get());
+        System::assert_last_event(mock::RuntimeEvent::DappsStaking(Event::Decomission));
+
+        let account = 1;
+        let contract_id = MockSmartContract::Evm(H160::repeat_byte(0x01));
+
+        // Ensure that expected calls no longer work
+        assert_noop!(
+            DappsStaking::register(RuntimeOrigin::root(), account, contract_id),
+            Error::<TestRuntime>::DecomissionInProgress
+        );
+        assert_noop!(
+            DappsStaking::unregister(RuntimeOrigin::root(), contract_id),
+            Error::<TestRuntime>::DecomissionInProgress
+        );
+        assert_noop!(
+            DappsStaking::withdraw_from_unregistered(RuntimeOrigin::signed(account), contract_id),
+            Error::<TestRuntime>::DecomissionInProgress
+        );
+
+        assert_noop!(
+            DappsStaking::bond_and_stake(RuntimeOrigin::signed(account), contract_id, 100),
+            Error::<TestRuntime>::DecomissionInProgress
+        );
+        assert_noop!(
+            DappsStaking::unbond_and_unstake(RuntimeOrigin::signed(account), contract_id, 100),
+            Error::<TestRuntime>::DecomissionInProgress
+        );
+        assert_noop!(
+            DappsStaking::nomination_transfer(
+                RuntimeOrigin::signed(account),
+                contract_id,
+                100,
+                contract_id,
+            ),
+            Error::<TestRuntime>::DecomissionInProgress
+        );
+    })
+}
+
+#[test]
+fn no_era_change_during_decommision() {
+    ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+
+        // Enable decomission mode and set the next era to start immediately after this block
+        assert_ok!(DappsStaking::decomission(RuntimeOrigin::root()));
+        NextEraStartingBlock::<TestRuntime>::put(System::block_number() + 1);
+
+        // Ensure nothing happens during on_initialize
+        assert_storage_noop!(DappsStaking::on_finalize(System::block_number()));
+        assert_storage_noop!(DappsStaking::on_initialize(System::block_number() + 1));
+        assert_storage_noop!(DappsStaking::on_finalize(System::block_number() + 1));
+        assert_storage_noop!(DappsStaking::on_initialize(System::block_number() + 2));
+    })
+}
+
+#[test]
 fn dev_stakers_split_util() {
     let base_stakers_reward = 7 * 11 * 13 * 17;
     let base_dapps_reward = 19 * 23 * 31;
@@ -2406,7 +2474,7 @@ fn claim_staker_for_works() {
             Error::<TestRuntime>::DecomissionNotStarted
         );
 
-        // Enable decomission mode
+        // Enable decomission mode & claim the reward
         assert_ok!(DappsStaking::decomission(RuntimeOrigin::root()));
         assert_ok!(DappsStaking::claim_staker_for(
             RuntimeOrigin::signed(claimer),
@@ -2419,5 +2487,44 @@ fn claim_staker_for_works() {
             System::events().last().unwrap().event,
             mock::RuntimeEvent::DappsStaking(Event::Reward(staker, _, _, _)) if staker == staker
         );
+    })
+}
+
+#[test]
+fn set_reward_destination_for_works() {
+    ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+
+        // Register a dApp and stake some amount on it
+        let developer = 1;
+        let caller = 2;
+        let staker = caller + 1; // has to be different
+        let smart_contract = MockSmartContract::Evm(H160::repeat_byte(0x02));
+        assert_register(developer, &smart_contract);
+        assert_bond_and_stake(staker, &smart_contract, 17);
+
+        // Claiming for another staker is not possible unless decomission has started
+        assert_noop!(
+            DappsStaking::set_reward_destination_for(
+                RuntimeOrigin::signed(caller),
+                staker,
+                RewardDestination::StakeBalance
+            ),
+            Error::<TestRuntime>::DecomissionNotStarted
+        );
+
+        // Enable decomission mode and set the reward destination
+        assert_ok!(DappsStaking::decomission(RuntimeOrigin::root()));
+        assert_ok!(DappsStaking::set_reward_destination_for(
+            RuntimeOrigin::signed(caller),
+            staker,
+            RewardDestination::StakeBalance
+        ));
+
+        // The reward destination must be set for the staker, not the caller.
+        System::assert_last_event(mock::RuntimeEvent::DappsStaking(Event::RewardDestination(
+            staker,
+            RewardDestination::StakeBalance,
+        )));
     })
 }

--- a/pallets/dapps-staking/src/tests.rs
+++ b/pallets/dapps-staking/src/tests.rs
@@ -2159,6 +2159,20 @@ fn decommision_is_ok() {
             ),
             Error::<TestRuntime>::DecomissionInProgress
         );
+
+        // Ensure that expected calls still work (or at least don't fail with `DecomissionInProgress` error)
+        assert_noop!(
+            DappsStaking::claim_staker(RuntimeOrigin::signed(account), contract_id,),
+            Error::<TestRuntime>::NotStakedContract
+        );
+        assert_noop!(
+            DappsStaking::claim_dapp(RuntimeOrigin::signed(account), contract_id, 1,),
+            Error::<TestRuntime>::NotOperatedContract
+        );
+        assert_noop!(
+            DappsStaking::withdraw_unbonded(RuntimeOrigin::signed(account),),
+            Error::<TestRuntime>::NothingToWithdraw
+        );
     })
 }
 

--- a/pallets/dapps-staking/src/tests.rs
+++ b/pallets/dapps-staking/src/tests.rs
@@ -2117,7 +2117,7 @@ fn decommision_is_ok() {
         initialize_first_block();
 
         // Init sanity check
-        assert_ok!(DappsStaking::ensure_not_in_decommision());
+        assert_ok!(DappsStaking::ensure_not_in_decommission());
         assert!(!DecommissionStarted::<TestRuntime>::exists());
 
         // Enable decommission mode
@@ -2159,6 +2159,10 @@ fn decommision_is_ok() {
             ),
             Error::<TestRuntime>::DecommissionInProgress
         );
+        assert_noop!(
+            DappsStaking::withdraw_unbonded(RuntimeOrigin::signed(account)),
+            Error::<TestRuntime>::DecommissionInProgress
+        );
 
         // Ensure that expected calls still work (or at least don't fail with `DecommissionInProgress` error)
         assert_noop!(
@@ -2168,10 +2172,6 @@ fn decommision_is_ok() {
         assert_noop!(
             DappsStaking::claim_dapp(RuntimeOrigin::signed(account), contract_id, 1,),
             Error::<TestRuntime>::NotOperatedContract
-        );
-        assert_noop!(
-            DappsStaking::withdraw_unbonded(RuntimeOrigin::signed(account),),
-            Error::<TestRuntime>::NothingToWithdraw
         );
     })
 }


### PR DESCRIPTION
## Summary

Introduces delegated functions for claiming staker rewards & changing reward destination.
This functionality is intended to be used during the transition period from _dApps Staking v2_ over to _dApp Staking v3_.

## Overview

* introduces a new pallet state - `DecomissionStarted`
  * this is a `semi-maintenance` mode, where most of the calls are prohibited & no new era changes occur
* once decommission has started, it is still possible to claim rewards, and delegated claiming becomes enabled
  * to account for a situation where claiming into `StakeBalance` would cause an error due to too many chunks, setting reward destination also becomes delegated
* eras no longer change during decommissioning process since we want to avoid new rewards becoming available, thus prolonging the entire cleanup process
* adjusted some weights to account for the whitelisted storage