### PR TITLE
dApp Staking v3 - Rewards As Tree

### DIFF
--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -66,6 +66,8 @@ mod benchmarking;
 mod types;
 pub use types::*;
 
+pub mod migrations;
+
 pub mod weights;
 pub use weights::WeightInfo;
 
@@ -343,8 +345,6 @@ pub mod pallet {
         /// No dApp tier info exists for the specified era. This can be because era has expired
         /// or because during the specified era there were no eligible rewards or protocol wasn't active.
         NoDAppTierInfo,
-        /// dApp reward has already been claimed for this era.
-        DAppRewardAlreadyClaimed,
         /// An unexpected error occured while trying to claim dApp reward.
         InternalClaimDAppError,
         /// Contract is still active, not unregistered.
@@ -1322,7 +1322,6 @@ pub mod pallet {
                     .try_claim(dapp_info.id)
                     .map_err(|error| match error {
                         DAppTierError::NoDAppInTiers => Error::<T>::NoClaimableRewards,
-                        DAppTierError::RewardAlreadyClaimed => Error::<T>::DAppRewardAlreadyClaimed,
                         _ => Error::<T>::InternalClaimDAppError,
                     })?;
 
@@ -1673,7 +1672,7 @@ pub mod pallet {
             // Iterate over configured tier and potential dApps.
             // Each dApp will be assigned to the best possible tier if it satisfies the required condition,
             // and tier capacity hasn't been filled yet.
-            let mut dapp_tiers = Vec::with_capacity(dapp_stakes.len());
+            let mut dapp_tiers = BTreeMap::new();
             let tier_config = TierConfig::<T>::get();
 
             let mut global_idx = 0;
@@ -1693,10 +1692,7 @@ pub mod pallet {
                 for (dapp_id, stake_amount) in dapp_stakes[global_idx..max_idx].iter() {
                     if tier_threshold.is_satisfied(*stake_amount) {
                         global_idx.saturating_inc();
-                        dapp_tiers.push(DAppTier {
-                            dapp_id: *dapp_id,
-                            tier_id: Some(tier_id),
-                        });
+                        dapp_tiers.insert(*dapp_id, tier_id);
                     } else {
                         break;
                     }
@@ -1986,108 +1982,5 @@ pub mod pallet {
 
             T::WeightInfo::on_idle_cleanup()
         }
-    }
-}
-
-/// `OnRuntimeUpgrade` logic used to set & configure init dApp staking v3 storage items.
-pub struct DAppStakingV3InitConfig<T, G>(PhantomData<(T, G)>);
-impl<
-        T: Config,
-        G: Get<(
-            EraNumber,
-            TierParameters<T::NumberOfTiers>,
-            TiersConfiguration<T::NumberOfTiers>,
-        )>,
-    > OnRuntimeUpgrade for DAppStakingV3InitConfig<T, G>
-{
-    fn on_runtime_upgrade() -> Weight {
-        if Pallet::<T>::on_chain_storage_version() >= STORAGE_VERSION {
-            return T::DbWeight::get().reads(1);
-        }
-
-        // 0. Unwrap arguments
-        let (init_era, tier_params, init_tier_config) = G::get();
-
-        // 1. Prepare init active protocol state
-        let now = frame_system::Pallet::<T>::block_number();
-        let voting_period_length = Pallet::<T>::blocks_per_voting_period();
-
-        let period_number = 1;
-        let protocol_state = ProtocolState {
-            era: init_era,
-            next_era_start: now.saturating_add(voting_period_length),
-            period_info: PeriodInfo {
-                number: period_number,
-                subperiod: Subperiod::Voting,
-                next_subperiod_start_era: init_era.saturating_add(1),
-            },
-            maintenance: true,
-        };
-
-        // 2. Prepare init current era info - need to set correct eras
-        let init_era_info = EraInfo {
-            total_locked: 0,
-            unlocking: 0,
-            current_stake_amount: StakeAmount {
-                voting: 0,
-                build_and_earn: 0,
-                era: init_era,
-                period: period_number,
-            },
-            next_stake_amount: StakeAmount {
-                voting: 0,
-                build_and_earn: 0,
-                era: init_era.saturating_add(1),
-                period: period_number,
-            },
-        };
-
-        // 3. Write necessary items into storage
-        ActiveProtocolState::<T>::put(protocol_state);
-        StaticTierParams::<T>::put(tier_params);
-        TierConfig::<T>::put(init_tier_config);
-        STORAGE_VERSION.put::<Pallet<T>>();
-        CurrentEraInfo::<T>::put(init_era_info);
-
-        // 4. Emit events to make indexers happy
-        Pallet::<T>::deposit_event(Event::<T>::NewEra { era: init_era });
-        Pallet::<T>::deposit_event(Event::<T>::NewSubperiod {
-            subperiod: Subperiod::Voting,
-            number: 1,
-        });
-
-        log::info!("dApp Staking v3 storage initialized.");
-
-        T::DbWeight::get().reads_writes(2, 5)
-    }
-
-    #[cfg(feature = "try-runtime")]
-    fn post_upgrade(_state: Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
-        assert_eq!(Pallet::<T>::on_chain_storage_version(), STORAGE_VERSION);
-        let protocol_state = ActiveProtocolState::<T>::get();
-        assert!(protocol_state.maintenance);
-
-        let number_of_tiers = T::NumberOfTiers::get();
-
-        let tier_params = StaticTierParams::<T>::get();
-        assert_eq!(tier_params.reward_portion.len(), number_of_tiers as usize);
-        assert!(tier_params.is_valid());
-
-        let tier_config = TierConfig::<T>::get();
-        assert_eq!(tier_config.reward_portion.len(), number_of_tiers as usize);
-        assert_eq!(tier_config.slots_per_tier.len(), number_of_tiers as usize);
-        assert_eq!(tier_config.tier_thresholds.len(), number_of_tiers as usize);
-
-        let current_era_info = CurrentEraInfo::<T>::get();
-        assert_eq!(
-            current_era_info.current_stake_amount.era,
-            protocol_state.era
-        );
-        assert_eq!(
-            current_era_info.next_stake_amount.era,
-            protocol_state.era + 1
-        );
-
-        Ok(())
     }
 }

--- a/pallets/dapp-staking-v3/src/migrations.rs
+++ b/pallets/dapp-staking-v3/src/migrations.rs
@@ -1,0 +1,202 @@
+// This file is part of Astar.
+
+// Copyright (C) 2019-2023 Stake Technologies Pte.Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Astar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Astar is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Astar. If not, see <http://www.gnu.org/licenses/>.
+
+use super::*;
+
+/// `OnRuntimeUpgrade` logic used to set & configure init dApp staking v3 storage items.
+pub struct DAppStakingV3InitConfig<T, G>(PhantomData<(T, G)>);
+impl<
+        T: Config,
+        G: Get<(
+            EraNumber,
+            TierParameters<T::NumberOfTiers>,
+            TiersConfiguration<T::NumberOfTiers>,
+        )>,
+    > OnRuntimeUpgrade for DAppStakingV3InitConfig<T, G>
+{
+    fn on_runtime_upgrade() -> Weight {
+        if Pallet::<T>::on_chain_storage_version() >= STORAGE_VERSION {
+            return T::DbWeight::get().reads(1);
+        }
+
+        // 0. Unwrap arguments
+        let (init_era, tier_params, init_tier_config) = G::get();
+
+        // 1. Prepare init active protocol state
+        let now = frame_system::Pallet::<T>::block_number();
+        let voting_period_length = Pallet::<T>::blocks_per_voting_period();
+
+        let period_number = 1;
+        let protocol_state = ProtocolState {
+            era: init_era,
+            next_era_start: now.saturating_add(voting_period_length),
+            period_info: PeriodInfo {
+                number: period_number,
+                subperiod: Subperiod::Voting,
+                next_subperiod_start_era: init_era.saturating_add(1),
+            },
+            maintenance: true,
+        };
+
+        // 2. Prepare init current era info - need to set correct eras
+        let init_era_info = EraInfo {
+            total_locked: 0,
+            unlocking: 0,
+            current_stake_amount: StakeAmount {
+                voting: 0,
+                build_and_earn: 0,
+                era: init_era,
+                period: period_number,
+            },
+            next_stake_amount: StakeAmount {
+                voting: 0,
+                build_and_earn: 0,
+                era: init_era.saturating_add(1),
+                period: period_number,
+            },
+        };
+
+        // 3. Write necessary items into storage
+        ActiveProtocolState::<T>::put(protocol_state);
+        StaticTierParams::<T>::put(tier_params);
+        TierConfig::<T>::put(init_tier_config);
+        STORAGE_VERSION.put::<Pallet<T>>();
+        CurrentEraInfo::<T>::put(init_era_info);
+
+        // 4. Emit events to make indexers happy
+        Pallet::<T>::deposit_event(Event::<T>::NewEra { era: init_era });
+        Pallet::<T>::deposit_event(Event::<T>::NewSubperiod {
+            subperiod: Subperiod::Voting,
+            number: 1,
+        });
+
+        log::info!("dApp Staking v3 storage initialized.");
+
+        T::DbWeight::get().reads_writes(2, 5)
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn post_upgrade(_state: Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+        assert_eq!(Pallet::<T>::on_chain_storage_version(), STORAGE_VERSION);
+        let protocol_state = ActiveProtocolState::<T>::get();
+        assert!(protocol_state.maintenance);
+
+        let number_of_tiers = T::NumberOfTiers::get();
+
+        let tier_params = StaticTierParams::<T>::get();
+        assert_eq!(tier_params.reward_portion.len(), number_of_tiers as usize);
+        assert!(tier_params.is_valid());
+
+        let tier_config = TierConfig::<T>::get();
+        assert_eq!(tier_config.reward_portion.len(), number_of_tiers as usize);
+        assert_eq!(tier_config.slots_per_tier.len(), number_of_tiers as usize);
+        assert_eq!(tier_config.tier_thresholds.len(), number_of_tiers as usize);
+
+        let current_era_info = CurrentEraInfo::<T>::get();
+        assert_eq!(
+            current_era_info.current_stake_amount.era,
+            protocol_state.era
+        );
+        assert_eq!(
+            current_era_info.next_stake_amount.era,
+            protocol_state.era + 1
+        );
+
+        Ok(())
+    }
+}
+
+/// Legacy struct type
+/// Should be deleted after the migration
+#[derive(Encode, Decode, MaxEncodedLen, Copy, Clone, Debug, PartialEq, Eq, TypeInfo)]
+struct OldDAppTier {
+    #[codec(compact)]
+    pub dapp_id: DAppId,
+    pub tier_id: Option<TierId>,
+}
+
+/// Information about all of the dApps that got into tiers, and tier rewards
+#[derive(
+    Encode,
+    Decode,
+    MaxEncodedLen,
+    RuntimeDebugNoBound,
+    PartialEqNoBound,
+    EqNoBound,
+    CloneNoBound,
+    TypeInfo,
+)]
+#[scale_info(skip_type_params(MD, NT))]
+struct OldDAppTierRewards<MD: Get<u32>, NT: Get<u32>> {
+    /// DApps and their corresponding tiers (or `None` if they have been claimed in the meantime)
+    pub dapps: BoundedVec<OldDAppTier, MD>,
+    /// Rewards for each tier. First entry refers to the first tier, and so on.
+    pub rewards: BoundedVec<Balance, NT>,
+    /// Period during which this struct was created.
+    #[codec(compact)]
+    pub period: PeriodNumber,
+}
+
+impl<MD: Get<u32>, NT: Get<u32>> Default for OldDAppTierRewards<MD, NT> {
+    fn default() -> Self {
+        Self {
+            dapps: BoundedVec::default(),
+            rewards: BoundedVec::default(),
+            period: 0,
+        }
+    }
+}
+
+// Legacy convenience type for `DAppTierRewards` usage.
+type OldDAppTierRewardsFor<T> =
+    OldDAppTierRewards<<T as Config>::MaxNumberOfContracts, <T as Config>::NumberOfTiers>;
+
+/// `OnRuntimeUpgrade` logic used to set & configure init dApp staking v3 storage items.
+pub struct DappStakingV3TierRewardAsTree<T>(PhantomData<T>);
+impl<T: Config> OnRuntimeUpgrade for DappStakingV3TierRewardAsTree<T> {
+    fn on_runtime_upgrade() -> Weight {
+        let mut counter = 0;
+        let mut translate = |pre: OldDAppTierRewardsFor<T>| -> DAppTierRewardsFor<T> {
+            let mut dapps_tree = BTreeMap::new();
+            for dapp_tier in &pre.dapps {
+                if let Some(tier_id) = dapp_tier.tier_id {
+                    dapps_tree.insert(dapp_tier.dapp_id, tier_id);
+                }
+            }
+
+            let result = DAppTierRewardsFor::<T>::new(dapps_tree, pre.rewards.to_vec(), pre.period);
+            if result.is_err() {
+                // Tests should ensure this never happens...
+                log::error!("Failed to migrate dApp tier rewards: {:?}", pre);
+            }
+
+            // For weight calculation purposes
+            counter.saturating_inc();
+
+            // ...if it does happen, there's not much to do except create an empty map
+            result.unwrap_or(
+                DAppTierRewardsFor::<T>::new(BTreeMap::new(), pre.rewards.to_vec(), pre.period)
+                    .unwrap_or_default(),
+            )
+        };
+
+        DAppTiers::<T>::translate(|_key, value: OldDAppTierRewardsFor<T>| Some(translate(value)));
+
+        T::DbWeight::get().reads_writes(counter, counter)
+    }
+}

--- a/pallets/dapp-staking-v3/src/migrations.rs
+++ b/pallets/dapp-staking-v3/src/migrations.rs
@@ -166,7 +166,7 @@ impl<MD: Get<u32>, NT: Get<u32>> Default for OldDAppTierRewards<MD, NT> {
 type OldDAppTierRewardsFor<T> =
     OldDAppTierRewards<<T as Config>::MaxNumberOfContracts, <T as Config>::NumberOfTiers>;
 
-/// `OnRuntimeUpgrade` logic used to set & configure init dApp staking v3 storage items.
+/// `OnRuntimeUpgrade` logic used to migrate DApp tiers storage item to BTreeMap.
 pub struct DappStakingV3TierRewardAsTree<T>(PhantomData<T>);
 impl<T: Config> OnRuntimeUpgrade for DappStakingV3TierRewardAsTree<T> {
     fn on_runtime_upgrade() -> Weight {

--- a/pallets/dapp-staking-v3/src/test/testing_utils.rs
+++ b/pallets/dapp-staking-v3/src/test/testing_utils.rs
@@ -983,7 +983,7 @@ pub(crate) fn assert_claim_dapp_reward(
         .clone();
     assert_eq!(
         info.try_claim(dapp_info.id),
-        Err(DAppTierError::RewardAlreadyClaimed),
+        Err(DAppTierError::NoDAppInTiers),
         "It must not be possible to claim the same reward twice!.",
     );
 }

--- a/pallets/dapp-staking-v3/src/test/tests.rs
+++ b/pallets/dapp-staking-v3/src/test/tests.rs
@@ -1792,7 +1792,7 @@ fn claim_dapp_reward_twice_for_same_era_fails() {
                 smart_contract,
                 claim_era_1
             ),
-            Error::<Test>::DAppRewardAlreadyClaimed,
+            Error::<Test>::NoClaimableRewards,
         );
 
         // We can still claim for another valid era
@@ -2299,34 +2299,25 @@ fn get_dapp_tier_assignment_basic_example_works() {
         assert_eq!(counter, number_of_smart_contracts);
 
         // 1st tier checks
-        let (entry_1, entry_2) = (tier_assignment.dapps[0], tier_assignment.dapps[1]);
-        assert_eq!(entry_1.dapp_id, 0);
-        assert_eq!(entry_1.tier_id, Some(0));
-
-        assert_eq!(entry_2.dapp_id, 1);
-        assert_eq!(entry_2.tier_id, Some(0));
+        let (dapp_1_tier, dapp_2_tier) = (tier_assignment.dapps[&0], tier_assignment.dapps[&1]);
+        assert_eq!(dapp_1_tier, 0);
+        assert_eq!(dapp_2_tier, 0);
 
         // 2nd tier checks
-        let (entry_3, entry_4) = (tier_assignment.dapps[2], tier_assignment.dapps[3]);
-        assert_eq!(entry_3.dapp_id, 2);
-        assert_eq!(entry_3.tier_id, Some(1));
-
-        assert_eq!(entry_4.dapp_id, 3);
-        assert_eq!(entry_4.tier_id, Some(1));
+        let (dapp_3_tier, dapp_4_tier) = (tier_assignment.dapps[&2], tier_assignment.dapps[&3]);
+        assert_eq!(dapp_3_tier, 1);
+        assert_eq!(dapp_4_tier, 1);
 
         // 4th tier checks
-        let (entry_5, entry_6) = (tier_assignment.dapps[4], tier_assignment.dapps[5]);
-        assert_eq!(entry_5.dapp_id, 4);
-        assert_eq!(entry_5.tier_id, Some(3));
-
-        assert_eq!(entry_6.dapp_id, 5);
-        assert_eq!(entry_6.tier_id, Some(3));
+        let (dapp_5_tier, dapp_6_tier) = (tier_assignment.dapps[&4], tier_assignment.dapps[&5]);
+        assert_eq!(dapp_5_tier, 3);
+        assert_eq!(dapp_6_tier, 3);
 
         // Sanity check - last dapp should not exists in the tier assignment
         assert!(tier_assignment
             .dapps
-            .binary_search_by(|x| x.dapp_id.cmp(&(dapp_index.try_into().unwrap())))
-            .is_err());
+            .get(&dapp_index.try_into().unwrap())
+            .is_none());
 
         // Check that rewards are calculated correctly
         tier_config

--- a/pallets/dapp-staking-v3/src/test/tests_types.rs
+++ b/pallets/dapp-staking-v3/src/test/tests_types.rs
@@ -2685,28 +2685,7 @@ fn dapp_tier_rewards_basic_tests() {
     get_u32_type!(NumberOfTiers, 3);
 
     // Example dApps & rewards
-    let dapps = vec![
-        DAppTier {
-            dapp_id: 1,
-            tier_id: Some(0),
-        },
-        DAppTier {
-            dapp_id: 2,
-            tier_id: Some(0),
-        },
-        DAppTier {
-            dapp_id: 3,
-            tier_id: Some(1),
-        },
-        DAppTier {
-            dapp_id: 5,
-            tier_id: Some(1),
-        },
-        DAppTier {
-            dapp_id: 6,
-            tier_id: Some(2),
-        },
-    ];
+    let dapps = BTreeMap::from([(1 as DAppId, 0 as TierId), (2, 0), (3, 1), (5, 1), (6, 2)]);
     let tier_rewards = vec![300, 20, 1];
     let period = 2;
 
@@ -2718,22 +2697,22 @@ fn dapp_tier_rewards_basic_tests() {
     .expect("Bounds are respected.");
 
     // 1st scenario - claim reward for a dApps
-    let tier_id = dapps[0].tier_id.unwrap();
+    let tier_id = dapps[&1];
     assert_eq!(
-        dapp_tier_rewards.try_claim(dapps[0].dapp_id),
+        dapp_tier_rewards.try_claim(1),
         Ok((tier_rewards[tier_id as usize], tier_id))
     );
 
-    let tier_id = dapps[3].tier_id.unwrap();
+    let tier_id = dapps[&5];
     assert_eq!(
-        dapp_tier_rewards.try_claim(dapps[3].dapp_id),
+        dapp_tier_rewards.try_claim(5),
         Ok((tier_rewards[tier_id as usize], tier_id))
     );
 
     // 2nd scenario - try to claim already claimed reward
     assert_eq!(
-        dapp_tier_rewards.try_claim(dapps[0].dapp_id),
-        Err(DAppTierError::RewardAlreadyClaimed),
+        dapp_tier_rewards.try_claim(1),
+        Err(DAppTierError::NoDAppInTiers),
         "Cannot claim the same reward twice."
     );
 

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -1380,7 +1380,7 @@ pub type Executive = frame_executive::Executive<
 /// All migrations that will run on the next runtime upgrade.
 ///
 /// Once done, migrations should be removed from the tuple.
-pub type Migrations = ();
+pub type Migrations = (pallet_dapp_staking_v3::migrations::DappStakingV3TierRewardAsTree<Runtime>,);
 
 type EventRecord = frame_system::EventRecord<
     <Runtime as frame_system::Config>::RuntimeEvent,


### PR DESCRIPTION
**Pull Request Summary**

Replaces the _sorted vector_ for rewards, with a `BTreeMap`.
This allows for efficient removal of entries from the tree, once reward has been claimed.

Error `DAppRewardAlreadyClaimed` has been removed.
Once dApp reward has been claimed for an era, further claim calls will result in
`NoClaimableRewards` error.

Also includes a minor storage migration, only to be used on Shibuya.
Moved all migration logic under a new module, for better readability.

Benchmarks will be re-run at another time.