### PR TITLE
Add vest call to WhitelistedLockdropCalls

### DIFF
--- a/runtime/astar/src/precompiles.rs
+++ b/runtime/astar/src/precompiles.rs
@@ -88,6 +88,7 @@ impl Contains<RuntimeCall> for WhitelistedLockdropCalls {
             RuntimeCall::Balances(pallet_balances::Call::transfer_keep_alive { .. }) => true,
             RuntimeCall::Balances(pallet_balances::Call::transfer_allow_death { .. }) => true,
             RuntimeCall::Assets(pallet_assets::Call::transfer { .. }) => true,
+            RuntimeCall::Vesting(pallet_vesting::Call::vest { .. }) => true,
             _ => false,
         }
     }

--- a/runtime/local/src/precompiles.rs
+++ b/runtime/local/src/precompiles.rs
@@ -87,6 +87,7 @@ impl Contains<RuntimeCall> for WhitelistedLockdropCalls {
             RuntimeCall::Balances(pallet_balances::Call::transfer_keep_alive { .. }) => true,
             RuntimeCall::Balances(pallet_balances::Call::transfer_allow_death { .. }) => true,
             RuntimeCall::Assets(pallet_assets::Call::transfer { .. }) => true,
+            RuntimeCall::Vesting(pallet_vesting::Call::vest { .. }) => true,
             _ => false,
         }
     }

--- a/runtime/shibuya/src/precompiles.rs
+++ b/runtime/shibuya/src/precompiles.rs
@@ -65,6 +65,7 @@ impl Contains<RuntimeCall> for WhitelistedCalls {
             RuntimeCall::Assets(pallet_assets::Call::transfer { .. }) => true,
             RuntimeCall::XTokens(orml_xtokens::Call::transfer_multiasset_with_fee { .. }) => true,
             RuntimeCall::XTokens(orml_xtokens::Call::transfer_multiasset { .. }) => true,
+            RuntimeCall::Vesting(pallet_vesting::Call::vest { .. }) => true,
             _ => false,
         }
     }

--- a/runtime/shiden/src/precompiles.rs
+++ b/runtime/shiden/src/precompiles.rs
@@ -87,6 +87,7 @@ impl Contains<RuntimeCall> for WhitelistedLockdropCalls {
             RuntimeCall::Balances(pallet_balances::Call::transfer_keep_alive { .. }) => true,
             RuntimeCall::Balances(pallet_balances::Call::transfer_allow_death { .. }) => true,
             RuntimeCall::Assets(pallet_assets::Call::transfer { .. }) => true,
+            RuntimeCall::Vesting(pallet_vesting::Call::vest { .. }) => true,
             _ => false,
         }
     }


### PR DESCRIPTION
**Pull Request Summary**

Added pallet_vesting::vest() call to the Lockdrop precompile filter, so that users can claim vested tokens