### PR TITLE
Skip WASM build for clippy

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -56,6 +56,8 @@ jobs:
       run: rustup target list --installed
 
     - uses: actions-rs/clippy-check@v1
+      env:
+        SKIP_WASM_BUILD: 1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         args: --features try-runtime,runtime-benchmarks -- -D warnings


### PR DESCRIPTION
Optimize `clippy` by skipping the WASM build.

Reduces execution time from ~10minutes to ~5minutes.