### PR TITLE
Integrated dApps improvement

### DIFF
--- a/pallets/dapp-staking-v3/src/test/testing_utils.rs
+++ b/pallets/dapp-staking-v3/src/test/testing_utils.rs
@@ -112,7 +112,6 @@ pub(crate) fn assert_register(owner: AccountId, smart_contract: &MockSmartContra
 
     // Verify post-state
     let dapp_info = IntegratedDApps::<Test>::get(smart_contract).unwrap();
-    assert_eq!(dapp_info.state, DAppState::Registered);
     assert_eq!(dapp_info.owner, owner);
     assert_eq!(dapp_info.id, pre_snapshot.next_dapp_id);
     assert!(dapp_info.reward_beneficiary.is_none());
@@ -194,12 +193,14 @@ pub(crate) fn assert_unregister(smart_contract: &MockSmartContract) {
     }));
 
     // Verify post-state
+    assert!(!IntegratedDApps::<Test>::contains_key(&smart_contract));
     assert_eq!(
-        IntegratedDApps::<Test>::get(&smart_contract).unwrap().state,
-        DAppState::Unregistered(pre_snapshot.active_protocol_state.era),
+        pre_snapshot.integrated_dapps.len() - 1,
+        IntegratedDApps::<Test>::count() as usize
     );
+
     assert!(!ContractStake::<Test>::contains_key(
-        &IntegratedDApps::<Test>::get(&smart_contract).unwrap().id
+        &pre_snapshot.integrated_dapps[&smart_contract].id
     ));
 }
 

--- a/pallets/dapp-staking-v3/src/test/tests.rs
+++ b/pallets/dapp-staking-v3/src/test/tests.rs
@@ -463,7 +463,7 @@ fn unregister_fails() {
         assert_unregister(&smart_contract);
         assert_noop!(
             DappStaking::unregister(RuntimeOrigin::root(), smart_contract),
-            Error::<Test>::NotOperatedDApp
+            Error::<Test>::ContractNotFound
         );
     })
 }
@@ -961,7 +961,7 @@ fn stake_on_invalid_dapp_fails() {
         let smart_contract = MockSmartContract::wasm(1 as AccountId);
         assert_noop!(
             DappStaking::stake(RuntimeOrigin::signed(account), smart_contract, 100),
-            Error::<Test>::NotOperatedDApp
+            Error::<Test>::ContractNotFound
         );
 
         // Try to stake on unregistered smart contract
@@ -969,7 +969,7 @@ fn stake_on_invalid_dapp_fails() {
         assert_unregister(&smart_contract);
         assert_noop!(
             DappStaking::stake(RuntimeOrigin::signed(account), smart_contract, 100),
-            Error::<Test>::NotOperatedDApp
+            Error::<Test>::ContractNotFound
         );
     })
 }
@@ -1237,7 +1237,7 @@ fn unstake_on_invalid_dapp_fails() {
         let smart_contract = MockSmartContract::wasm(1 as AccountId);
         assert_noop!(
             DappStaking::unstake(RuntimeOrigin::signed(account), smart_contract, 100),
-            Error::<Test>::NotOperatedDApp
+            Error::<Test>::ContractNotFound
         );
 
         // Try to unstake from unregistered smart contract
@@ -1246,7 +1246,7 @@ fn unstake_on_invalid_dapp_fails() {
         assert_unregister(&smart_contract);
         assert_noop!(
             DappStaking::unstake(RuntimeOrigin::signed(account), smart_contract, 100),
-            Error::<Test>::NotOperatedDApp
+            Error::<Test>::ContractNotFound
         );
     })
 }

--- a/pallets/dapp-staking-v3/src/test/tests_types.rs
+++ b/pallets/dapp-staking-v3/src/test/tests_types.rs
@@ -157,7 +157,6 @@ fn dapp_info_basic_checks() {
     let mut dapp_info = DAppInfo {
         owner,
         id: 7,
-        state: DAppState::Registered,
         reward_beneficiary: None,
     };
 
@@ -167,12 +166,6 @@ fn dapp_info_basic_checks() {
     // Beneficiary receives rewards in case it is set
     dapp_info.reward_beneficiary = Some(beneficiary);
     assert_eq!(*dapp_info.reward_beneficiary(), beneficiary);
-
-    // Check if dApp is registered
-    assert!(dapp_info.is_registered());
-
-    dapp_info.state = DAppState::Unregistered(10);
-    assert!(!dapp_info.is_registered());
 }
 
 #[test]

--- a/pallets/dapp-staking-v3/src/types.rs
+++ b/pallets/dapp-staking-v3/src/types.rs
@@ -247,15 +247,6 @@ impl ProtocolState {
     }
 }
 
-/// State in which some dApp is in.
-#[derive(Encode, Decode, MaxEncodedLen, Clone, Copy, Debug, PartialEq, Eq, TypeInfo)]
-pub enum DAppState {
-    /// dApp is registered and active.
-    Registered,
-    /// dApp has been unregistered in the contained era.
-    Unregistered(#[codec(compact)] EraNumber),
-}
-
 /// General information about a dApp.
 #[derive(Encode, Decode, MaxEncodedLen, Clone, Copy, Debug, PartialEq, Eq, TypeInfo)]
 pub struct DAppInfo<AccountId> {
@@ -264,8 +255,6 @@ pub struct DAppInfo<AccountId> {
     /// dApp's unique identifier in dApp staking.
     #[codec(compact)]
     pub id: DAppId,
-    /// Current state of the dApp.
-    pub state: DAppState,
     // If `None`, rewards goes to the developer account, otherwise to the account Id in `Some`.
     pub reward_beneficiary: Option<AccountId>,
 }
@@ -277,11 +266,6 @@ impl<AccountId> DAppInfo<AccountId> {
             Some(account_id) => account_id,
             None => &self.owner,
         }
-    }
-
-    /// `true` if dApp is registered, `false` otherwise.
-    pub fn is_registered(&self) -> bool {
-        self.state == DAppState::Registered
     }
 }
 

--- a/pallets/inflation/src/lib.rs
+++ b/pallets/inflation/src/lib.rs
@@ -671,24 +671,3 @@ impl<T: Config, P: Get<(InflationParameters, EraNumber)>> OnRuntimeUpgrade
         Ok(())
     }
 }
-
-/// To be used just for Shibuya, can be removed after migration has been executed.
-pub struct PalletInflationShibuyaMigration<T, P>(PhantomData<(T, P)>);
-impl<T: Config, P: Get<(EraNumber, Weight)>> OnRuntimeUpgrade
-    for PalletInflationShibuyaMigration<T, P>
-{
-    fn on_runtime_upgrade() -> Weight {
-        let (recalculation_era, weight) = P::get();
-        ActiveInflationConfig::<T>::mutate(|config| {
-            // Both recalculation_era and recalculation_block are of the same `u32` type so no need to do any translation.
-            config.recalculation_era = recalculation_era;
-        });
-
-        log::info!(
-            "Inflation pallet recalculation era set to {}.",
-            recalculation_era
-        );
-
-        T::DbWeight::get().reads_writes(1, 1).saturating_add(weight)
-    }
-}


### PR DESCRIPTION
## Summary

To provide more capacity for new dApps, when dApp is unregistered, it will be removed from `IntegratedDApps` storage.
The dApp Id will still remain occupied, but that can be resolved in [the future](https://github.com/AstarNetwork/Astar/issues/1152) when required.

## Overview

- `NotOperatedDApp` error has been removed and completely replaced with `ContractNotFound` error
- `DAppInfo` struct has been changed, with field `state` being removed
- Removed executed migrations

