### PR TITLE
Fix/incorrect eras per cycle function

### DIFF
--- a/pallets/inflation/src/tests.rs
+++ b/pallets/inflation/src/tests.rs
@@ -460,14 +460,20 @@ fn cycle_configuration_works() {
     ExternalityBuilder::build().execute_with(|| {
         type CycleConfig = <Test as Config>::CycleConfiguration;
 
-        let eras_per_period = CycleConfig::eras_per_voting_subperiod()
-            + CycleConfig::eras_per_build_and_earn_subperiod();
+        let eras_per_period = CycleConfig::eras_per_build_and_earn_subperiod() + 1;
         assert_eq!(CycleConfig::eras_per_period(), eras_per_period);
+
+        let period_in_era_lengths = CycleConfig::eras_per_voting_subperiod()
+            + CycleConfig::eras_per_build_and_earn_subperiod();
+        assert_eq!(CycleConfig::period_in_era_lengths(), period_in_era_lengths);
 
         let eras_per_cycle = eras_per_period * CycleConfig::periods_per_cycle();
         assert_eq!(CycleConfig::eras_per_cycle(), eras_per_cycle);
 
-        let blocks_per_cycle = eras_per_cycle * CycleConfig::blocks_per_era();
+        let cycle_in_era_lengths = period_in_era_lengths * CycleConfig::periods_per_cycle();
+        assert_eq!(CycleConfig::cycle_in_era_lengths(), cycle_in_era_lengths);
+
+        let blocks_per_cycle = cycle_in_era_lengths * CycleConfig::blocks_per_era();
         assert_eq!(CycleConfig::blocks_per_cycle(), blocks_per_cycle);
 
         let build_and_earn_eras_per_cycle =

--- a/primitives/src/dapp_staking.rs
+++ b/primitives/src/dapp_staking.rs
@@ -62,23 +62,33 @@ pub trait CycleConfiguration {
     fn blocks_per_era() -> BlockNumber;
 
     /// For how many standard era lengths does the period last.
-    fn eras_per_period() -> EraNumber {
+    fn period_in_era_lengths() -> EraNumber {
         Self::eras_per_voting_subperiod().saturating_add(Self::eras_per_build_and_earn_subperiod())
     }
 
     /// For how many standard era lengths does the cycle (a 'year') last.
-    fn eras_per_cycle() -> EraNumber {
-        Self::eras_per_period().saturating_mul(Self::periods_per_cycle())
+    fn cycle_in_era_lengths() -> EraNumber {
+        Self::period_in_era_lengths().saturating_mul(Self::periods_per_cycle())
     }
 
     /// How many blocks are there per cycle (a 'year').
     fn blocks_per_cycle() -> BlockNumber {
-        Self::blocks_per_era().saturating_mul(Self::eras_per_cycle())
+        Self::blocks_per_era().saturating_mul(Self::cycle_in_era_lengths())
     }
 
     /// For how many standard era lengths do all the build&earn subperiods in a cycle last.    
     fn build_and_earn_eras_per_cycle() -> EraNumber {
         Self::eras_per_build_and_earn_subperiod().saturating_mul(Self::periods_per_cycle())
+    }
+
+    /// How many distinct eras are there in a single period.
+    fn eras_per_period() -> EraNumber {
+        Self::eras_per_build_and_earn_subperiod().saturating_add(1)
+    }
+
+    /// How many distinct eras are there in a cycle.
+    fn eras_per_cycle() -> EraNumber {
+        Self::eras_per_period().saturating_mul(Self::periods_per_cycle())
     }
 }
 

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -1106,7 +1106,26 @@ pub type Migrations = (
         DappStakingMigrationName,
         <Runtime as frame_system::Config>::DbWeight,
     >,
+    // Part of shiden-119
+    RecalculationEraFix,
 );
+
+use frame_support::traits::OnRuntimeUpgrade;
+pub struct RecalculationEraFix;
+impl OnRuntimeUpgrade for RecalculationEraFix {
+    fn on_runtime_upgrade() -> Weight {
+        let first_dapp_staking_v3_era = 743;
+
+        let expected_recalculation_era =
+            InflationCycleConfig::eras_per_cycle().saturating_add(first_dapp_staking_v3_era);
+
+        pallet_inflation::ActiveInflationConfig::<Runtime>::mutate(|config| {
+            config.recalculation_era = expected_recalculation_era;
+        });
+
+        <Runtime as frame_system::Config>::DbWeight::get().reads_writes(1, 1)
+    }
+}
 
 type EventRecord = frame_system::EventRecord<
     <Runtime as frame_system::Config>::RuntimeEvent,


### PR DESCRIPTION
**Pull Request Summary**

Fix an issue where inflation recalculation era would be incorrectly calculated.

Instead of accounting for cycle length in era lengths, number of discreet era per cycle needs to be considered.
