### PR TITLE
feat: allow xtoken in dispatch precompile

### DIFF
--- a/runtime/astar/src/precompiles.rs
+++ b/runtime/astar/src/precompiles.rs
@@ -59,6 +59,8 @@ impl Contains<RuntimeCall> for WhitelistedCalls {
             }
             RuntimeCall::DappStaking(_) => true,
             RuntimeCall::Assets(pallet_assets::Call::transfer { .. }) => true,
+            RuntimeCall::XTokens(orml_xtokens::Call::transfer_multiasset_with_fee { .. }) => true,
+            RuntimeCall::XTokens(orml_xtokens::Call::transfer_multiasset { .. }) => true,
             _ => false,
         }
     }

--- a/runtime/shibuya/src/precompiles.rs
+++ b/runtime/shibuya/src/precompiles.rs
@@ -63,6 +63,8 @@ impl Contains<RuntimeCall> for WhitelistedCalls {
             }
             RuntimeCall::DappStaking(_) => true,
             RuntimeCall::Assets(pallet_assets::Call::transfer { .. }) => true,
+            RuntimeCall::XTokens(orml_xtokens::Call::transfer_multiasset_with_fee { .. }) => true,
+            RuntimeCall::XTokens(orml_xtokens::Call::transfer_multiasset { .. }) => true,
             _ => false,
         }
     }

--- a/runtime/shiden/src/precompiles.rs
+++ b/runtime/shiden/src/precompiles.rs
@@ -59,6 +59,8 @@ impl Contains<RuntimeCall> for WhitelistedCalls {
             }
             RuntimeCall::DappStaking(_) => true,
             RuntimeCall::Assets(pallet_assets::Call::transfer { .. }) => true,
+            RuntimeCall::XTokens(orml_xtokens::Call::transfer_multiasset_with_fee { .. }) => true,
+            RuntimeCall::XTokens(orml_xtokens::Call::transfer_multiasset { .. }) => true,
             _ => false,
         }
     }


### PR DESCRIPTION
**Pull Request Summary**
Whitelist the following calls for dispatch precompile
- `orml_xtokens::transfer_multiasset_with_fee`
- `orml_xtokens::transfer_multiasset` 

**Check list**
- [ ] added or updated unit tests
- [ ] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [ ] added benchmarks & weights for any modified runtime logics.
