### PR TITLE
Enable `UnsafeUnstableInterface` in local-runtime

### DIFF
--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -932,7 +932,7 @@ impl pallet_contracts::Config for Runtime {
     type AddressGenerator = pallet_contracts::DefaultAddressGenerator;
     type MaxCodeLen = ConstU32<{ 123 * 1024 }>;
     type MaxStorageKeyLen = ConstU32<128>;
-    type UnsafeUnstableInterface = ConstBool<false>;
+    type UnsafeUnstableInterface = ConstBool<true>;
     type MaxDebugBufferLen = ConstU32<{ 2 * 1024 * 1024 }>;
 }
 


### PR DESCRIPTION
For some reason `UnsafeUnstableInterface` is disabled in local-runtime, even though it is enabled in Shibuya.

This is pretty confusing and it took me quite some time to notice when I was doing e2e contract testing after testing the functionality manually on Shibuya.