### PR TITLE
Expanded DappStakingApi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2441,6 +2441,7 @@ dependencies = [
  "astar-primitives",
  "pallet-dapp-staking-v3",
  "sp-api",
+ "sp-std",
 ]
 
 [[package]]

--- a/pallets/dapp-staking-v3/rpc/runtime-api/Cargo.toml
+++ b/pallets/dapp-staking-v3/rpc/runtime-api/Cargo.toml
@@ -12,6 +12,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 sp-api = { workspace = true }
+sp-std = { workspace = true }
 
 astar-primitives = { workspace = true }
 pallet-dapp-staking-v3 = { workspace = true }
@@ -20,6 +21,7 @@ pallet-dapp-staking-v3 = { workspace = true }
 default = ["std"]
 std = [
 	"sp-api/std",
+	"sp-std/std",
 	"pallet-dapp-staking-v3/std",
 	"astar-primitives/std",
 ]

--- a/pallets/dapp-staking-v3/rpc/runtime-api/src/lib.rs
+++ b/pallets/dapp-staking-v3/rpc/runtime-api/src/lib.rs
@@ -19,7 +19,8 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use astar_primitives::BlockNumber;
-use pallet_dapp_staking_v3::EraNumber;
+use pallet_dapp_staking_v3::{DAppId, EraNumber, PeriodNumber, TierId};
+pub use sp_std::collections::btree_map::BTreeMap;
 
 sp_api::decl_runtime_apis! {
 
@@ -27,6 +28,9 @@ sp_api::decl_runtime_apis! {
     ///
     /// Used to provide information otherwise not available via RPC.
     pub trait DappStakingApi {
+
+        /// How many periods are there in one cycle.
+        fn periods_per_cycle() -> PeriodNumber;
 
         /// For how many standard era lengths does the voting subperiod last.
         fn eras_per_voting_subperiod() -> EraNumber;
@@ -36,5 +40,8 @@ sp_api::decl_runtime_apis! {
 
         /// How many blocks are there per standard era.
         fn blocks_per_era() -> BlockNumber;
+
+        /// Get dApp tier assignment for the given dApp.
+        fn get_dapp_tier_assignment() -> BTreeMap<DAppId, TierId>;
     }
 }

--- a/pallets/dapp-staking-v3/src/benchmarking/mod.rs
+++ b/pallets/dapp-staking-v3/src/benchmarking/mod.rs
@@ -946,8 +946,11 @@ mod benchmarks {
 
         #[block]
         {
-            let (dapp_tiers, _) =
-                Pallet::<T>::get_dapp_tier_assignment(reward_era, reward_period, reward_pool);
+            let (dapp_tiers, _) = Pallet::<T>::get_dapp_tier_assignment_and_rewards(
+                reward_era,
+                reward_period,
+                reward_pool,
+            );
             assert_eq!(dapp_tiers.dapps.len(), x as usize);
         }
     }

--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -56,9 +56,6 @@ use astar_primitives::{
     Balance, BlockNumber,
 };
 
-// TODO: remove this after rebase
-use sp_std::collections::btree_map::BTreeMap;
-
 pub use pallet::*;
 
 #[cfg(test)]
@@ -1640,8 +1637,7 @@ pub mod pallet {
             T::CycleConfiguration::blocks_per_era().saturating_mul(T::UnlockingPeriod::get().into())
         }
 
-        // TODO: finish this after rebase/merge with latest pending updates
-        // Maybe define an interface for this.
+        /// Returns the dApp tier assignment for the current era, based on the current stake amounts.
         pub fn get_dapp_tier_assignment() -> BTreeMap<DAppId, TierId> {
             let protocol_state = ActiveProtocolState::<T>::get();
 
@@ -1651,17 +1647,7 @@ pub mod pallet {
                 Balance::zero(),
             );
 
-            dapp_tiers
-                .dapps
-                .into_iter()
-                .filter_map(|dapp_tier| {
-                    if let Some(tier_id) = dapp_tier.tier_id {
-                        Some((dapp_tier.dapp_id, tier_id))
-                    } else {
-                        None
-                    }
-                })
-                .collect()
+            dapp_tiers.dapps.into_inner()
         }
 
         /// Assign eligible dApps into appropriate tiers, and calculate reward for each tier.

--- a/pallets/dapp-staking-v3/src/test/tests.rs
+++ b/pallets/dapp-staking-v3/src/test/tests.rs
@@ -2262,7 +2262,7 @@ fn force_with_incorrect_origin_fails() {
 }
 
 #[test]
-fn get_dapp_tier_assignment_basic_example_works() {
+fn get_dapp_tier_assignment_and_rewards_basic_example_works() {
     ExtBuilder::build().execute_with(|| {
         // This test will rely on the configuration inside the mock file.
         // If that changes, this test will have to be updated as well.
@@ -2339,7 +2339,7 @@ fn get_dapp_tier_assignment_basic_example_works() {
         // Finally, the actual test
         let protocol_state = ActiveProtocolState::<Test>::get();
         let dapp_reward_pool = 1000000;
-        let (tier_assignment, counter) = DappStaking::get_dapp_tier_assignment(
+        let (tier_assignment, counter) = DappStaking::get_dapp_tier_assignment_and_rewards(
             protocol_state.era + 1,
             protocol_state.period_number(),
             dapp_reward_pool,
@@ -2402,7 +2402,7 @@ fn get_dapp_tier_assignment_basic_example_works() {
 }
 
 #[test]
-fn get_dapp_tier_assignment_zero_slots_per_tier_works() {
+fn get_dapp_tier_assignment_and_rewards_zero_slots_per_tier_works() {
     ExtBuilder::build().execute_with(|| {
         // This test will rely on the configuration inside the mock file.
         // If that changes, this test might have to be updated as well.
@@ -2417,7 +2417,7 @@ fn get_dapp_tier_assignment_zero_slots_per_tier_works() {
         // Calculate tier assignment (we don't need dApps for this test)
         let protocol_state = ActiveProtocolState::<Test>::get();
         let dapp_reward_pool = 1000000;
-        let (tier_assignment, counter) = DappStaking::get_dapp_tier_assignment(
+        let (tier_assignment, counter) = DappStaking::get_dapp_tier_assignment_and_rewards(
             protocol_state.era,
             protocol_state.period_number(),
             dapp_reward_pool,

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -59,7 +59,7 @@ use sp_runtime::{
     transaction_validity::{TransactionSource, TransactionValidity, TransactionValidityError},
     ApplyExtrinsicResult, FixedPointNumber, Perbill, Permill, Perquintill, RuntimeDebug,
 };
-use sp_std::prelude::*;
+use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 
 use astar_primitives::{
     dapp_staking::{CycleConfiguration, SmartContract},
@@ -1731,6 +1731,10 @@ impl_runtime_apis! {
     }
 
     impl dapp_staking_v3_runtime_api::DappStakingApi<Block> for Runtime {
+        fn periods_per_cycle() -> pallet_dapp_staking_v3::PeriodNumber {
+            InflationCycleConfig::periods_per_cycle()
+        }
+
         fn eras_per_voting_subperiod() -> pallet_dapp_staking_v3::EraNumber {
             InflationCycleConfig::eras_per_voting_subperiod()
         }
@@ -1741,6 +1745,10 @@ impl_runtime_apis! {
 
         fn blocks_per_era() -> BlockNumber {
             InflationCycleConfig::blocks_per_era()
+        }
+
+        fn get_dapp_tier_assignment() -> BTreeMap<pallet_dapp_staking_v3::DAppId, pallet_dapp_staking_v3::TierId> {
+            DappStaking::get_dapp_tier_assignment()
         }
     }
 

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -65,7 +65,7 @@ use sp_runtime::{
     transaction_validity::{TransactionSource, TransactionValidity, TransactionValidityError},
     ApplyExtrinsicResult, FixedPointNumber, Perbill, Permill, Perquintill, RuntimeDebug,
 };
-use sp_std::prelude::*;
+use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 
 use astar_primitives::{
     dapp_staking::{CycleConfiguration, SmartContract},
@@ -1926,6 +1926,10 @@ impl_runtime_apis! {
     }
 
     impl dapp_staking_v3_runtime_api::DappStakingApi<Block> for Runtime {
+        fn periods_per_cycle() -> pallet_dapp_staking_v3::PeriodNumber {
+            InflationCycleConfig::periods_per_cycle()
+        }
+
         fn eras_per_voting_subperiod() -> pallet_dapp_staking_v3::EraNumber {
             InflationCycleConfig::eras_per_voting_subperiod()
         }
@@ -1936,6 +1940,10 @@ impl_runtime_apis! {
 
         fn blocks_per_era() -> BlockNumber {
             InflationCycleConfig::blocks_per_era()
+        }
+
+        fn get_dapp_tier_assignment() -> BTreeMap<pallet_dapp_staking_v3::DAppId, pallet_dapp_staking_v3::TierId> {
+            DappStaking::get_dapp_tier_assignment()
         }
     }
 


### PR DESCRIPTION
**Pull Request Summary**

Extends the dApp staking runtime API with two additional calls:
- `periods_per_cycle()` - how many periods occur in a single inflation cycle
- `get_dapp_tier_assignment()` - returns dApps tier assignment based on the staked values at the called block
