### PR TITLE
Add DescribeBodyTerminal to DescribeAllTerminal

### DIFF
--- a/primitives/src/xcm/mod.rs
+++ b/primitives/src/xcm/mod.rs
@@ -345,11 +345,22 @@ impl DescribeLocation for DescribeAccountKey20Terminal {
 
 pub type DescribeAccountIdTerminal = (DescribeAccountId32Terminal, DescribeAccountKey20Terminal);
 
+pub struct DescribeBodyTerminal;
+impl DescribeLocation for DescribeBodyTerminal {
+    fn describe_location(l: &MultiLocation) -> Option<Vec<u8>> {
+        match (l.parents, &l.interior) {
+            (0, X1(Plurality { id, part })) => Some((b"Body", id, part).encode()),
+            _ => return None,
+        }
+    }
+}
+
 pub type DescribeAllTerminal = (
     DescribeTerminus,
     DescribePalletTerminal,
     DescribeAccountId32Terminal,
     DescribeAccountKey20Terminal,
+    DescribeBodyTerminal,
 );
 
 pub struct DescribeFamily<DescribeInterior>(PhantomData<DescribeInterior>);


### PR DESCRIPTION
This PR adds `DescribeBodyTerminal` to `DescribeAllTerminal`, keeping the local implementation of `DescribeAllTerminal` in sync with later versions of the Polkadot SDK, where `DescribeBodyTerminal` was introduced in-between versions 1.1.0 and 1.2.0.

For reference, [this](https://github.com/paritytech/polkadot-sdk/blob/release-polkadot-v1.2.0/polkadot/xcm/xcm-builder/src/location_conversion.rs#L104) is the implementation in v1.2.0.
