### PR TITLE
fix: `BuyExecution` xcm benchmark tests

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -47,7 +47,7 @@ jobs:
       uses: actions-rs/tarpaulin@v0.1
       with:
         version: 0.22.0
-        args: '--workspace -e astar-collator xcm-tools local-runtime shibuya-runtime shiden-runtime astar-runtime integration-tests --exclude-files vendor/* bin/* runtime/* tests/* **/mock.rs **/weights.rs precompiles/utils/*'
+        args: '--workspace --features try-runtime,runtime-benchmarks -e astar-collator xcm-tools local-runtime shibuya-runtime shiden-runtime astar-runtime integration-tests --exclude-files vendor/* bin/* runtime/* tests/* **/mock.rs **/weights.rs precompiles/utils/*'
         out-type: Xml
 
     - name: Code Coverage Summary Report

--- a/pallets/astar-xcm-benchmarks/src/generic/benchmarking.rs
+++ b/pallets/astar-xcm-benchmarks/src/generic/benchmarking.rs
@@ -43,7 +43,7 @@ mod benchmarks {
         let fee_asset = Concrete(MultiLocation::parent());
 
         let instruction = Instruction::<XcmCallOf<T>>::BuyExecution {
-            fees: (fee_asset, 100_000_000u128).into(), // should be something inside of holding
+            fees: (fee_asset, u128::MAX).into(), // should be something inside of holding
             // this should not be Unlimited, as xcm-executor will skip buying the
             // exceution altogether.
             weight_limit: WeightLimit::Limited(Weight::from_parts(1u64, 1024)),

--- a/pallets/astar-xcm-benchmarks/src/mock.rs
+++ b/pallets/astar-xcm-benchmarks/src/mock.rs
@@ -228,7 +228,7 @@ parameter_types! {
     pub const MaxInstructions: u32 = 100;
     pub const MaxAssetsIntoHolding: u32 = 64;
 
-    pub const WeightPrice: (xcm::latest::AssetId, u128, u128) = (Concrete(TransactAssetLocation::get()), 1_000_000, 1024);
+    pub WeightPrice: (xcm::latest::AssetId, u128, u128) = (Concrete(Parent.into()), 1_000_000, 1024);
     pub const UnitWeightCost: u64 = 10;
 }
 


### PR DESCRIPTION
**Pull Request Summary**
- Fix a silly mistake in xcm benchmarks mock where fee currency was set worngly.
- Add `runtime-benchmarks` and `try-runtime` features in tarpaulin CI job


**Check list**
- [ ] added or updated unit tests
- [ ] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [ ] added benchmarks & weights for any modified runtime logics.
