### PR TITLE
dApp Staking v3 - Unbond During Decommission

### DIFF
--- a/pallets/dapps-staking/src/pallet/mod.rs
+++ b/pallets/dapps-staking/src/pallet/mod.rs
@@ -569,7 +569,6 @@ pub mod pallet {
             #[pallet::compact] value: Balance,
         ) -> DispatchResultWithPostInfo {
             Self::ensure_pallet_enabled()?;
-            Self::ensure_not_in_decommission()?;
             let staker = ensure_signed(origin)?;
 
             ensure!(value > Zero::zero(), Error::<T>::UnstakingWithNoValue);
@@ -630,7 +629,6 @@ pub mod pallet {
         #[pallet::weight(T::WeightInfo::withdraw_unbonded())]
         pub fn withdraw_unbonded(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
             Self::ensure_pallet_enabled()?;
-            Self::ensure_not_in_decommission()?;
             let staker = ensure_signed(origin)?;
 
             let mut ledger = Self::ledger(&staker);

--- a/pallets/dapps-staking/src/tests.rs
+++ b/pallets/dapps-staking/src/tests.rs
@@ -2173,11 +2173,18 @@ fn decommision_is_ok() {
             DappsStaking::withdraw_unbonded(RuntimeOrigin::signed(account)),
             Error::<TestRuntime>::NothingToWithdraw
         );
+        assert_noop!(
+            DappsStaking::set_reward_destination(
+                RuntimeOrigin::signed(account),
+                RewardDestination::StakeBalance
+            ),
+            Error::<TestRuntime>::NotActiveStaker
+        );
     })
 }
 
 #[test]
-fn no_era_change_during_decommision() {
+fn no_era_change_during_decommission() {
     ExternalityBuilder::build().execute_with(|| {
         initialize_first_block();
 

--- a/pallets/dapps-staking/src/tests.rs
+++ b/pallets/dapps-staking/src/tests.rs
@@ -2147,20 +2147,12 @@ fn decommision_is_ok() {
             Error::<TestRuntime>::DecommissionInProgress
         );
         assert_noop!(
-            DappsStaking::unbond_and_unstake(RuntimeOrigin::signed(account), contract_id, 100),
-            Error::<TestRuntime>::DecommissionInProgress
-        );
-        assert_noop!(
             DappsStaking::nomination_transfer(
                 RuntimeOrigin::signed(account),
                 contract_id,
                 100,
                 contract_id,
             ),
-            Error::<TestRuntime>::DecommissionInProgress
-        );
-        assert_noop!(
-            DappsStaking::withdraw_unbonded(RuntimeOrigin::signed(account)),
             Error::<TestRuntime>::DecommissionInProgress
         );
 
@@ -2172,6 +2164,14 @@ fn decommision_is_ok() {
         assert_noop!(
             DappsStaking::claim_dapp(RuntimeOrigin::signed(account), contract_id, 1,),
             Error::<TestRuntime>::NotOperatedContract
+        );
+        assert_noop!(
+            DappsStaking::unbond_and_unstake(RuntimeOrigin::signed(account), contract_id, 100),
+            Error::<TestRuntime>::NotOperatedContract
+        );
+        assert_noop!(
+            DappsStaking::withdraw_unbonded(RuntimeOrigin::signed(account)),
+            Error::<TestRuntime>::NothingToWithdraw
         );
     })
 }


### PR DESCRIPTION
**Pull Request Summary**

Adds `unbond_and_unstake` and `withdraw_unbonded` to calls supported in the decommissioning period.

This is needed for Ledger users who want to switch accounts since generic Ledger app won't be available
on the launch day.
