### PR TITLE
Feat/delegated claim charging

### DIFF
--- a/pallets/dapp-staking-migration/src/mock.rs
+++ b/pallets/dapp-staking-migration/src/mock.rs
@@ -216,6 +216,7 @@ impl pallet_dapps_staking::Config for Test {
     type MaxEraStakeValues = ConstU32<10>;
     type UnregisteredDappRewardRetention = ConstU32<10>;
     type ForcePalletDisabled = ConstBool<false>;
+    type DelegateClaimFee = ConstU128<1>;
 }
 
 impl pallet_dapp_staking_migration::Config for Test {

--- a/pallets/dapps-staking/src/mock.rs
+++ b/pallets/dapps-staking/src/mock.rs
@@ -30,7 +30,7 @@ use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use sp_io::TestExternalities;
 use sp_runtime::{
     testing::Header,
-    traits::{BlakeTwo256, ConstBool, ConstU32, IdentityLookup},
+    traits::{BlakeTwo256, ConstBool, ConstU128, ConstU32, IdentityLookup},
 };
 
 pub(crate) type AccountId = u64;
@@ -167,6 +167,7 @@ impl pallet_dapps_staking::Config for TestRuntime {
     type MaxEraStakeValues = MaxEraStakeValues;
     type UnregisteredDappRewardRetention = ConstU32<REWARD_RETENTION_PERIOD>;
     type ForcePalletDisabled = ConstBool<false>;
+    type DelegateClaimFee = ConstU128<7>;
 }
 
 #[derive(

--- a/pallets/dapps-staking/src/pallet/mod.rs
+++ b/pallets/dapps-staking/src/pallet/mod.rs
@@ -1315,14 +1315,6 @@ pub mod pallet {
             let max_staker_reward =
                 Perbill::from_rational(staked, staking_info.total) * stakers_joint_reward;
 
-            let mut ledger = Self::ledger(&staker);
-
-            let should_restake_reward = Self::should_restake_reward(
-                ledger.reward_destination,
-                dapp_info.state,
-                staker_info.latest_staked_value(),
-            );
-
             // Withdraw reward funds from the dapps staking pot
             let total_imbalance = T::Currency::withdraw(
                 &Self::account_id(),
@@ -1340,6 +1332,14 @@ pub mod pallet {
 
             let staker_reward = reward_imbalance.peek();
 
+            let mut ledger = Self::ledger(&staker);
+
+            let should_restake_reward = Self::should_restake_reward(
+                ledger.reward_destination,
+                dapp_info.state,
+                staker_info.latest_staked_value(),
+            );
+
             if should_restake_reward {
                 staker_info
                     .stake(current_era, staker_reward)
@@ -1351,9 +1351,7 @@ pub mod pallet {
                     staker_info.len() <= T::MaxEraStakeValues::get(),
                     Error::<T>::TooManyEraStakeValues
                 );
-            }
 
-            if should_restake_reward {
                 ledger.locked = ledger.locked.saturating_add(staker_reward);
                 Self::update_ledger(&staker, ledger);
 

--- a/pallets/dapps-staking/src/pallet/mod.rs
+++ b/pallets/dapps-staking/src/pallet/mod.rs
@@ -305,8 +305,6 @@ pub mod pallet {
         NominationTransferToSameContract,
         /// Decommission is in progress so this call is not allowed.
         DecommissionInProgress,
-        /// Pallet decommission hasn't been started yet so this call is not allowed.
-        DecommissionNotStarted,
     }
 
     #[pallet::hooks]
@@ -925,10 +923,6 @@ pub mod pallet {
             contract_id: T::SmartContract,
         ) -> DispatchResultWithPostInfo {
             Self::ensure_pallet_enabled()?;
-            ensure!(
-                DecommissionStarted::<T>::get(),
-                Error::<T>::DecommissionNotStarted
-            );
             ensure_signed(origin)?;
 
             Self::internal_claim_staker_for(staker, contract_id)
@@ -944,10 +938,7 @@ pub mod pallet {
             reward_destination: RewardDestination,
         ) -> DispatchResultWithPostInfo {
             Self::ensure_pallet_enabled()?;
-            ensure!(
-                DecommissionStarted::<T>::get(),
-                Error::<T>::DecommissionNotStarted
-            );
+
             ensure_signed(origin)?;
 
             Self::internal_set_reward_destination_for(staker, reward_destination)

--- a/pallets/dapps-staking/src/pallet/mod.rs
+++ b/pallets/dapps-staking/src/pallet/mod.rs
@@ -310,6 +310,8 @@ pub mod pallet {
         NominationTransferToSameContract,
         /// Decommission is in progress so this call is not allowed.
         DecommissionInProgress,
+        /// Delegated claim call is not allowed if both the staker & caller are the same accounts.
+        ClaimForCallerAccount,
     }
 
     #[pallet::hooks]
@@ -929,6 +931,8 @@ pub mod pallet {
         ) -> DispatchResultWithPostInfo {
             Self::ensure_pallet_enabled()?;
             let caller = ensure_signed(origin)?;
+
+            ensure!(caller != staker, Error::<T>::ClaimForCallerAccount);
 
             Self::internal_claim_staker_for(caller, staker, contract_id, true)
         }

--- a/pallets/dapps-staking/src/pallet/mod.rs
+++ b/pallets/dapps-staking/src/pallet/mod.rs
@@ -119,6 +119,11 @@ pub mod pallet {
         #[pallet::constant]
         type ForcePalletDisabled: Get<bool>;
 
+        /// The fee that will be charged for claiming rewards on behalf of a staker.
+        /// This amount will be transferred from the staker over to the caller.
+        #[pallet::constant]
+        type DelegateClaimFee: Get<Balance>;
+
         /// The overarching event type.
         type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
@@ -927,11 +932,9 @@ pub mod pallet {
 
             let result = Self::internal_claim_staker_for(staker.clone(), contract_id)?;
 
-            let fixed_amount = 057_950_348_114_187_155 as Balance; // TODO: make this a configurable parameter
-
             let delegated_claim_fee = T::Currency::withdraw(
                 &staker,
-                fixed_amount,
+                T::DelegateClaimFee::get(),
                 WithdrawReasons::TRANSFER,
                 ExistenceRequirement::KeepAlive,
             )?;
@@ -942,7 +945,6 @@ pub mod pallet {
             // - staker: to deposit the reward
             //
             // Which means we don't need to add new benchmarks just for this (given the fact pallet will be obsolete soon)
-
             Ok(result)
         }
 

--- a/pallets/dapps-staking/src/tests.rs
+++ b/pallets/dapps-staking/src/tests.rs
@@ -2551,6 +2551,32 @@ fn claim_staker_for_works() {
 }
 
 #[test]
+fn claim_staker_for_fails_if_caller_is_same_as_staker() {
+    ExternalityBuilder::build().execute_with(|| {
+        initialize_first_block();
+
+        // Register a dApp and stake some amount on it
+        let developer = 1;
+        let staker = 2;
+        let smart_contract = MockSmartContract::Evm(H160::repeat_byte(0x02));
+        assert_register(developer, &smart_contract);
+        assert_bond_and_stake(staker, &smart_contract, 13);
+
+        // Advance to next era so we can claim rewards for it
+        advance_to_era(DappsStaking::current_era() + 1);
+
+        assert_noop!(
+            DappsStaking::claim_staker_for(
+                RuntimeOrigin::signed(staker),
+                staker,
+                smart_contract.clone()
+            ),
+            Error::<TestRuntime>::ClaimForCallerAccount
+        );
+    })
+}
+
+#[test]
 fn set_reward_destination_for_works() {
     ExternalityBuilder::build().execute_with(|| {
         initialize_first_block();

--- a/pallets/dapps-staking/src/tests.rs
+++ b/pallets/dapps-staking/src/tests.rs
@@ -2485,18 +2485,6 @@ fn claim_staker_for_works() {
         // Advance to next era so we can claim rewards for it
         advance_to_era(DappsStaking::current_era() + 1);
 
-        // Claiming for another staker is not possible unless decommission has started
-        assert_noop!(
-            DappsStaking::claim_staker_for(
-                RuntimeOrigin::signed(claimer),
-                staker,
-                smart_contract.clone()
-            ),
-            Error::<TestRuntime>::DecommissionNotStarted
-        );
-
-        // Enable decommission mode & claim the reward
-        assert_ok!(DappsStaking::decommission(RuntimeOrigin::root()));
         assert_ok!(DappsStaking::claim_staker_for(
             RuntimeOrigin::signed(claimer),
             staker,
@@ -2524,18 +2512,6 @@ fn set_reward_destination_for_works() {
         assert_register(developer, &smart_contract);
         assert_bond_and_stake(staker, &smart_contract, 17);
 
-        // Claiming for another staker is not possible unless decommission has started
-        assert_noop!(
-            DappsStaking::set_reward_destination_for(
-                RuntimeOrigin::signed(caller),
-                staker,
-                RewardDestination::StakeBalance
-            ),
-            Error::<TestRuntime>::DecommissionNotStarted
-        );
-
-        // Enable decommission mode and set the reward destination
-        assert_ok!(DappsStaking::decommission(RuntimeOrigin::root()));
         assert_ok!(DappsStaking::set_reward_destination_for(
             RuntimeOrigin::signed(caller),
             staker,

--- a/precompiles/dapps-staking/src/mock.rs
+++ b/precompiles/dapps-staking/src/mock.rs
@@ -21,7 +21,7 @@ use super::*;
 use fp_evm::{IsPrecompileResult, Precompile};
 use frame_support::{
     construct_runtime, parameter_types,
-    traits::{ConstBool, ConstU64, Currency, OnFinalize, OnInitialize},
+    traits::{ConstBool, ConstU128, ConstU64, Currency, OnFinalize, OnInitialize},
     weights::{RuntimeDbWeight, Weight},
     PalletId,
 };

--- a/precompiles/dapps-staking/src/mock.rs
+++ b/precompiles/dapps-staking/src/mock.rs
@@ -310,6 +310,7 @@ impl pallet_dapps_staking::Config for TestRuntime {
     type MaxEraStakeValues = MaxEraStakeValues;
     type UnregisteredDappRewardRetention = ConstU32<2>;
     type ForcePalletDisabled = ConstBool<false>;
+    type DelegateClaimFee = ConstU128<1>;
 }
 
 pub struct ExternalityBuilder {

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -33,8 +33,8 @@ use frame_support::{
     dispatch::DispatchClass,
     parameter_types,
     traits::{
-        AsEnsureOriginWithArg, ConstBool, ConstU32, Contains, Currency, FindAuthor, Get, Imbalance,
-        InstanceFilter, Nothing, OnFinalize, OnUnbalanced, Randomness, WithdrawReasons,
+        AsEnsureOriginWithArg, ConstBool, ConstU128, ConstU32, Contains, Currency, FindAuthor, Get,
+        Imbalance, InstanceFilter, Nothing, OnFinalize, OnUnbalanced, Randomness, WithdrawReasons,
     },
     weights::{
         constants::{
@@ -337,6 +337,8 @@ impl pallet_dapps_staking::Config for Runtime {
     // Not allowed on Astar yet
     type UnregisteredDappRewardRetention = ConstU32<{ u32::MAX }>;
     type ForcePalletDisabled = ConstBool<false>;
+    // Fee required to claim rewards for another account. Calculated & tested manually.
+    type DelegateClaimFee = ConstU128<057_950_348_114_187_155>;
 }
 
 /// Multi-VM pointer to smart contract instance.

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -482,6 +482,7 @@ impl pallet_dapps_staking::Config for Runtime {
     type MaxEraStakeValues = MaxEraStakeValues;
     type UnregisteredDappRewardRetention = ConstU32<3>;
     type ForcePalletDisabled = ConstBool<false>; // This will be set to `true` when needed
+    type DelegateClaimFee = ConstU128<1>; // TODO
 }
 
 impl pallet_static_price_provider::Config for Runtime {

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -482,7 +482,7 @@ impl pallet_dapps_staking::Config for Runtime {
     type MaxEraStakeValues = MaxEraStakeValues;
     type UnregisteredDappRewardRetention = ConstU32<3>;
     type ForcePalletDisabled = ConstBool<false>; // This will be set to `true` when needed
-    type DelegateClaimFee = ConstU128<1>; // TODO
+    type DelegateClaimFee = ConstU128<1>;
 }
 
 impl pallet_static_price_provider::Config for Runtime {

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -28,7 +28,7 @@ use frame_support::{
     dispatch::DispatchClass,
     parameter_types,
     traits::{
-        AsEnsureOriginWithArg, ConstU32, Contains, Currency, FindAuthor, Get, Imbalance,
+        AsEnsureOriginWithArg, ConstU128, ConstU32, Contains, Currency, FindAuthor, Get, Imbalance,
         InstanceFilter, Nothing, OnFinalize, OnUnbalanced, WithdrawReasons,
     },
     weights::{
@@ -340,6 +340,8 @@ impl pallet_dapps_staking::Config for Runtime {
     type MaxEraStakeValues = MaxEraStakeValues;
     type UnregisteredDappRewardRetention = ConstU32<7>;
     type ForcePalletDisabled = ConstBool<false>;
+    // Fee required to claim rewards for another account. Calculated & tested manually.
+    type DelegateClaimFee = ConstU128<000_579_268_481_141_871>;
 }
 
 /// Multi-VM pointer to smart contract instance.

--- a/tests/xcm-simulator/src/mocks/parachain.rs
+++ b/tests/xcm-simulator/src/mocks/parachain.rs
@@ -312,6 +312,7 @@ impl pallet_dapps_staking::Config for Runtime {
     type MaxEraStakeValues = ConstU32<4>;
     type UnregisteredDappRewardRetention = ConstU32<7>;
     type ForcePalletDisabled = ConstBool<false>;
+    type DelegateClaimFee = ConstU128<1>;
 }
 
 /// The type used to represent the kinds of proxying allowed.


### PR DESCRIPTION
## Summary

After some analysis, it proved there are millions of unclaimed eras in dApp staking.
A decision was made to claim these rewards on behalf of other users, to prevent rewards lost.

If `Alice` claims rewards on behalf of `Bob`, it means `Bob` will get rewards deposited into his account,
while `Alice` will pay for the transaction fees. This is unfair to the active users who diligently claim their rewards
(even though they have already earned ample compound interest by being active).

To remedy this situation, when delegated claim call is executed, the staker's reward will be reduced by the amount
required to pay the fee, and caller will be refunded by that amount.

Astar forum discussion: [HERE](https://forum.astar.network/t/dapps-staking-v2-delegated-reward-claim-cont/6003)

## What Does This Mean?

For reward claimers it means that even if they decide to claim rewards for others, they don't stand to benefit anything from that, but they will get a refund of the minimum possible transaction fee.
**NOTE:** The caller will be at a slight loss since fees change dynamically (lowest possible fee is charged for delegate claim), and they have to pay for the _tip_.

For stakers it means that someone will simply be able to claim their rewards for them, but it will be reduced by the minimum fee they would have to pay themselves anyways.

The most important thing is that no staker rewards will be burned or lost this way, everything will be claimed.

## Values

Minimum values were calculated offline, by ensuring minimum possible fee.
This ensures stakers are never at a loss.

The reason why static values are used is to ensure 100% that nothing more could be transferred.
Alternative would be to provide a _type_ from the transaction fee pallet to calculate the actual fee in respect
to weight, but that can be more error prone than the current _dumb&simple_ approach.
