### PR TITLE
Prep for v5.36.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "astar-collator"
-version = "5.35.0"
+version = "5.36.0"
 dependencies = [
  "astar-primitives",
  "astar-runtime",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "astar-runtime"
-version = "5.35.0"
+version = "5.36.0"
 dependencies = [
  "array-bytes",
  "astar-primitives",
@@ -6623,7 +6623,7 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "local-runtime"
-version = "5.35.0"
+version = "5.36.0"
 dependencies = [
  "array-bytes",
  "astar-primitives",
@@ -13987,7 +13987,7 @@ dependencies = [
 
 [[package]]
 name = "shibuya-runtime"
-version = "5.35.0"
+version = "5.36.0"
 dependencies = [
  "array-bytes",
  "astar-primitives",
@@ -14107,7 +14107,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "5.35.0"
+version = "5.36.0"
 dependencies = [
  "array-bytes",
  "astar-primitives",

--- a/bin/collator/Cargo.toml
+++ b/bin/collator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-collator"
-version = "5.35.0"
+version = "5.36.0"
 description = "Astar collator implementation in Rust."
 build = "build.rs"
 default-run = "astar-collator"

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-runtime"
-version = "5.35.0"
+version = "5.36.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -148,7 +148,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("astar"),
     impl_name: create_runtime_str!("astar"),
     authoring_version: 1,
-    spec_version: 83,
+    spec_version: 84,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/runtime/local/Cargo.toml
+++ b/runtime/local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-runtime"
-version = "5.35.0"
+version = "5.36.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "5.35.0"
+version = "5.36.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -174,7 +174,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shibuya"),
     impl_name: create_runtime_str!("shibuya"),
     authoring_version: 1,
-    spec_version: 125,
+    spec_version: 126,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "5.35.0"
+version = "5.36.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -153,7 +153,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shiden"),
     impl_name: create_runtime_str!("shiden"),
     authoring_version: 1,
-    spec_version: 122,
+    spec_version: 123,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,


### PR DESCRIPTION
**Pull Request Summary**

Prep work for `v5.36.0` release.