### PR TITLE
dApp Staking v3 - Legacy Ledger Support

### DIFF
--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -575,7 +575,7 @@ pub mod pallet {
             Self::unlock(origin, value)
         }
 
-        /// Wrapper around _legacy-like_ `claim_unlocked`.
+        /// Wrapper around _legacy-like_ `withdraw_unbonded`.
         ///
         /// Used to support legacy Ledger users so they can reclaim unlocked chunks back into
         /// their _transferable_ free balance.


### PR DESCRIPTION
**Pull Request Summary**

Adds _legacy wrapper_ into `dApp staking v3` to support two `dApps staking v2` calls:
* `unbond_and_unstake`
* `withdraw_from_unregistered`

This will allow users of the legacy Astar Native Ledger app to withdraw their funds after the v3 launch.

From the Ledger app:
```C
#define PD_CALL_DAPPSSTAKING_UNBOND_AND_UNSTAKE_V2 4
typedef struct {
    pd_SmartContract_t contract_id;
    pd_Compactu128_t amount;
} pd_dappsstaking_unbond_and_unstake_V2_t;

#define PD_CALL_DAPPSSTAKING_WITHDRAW_UNBONDED_V2 5
typedef struct {
} pd_dappsstaking_withdraw_unbonded_V2_t;
```
