### PR TITLE
dApp staking v3 - claim staker benchmark fix

### DIFF
--- a/pallets/dapp-staking-v3/src/benchmarking/utils.rs
+++ b/pallets/dapp-staking-v3/src/benchmarking/utils.rs
@@ -53,7 +53,7 @@ pub(super) fn advance_to_era<T: Config>(era: EraNumber) {
 ///
 /// Relies on the `force` approach to advance one era per block.
 pub(super) fn force_advance_to_era<T: Config>(era: EraNumber) {
-    assert!(era >= ActiveProtocolState::<T>::get().era);
+    assert!(era > ActiveProtocolState::<T>::get().era);
     while ActiveProtocolState::<T>::get().era < era {
         assert_ok!(DappStaking::<T>::force(
             RawOrigin::Root.into(),
@@ -259,4 +259,19 @@ fn trivial_fisher_yates_shuffle<T>(vector: &mut Vec<T>, random_seed: u64) {
         vector.swap(i, j);
         rng = (rng.wrapping_mul(8427637) + 1) as usize; // Some random number generation
     }
+}
+
+/// Returns max amount of rewards that can be claimed in a single claim reward call from a past period.
+///
+/// Bounded by era reward span length & number of eras per period (not length but absolute number).
+pub(super) fn max_claim_size_past_period<T: Config>() -> u32 {
+    T::EraRewardSpanLength::get().min(T::CycleConfiguration::eras_per_build_and_earn_subperiod())
+}
+
+/// Returns max amount of rewards that can be claimed in a single claim reward call from an ongoing period.
+///
+/// Bounded by era reward span length & number of eras per period (not length but absolute number).
+pub(super) fn max_claim_size_ongoing_period<T: Config>() -> u32 {
+    T::EraRewardSpanLength::get()
+        .min(T::CycleConfiguration::eras_per_build_and_earn_subperiod() - 1)
 }


### PR DESCRIPTION
**Pull Request Summary**

Both a minor improvement & bug fix in claim staker rewards benchmark.

There were issues depending on whether the `Build&Earn` duration was longer or shorter than `EraRewardSpanLength`.


