### PR TITLE
Relaxed decommission mode

### DIFF
--- a/pallets/dapps-staking/src/pallet/mod.rs
+++ b/pallets/dapps-staking/src/pallet/mod.rs
@@ -305,8 +305,6 @@ pub mod pallet {
         NominationTransferToSameContract,
         /// Decommission is in progress so this call is not allowed.
         DecommissionInProgress,
-        /// Pallet decommission hasn't been started yet so this call is not allowed.
-        DecommissionNotStarted,
     }
 
     #[pallet::hooks]
@@ -925,10 +923,6 @@ pub mod pallet {
             contract_id: T::SmartContract,
         ) -> DispatchResultWithPostInfo {
             Self::ensure_pallet_enabled()?;
-            ensure!(
-                DecommissionStarted::<T>::get(),
-                Error::<T>::DecommissionNotStarted
-            );
             ensure_signed(origin)?;
 
             Self::internal_claim_staker_for(staker, contract_id)
@@ -944,10 +938,7 @@ pub mod pallet {
             reward_destination: RewardDestination,
         ) -> DispatchResultWithPostInfo {
             Self::ensure_pallet_enabled()?;
-            ensure!(
-                DecommissionStarted::<T>::get(),
-                Error::<T>::DecommissionNotStarted
-            );
+
             ensure_signed(origin)?;
 
             Self::internal_set_reward_destination_for(staker, reward_destination)

--- a/pallets/dapps-staking/src/tests.rs
+++ b/pallets/dapps-staking/src/tests.rs
@@ -2485,18 +2485,6 @@ fn claim_staker_for_works() {
         // Advance to next era so we can claim rewards for it
         advance_to_era(DappsStaking::current_era() + 1);
 
-        // Claiming for another staker is not possible unless decommission has started
-        assert_noop!(
-            DappsStaking::claim_staker_for(
-                RuntimeOrigin::signed(claimer),
-                staker,
-                smart_contract.clone()
-            ),
-            Error::<TestRuntime>::DecommissionNotStarted
-        );
-
-        // Enable decommission mode & claim the reward
-        assert_ok!(DappsStaking::decommission(RuntimeOrigin::root()));
         assert_ok!(DappsStaking::claim_staker_for(
             RuntimeOrigin::signed(claimer),
             staker,
@@ -2524,18 +2512,6 @@ fn set_reward_destination_for_works() {
         assert_register(developer, &smart_contract);
         assert_bond_and_stake(staker, &smart_contract, 17);
 
-        // Claiming for another staker is not possible unless decommission has started
-        assert_noop!(
-            DappsStaking::set_reward_destination_for(
-                RuntimeOrigin::signed(caller),
-                staker,
-                RewardDestination::StakeBalance
-            ),
-            Error::<TestRuntime>::DecommissionNotStarted
-        );
-
-        // Enable decommission mode and set the reward destination
-        assert_ok!(DappsStaking::decommission(RuntimeOrigin::root()));
         assert_ok!(DappsStaking::set_reward_destination_for(
             RuntimeOrigin::signed(caller),
             staker,


### PR DESCRIPTION
**Pull Request Summary**

Allow delegated claim calls to be used outside of `Decommission` mode context.

This is because there are so many unclaimed rewards, delegated claiming will take days to finish.
And we don't want to stop dApp staking from generating rewards for a prolonged period of time.
