### PR TITLE
Basic static price provider pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,6 +531,7 @@ dependencies = [
  "pallet-xc-asset-config",
  "parity-scale-codec",
  "scale-info",
+ "sp-arithmetic",
  "sp-core",
  "sp-io",
  "sp-runtime",
@@ -6061,6 +6062,7 @@ dependencies = [
  "pallet-preimage",
  "pallet-proxy",
  "pallet-scheduler",
+ "pallet-static-price-provider",
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",
@@ -8696,6 +8698,25 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-static-price-provider"
+version = "0.1.0"
+dependencies = [
+ "astar-primitives",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-balances",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-arithmetic",
+ "sp-core",
  "sp-runtime",
  "sp-std",
 ]
@@ -13209,6 +13230,7 @@ dependencies = [
  "pallet-proxy",
  "pallet-scheduler",
  "pallet-session",
+ "pallet-static-price-provider",
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,6 +282,7 @@ pallet-ethereum-checked = { path = "./pallets/ethereum-checked", default-feature
 pallet-inflation = { path = "./pallets/inflation", default-features = false }
 pallet-dynamic-evm-base-fee = { path = "./pallets/dynamic-evm-base-fee", default-features = false }
 pallet-unified-accounts = { path = "./pallets/unified-accounts", default-features = false }
+pallet-static-price-provider = { path = "./pallets/static-price-provider", default-features = false }
 
 dapp-staking-v3-runtime-api = { path = "./pallets/dapp-staking-v3/rpc/runtime-api", default-features = false }
 

--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -52,6 +52,7 @@ pub use sp_std::vec::Vec;
 
 use astar_primitives::{
     dapp_staking::{CycleConfiguration, SmartContractHandle, StakingRewardHandler},
+    oracle::PriceProvider,
     Balance, BlockNumber,
 };
 

--- a/pallets/dapp-staking-v3/src/types.rs
+++ b/pallets/dapp-staking-v3/src/types.rs
@@ -1757,19 +1757,3 @@ pub struct CleanupMarker {
     #[codec(compact)]
     pub dapp_tiers_index: EraNumber,
 }
-
-///////////////////////////////////////////////////////////////////////
-////////////   MOVE THIS TO SOME PRIMITIVES CRATE LATER    ////////////
-///////////////////////////////////////////////////////////////////////
-
-/// Interface for fetching price of the native token.
-///
-/// TODO: discussion about below
-/// The assumption is that the underlying implementation will ensure
-/// this price is averaged and/or weighted over a certain period of time.
-/// Alternative is to provide e.g. number of blocks for which an approximately averaged value is needed,
-/// and let the underlying implementation take care converting block range into value best represening it.
-pub trait PriceProvider {
-    /// Get the price of the native token.
-    fn average_price() -> FixedU64;
-}

--- a/pallets/static-price-provider/Cargo.toml
+++ b/pallets/static-price-provider/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name = "pallet-static-price-provider"
+version = "0.1.0"
+license = "GPL-3.0-or-later"
+description = "Static price provider for native currency"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+log = { workspace = true }
+parity-scale-codec = { workspace = true }
+serde = { workspace = true }
+
+astar-primitives = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+scale-info = { workspace = true }
+sp-arithmetic = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
+
+frame-benchmarking = { workspace = true, optional = true }
+
+[dev-dependencies]
+pallet-balances = { workspace = true }
+sp-core = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+	"parity-scale-codec/std",
+	"log/std",
+	"sp-core/std",
+	"scale-info/std",
+	"serde/std",
+	"sp-std/std",
+	"frame-support/std",
+	"frame-system/std",
+	"pallet-balances/std",
+	"astar-primitives/std",
+	"sp-arithmetic/std",
+]
+runtime-benchmarks = [
+	"frame-benchmarking",
+	"frame-support/runtime-benchmarks",
+	"frame-system/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
+	"astar-primitives/runtime-benchmarks",
+]
+try-runtime = ["frame-support/try-runtime"]

--- a/pallets/static-price-provider/src/lib.rs
+++ b/pallets/static-price-provider/src/lib.rs
@@ -1,0 +1,116 @@
+// This file is part of Astar.
+
+// Copyright (C) 2019-2023 Stake Technologies Pte.Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Astar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Astar is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Astar. If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use frame_support::{pallet_prelude::*, traits::OnRuntimeUpgrade};
+use frame_system::{ensure_root, pallet_prelude::*};
+pub use pallet::*;
+use sp_arithmetic::{fixed_point::FixedU64, traits::Zero, FixedPointNumber};
+use sp_std::marker::PhantomData;
+
+use astar_primitives::oracle::PriceProvider;
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+#[frame_support::pallet]
+pub mod pallet {
+
+    use super::*;
+
+    /// The current storage version.
+    pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+
+    #[pallet::pallet]
+    #[pallet::storage_version(STORAGE_VERSION)]
+    pub struct Pallet<T>(PhantomData<T>);
+
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+        /// The overarching event type.
+        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+    }
+
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(crate) fn deposit_event)]
+    pub enum Event<T: Config> {
+        /// New static native currency price has been set.
+        PriceSet { price: FixedU64 },
+    }
+
+    #[pallet::error]
+    pub enum Error<T> {
+        /// Zero is invalid value for the price (hopefully).
+        ZeroPrice,
+    }
+
+    /// Default value handler for active price.
+    /// This pallet is temporary and it's not worth bothering with genesis config.
+    pub struct DefaultActivePrice;
+    impl Get<FixedU64> for DefaultActivePrice {
+        fn get() -> FixedU64 {
+            FixedU64::from_rational(1, 10)
+        }
+    }
+
+    /// Current active native currency price.
+    #[pallet::storage]
+    #[pallet::whitelist_storage]
+    pub type ActivePrice<T: Config> = StorageValue<_, FixedU64, ValueQuery, DefaultActivePrice>;
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        /// Privileged action used to set the active native currency price.
+        ///
+        /// This is a temporary solution before oracle is implemented & operational.
+        #[pallet::call_index(0)]
+        #[pallet::weight(T::DbWeight::get().writes(1))]
+        pub fn force_set_price(origin: OriginFor<T>, price: FixedU64) -> DispatchResult {
+            ensure_root(origin)?;
+            ensure!(!price.is_zero(), Error::<T>::ZeroPrice);
+
+            ActivePrice::<T>::put(price);
+
+            Self::deposit_event(Event::<T>::PriceSet { price });
+
+            Ok(().into())
+        }
+    }
+
+    impl<T: Config> PriceProvider for Pallet<T> {
+        fn average_price() -> FixedU64 {
+            ActivePrice::<T>::get()
+        }
+    }
+}
+
+/// `OnRuntimeUpgrade` logic for integrating this pallet into the live network.
+pub struct InitActivePrice<T, P>(PhantomData<(T, P)>);
+impl<T: Config, P: Get<FixedU64>> OnRuntimeUpgrade for InitActivePrice<T, P> {
+    fn on_runtime_upgrade() -> Weight {
+        let init_price = P::get().max(FixedU64::from_rational(1, FixedU64::DIV.into()));
+
+        log::info!("Setting initial active price to {:?}", init_price);
+        ActivePrice::<T>::put(init_price);
+
+        T::DbWeight::get().writes(1)
+    }
+}

--- a/pallets/static-price-provider/src/mock.rs
+++ b/pallets/static-price-provider/src/mock.rs
@@ -1,0 +1,117 @@
+// This file is part of Astar.
+
+// Copyright (C) 2019-2023 Stake Technologies Pte.Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Astar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Astar is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Astar. If not, see <http://www.gnu.org/licenses/>.
+
+use crate::{self as pallet_static_price_provider};
+
+use frame_support::{
+    construct_runtime, parameter_types,
+    sp_io::TestExternalities,
+    traits::{ConstU128, ConstU32},
+    weights::Weight,
+};
+
+use sp_core::H256;
+use sp_runtime::traits::{BlakeTwo256, IdentityLookup};
+
+use astar_primitives::{testing::Header, Balance, BlockNumber};
+type AccountId = u64;
+
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+parameter_types! {
+    pub const BlockHashCount: BlockNumber = 250;
+    pub BlockWeights: frame_system::limits::BlockWeights =
+        frame_system::limits::BlockWeights::simple_max(Weight::from_parts(1024, 0));
+}
+
+impl frame_system::Config for Test {
+    type BaseCallFilter = frame_support::traits::Everything;
+    type BlockWeights = ();
+    type BlockLength = ();
+    type RuntimeOrigin = RuntimeOrigin;
+    type Index = u64;
+    type RuntimeCall = RuntimeCall;
+    type BlockNumber = BlockNumber;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = AccountId;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type RuntimeEvent = RuntimeEvent;
+    type BlockHashCount = BlockHashCount;
+    type DbWeight = ();
+    type Version = ();
+    type PalletInfo = PalletInfo;
+    type AccountData = pallet_balances::AccountData<Balance>;
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+    type SystemWeightInfo = ();
+    type SS58Prefix = ();
+    type OnSetCode = ();
+    type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
+
+impl pallet_balances::Config for Test {
+    type MaxLocks = ConstU32<4>;
+    type MaxReserves = ();
+    type ReserveIdentifier = [u8; 8];
+    type Balance = Balance;
+    type RuntimeEvent = RuntimeEvent;
+    type DustRemoval = ();
+    type ExistentialDeposit = ConstU128<1>;
+    type AccountStore = System;
+    type WeightInfo = ();
+    type HoldIdentifier = ();
+    type FreezeIdentifier = ();
+    type MaxHolds = ConstU32<0>;
+    type MaxFreezes = ConstU32<0>;
+}
+
+impl pallet_static_price_provider::Config for Test {
+    type RuntimeEvent = RuntimeEvent;
+}
+
+construct_runtime!(
+    pub struct Test
+    where
+        Block = Block,
+        NodeBlock = Block,
+        UncheckedExtrinsic = UncheckedExtrinsic,
+    {
+        System: frame_system,
+        Balances: pallet_balances,
+        StaticPriceProvider: pallet_static_price_provider,
+    }
+);
+
+pub struct ExternalityBuilder;
+impl ExternalityBuilder {
+    pub fn build() -> TestExternalities {
+        let storage = frame_system::GenesisConfig::default()
+            .build_storage::<Test>()
+            .unwrap();
+
+        let mut ext = TestExternalities::from(storage);
+        ext.execute_with(|| {
+            System::set_block_number(1);
+        });
+
+        ext
+    }
+}

--- a/pallets/static-price-provider/src/tests.rs
+++ b/pallets/static-price-provider/src/tests.rs
@@ -1,0 +1,60 @@
+// This file is part of Astar.
+
+// Copyright (C) 2019-2023 Stake Technologies Pte.Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Astar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Astar is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Astar. If not, see <http://www.gnu.org/licenses/>.
+
+use super::{pallet::Error, Event, *};
+use frame_support::{assert_noop, assert_ok};
+use mock::*;
+use sp_runtime::traits::{BadOrigin, Zero};
+
+#[test]
+fn force_set_price_works() {
+    ExternalityBuilder::build().execute_with(|| {
+        assert!(!ActivePrice::<Test>::get().is_zero(), "Sanity check");
+
+        let new_price = ActivePrice::<Test>::get() * 2.into();
+        assert_ok!(StaticPriceProvider::force_set_price(
+            RuntimeOrigin::root(),
+            new_price
+        ));
+        System::assert_last_event(RuntimeEvent::StaticPriceProvider(Event::PriceSet {
+            price: new_price,
+        }));
+        assert_eq!(ActivePrice::<Test>::get(), new_price);
+        assert_eq!(StaticPriceProvider::average_price(), new_price);
+    })
+}
+
+#[test]
+fn force_set_zero_price_fails() {
+    ExternalityBuilder::build().execute_with(|| {
+        assert_noop!(
+            StaticPriceProvider::force_set_price(RuntimeOrigin::root(), 0.into()),
+            Error::<Test>::ZeroPrice
+        );
+    })
+}
+
+#[test]
+fn force_set_price_with_invalid_origin_fails() {
+    ExternalityBuilder::build().execute_with(|| {
+        assert_noop!(
+            StaticPriceProvider::force_set_price(RuntimeOrigin::signed(1), 1.into()),
+            BadOrigin
+        );
+    })
+}

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -21,6 +21,7 @@ fp-evm = { workspace = true }
 # Substrate dependencies
 frame-support = { workspace = true }
 pallet-assets = { workspace = true }
+sp-arithmetic = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
@@ -66,5 +67,6 @@ std = [
 	"pallet-evm/std",
 	"pallet-evm-precompile-assets-erc20/std",
 	"pallet-evm-precompile-dispatch/std",
+	"sp-arithmetic/std",
 ]
 runtime-benchmarks = ["xcm-builder/runtime-benchmarks", "pallet-assets/runtime-benchmarks"]

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -41,6 +41,9 @@ pub mod dapp_staking;
 /// Useful primitives for testing.
 pub mod testing;
 
+/// Oracle & price primitives.
+pub mod oracle;
+
 /// Benchmark primitives
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarks;

--- a/primitives/src/oracle.rs
+++ b/primitives/src/oracle.rs
@@ -1,0 +1,28 @@
+// This file is part of Astar.
+
+// Copyright (C) 2019-2023 Stake Technologies Pte.Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Astar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Astar is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Astar. If not, see <http://www.gnu.org/licenses/>.
+
+use sp_arithmetic::fixed_point::FixedU64;
+
+/// Interface for fetching price of the native token.
+///
+/// **NOTE:** This is just a temporary interface, and will be replaced with a proper oracle which will average
+/// the price over a certain period of time.
+pub trait PriceProvider {
+    /// Get the price of the native token.
+    fn average_price() -> FixedU64;
+}

--- a/runtime/local/Cargo.toml
+++ b/runtime/local/Cargo.toml
@@ -81,6 +81,7 @@ pallet-evm-precompile-substrate-ecdsa = { workspace = true }
 pallet-evm-precompile-unified-accounts = { workspace = true }
 pallet-evm-precompile-xvm = { workspace = true }
 pallet-inflation = { workspace = true }
+pallet-static-price-provider = { workspace = true }
 pallet-unified-accounts = { workspace = true }
 pallet-xvm = { workspace = true }
 
@@ -130,6 +131,7 @@ std = [
 	"pallet-dapp-staking-migration/std",
 	"dapp-staking-v3-runtime-api/std",
 	"pallet-inflation/std",
+	"pallet-static-price-provider/std",
 	"pallet-dynamic-evm-base-fee/std",
 	"pallet-ethereum/std",
 	"pallet-evm/std",
@@ -241,6 +243,7 @@ try-runtime = [
 	"pallet-evm/try-runtime",
 	"pallet-ethereum-checked/try-runtime",
 	"pallet-dapp-staking-migration/try-runtime",
+	"pallet-static-price-provider/try-runtime",
 ]
 evm-tracing = [
 	"moonbeam-evm-tracer",

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -48,7 +48,6 @@ use pallet_grandpa::{fg_primitives, AuthorityList as GrandpaAuthorityList};
 use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
 use parity_scale_codec::{Compact, Decode, Encode, MaxEncodedLen};
 use sp_api::impl_runtime_apis;
-use sp_arithmetic::fixed_point::FixedU64;
 use sp_core::{crypto::KeyTypeId, ConstBool, OpaqueMetadata, H160, H256, U256};
 use sp_runtime::{
     create_runtime_str, generic, impl_opaque_keys,
@@ -485,11 +484,8 @@ impl pallet_dapps_staking::Config for Runtime {
     type ForcePalletDisabled = ConstBool<false>; // This will be set to `true` when needed
 }
 
-pub struct DummyPriceProvider;
-impl pallet_dapp_staking_v3::PriceProvider for DummyPriceProvider {
-    fn average_price() -> FixedU64 {
-        FixedU64::from_rational(1, 10)
-    }
+impl pallet_static_price_provider::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
 }
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -515,7 +511,7 @@ impl pallet_dapp_staking_v3::Config for Runtime {
     type Currency = Balances;
     type SmartContract = SmartContract<AccountId>;
     type ManagerOrigin = frame_system::EnsureRoot<AccountId>;
-    type NativePriceProvider = DummyPriceProvider;
+    type NativePriceProvider = StaticPriceProvider;
     type StakingRewardHandler = Inflation;
     type CycleConfiguration = InflationCycleConfig;
     type EraRewardSpanLength = ConstU32<8>;
@@ -1104,6 +1100,7 @@ construct_runtime!(
         DappStaking: pallet_dapp_staking_v3,
         DappStakingMigration: pallet_dapp_staking_migration,
         Inflation: pallet_inflation,
+        StaticPriceProvider: pallet_static_price_provider,
         BlockReward: pallet_block_rewards_hybrid,
         TransactionPayment: pallet_transaction_payment,
         EVM: pallet_evm,

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -113,6 +113,7 @@ pallet-evm-precompile-unified-accounts = { workspace = true }
 pallet-evm-precompile-xcm = { workspace = true }
 pallet-evm-precompile-xvm = { workspace = true }
 pallet-inflation = { workspace = true }
+pallet-static-price-provider = { workspace = true }
 pallet-unified-accounts = { workspace = true }
 pallet-xc-asset-config = { workspace = true }
 pallet-xcm = { workspace = true }
@@ -195,6 +196,7 @@ std = [
 	"pallet-dapp-staking-migration/std",
 	"dapp-staking-v3-runtime-api/std",
 	"pallet-inflation/std",
+	"pallet-static-price-provider/std",
 	"pallet-identity/std",
 	"pallet-multisig/std",
 	"pallet-insecure-randomness-collective-flip/std",
@@ -284,6 +286,7 @@ try-runtime = [
 	"pallet-dapp-staking-v3/try-runtime",
 	"pallet-dapp-staking-migration/try-runtime",
 	"pallet-inflation/try-runtime",
+	"pallet-static-price-provider/try-runtime",
 	"pallet-sudo/try-runtime",
 	"pallet-timestamp/try-runtime",
 	"pallet-transaction-payment/try-runtime",


### PR DESCRIPTION
**Pull Request Summary**

Introduces a basic pallet to handle active native currency price setting.
This is used when calculating dApp tier slots & rewards.

The proper solution will be done in the future via oracle, but for now, a privileged
call for price setting is enabled.
