### PR TITLE
fix export genesis state

### DIFF
--- a/bin/collator/src/command.rs
+++ b/bin/collator/src/command.rs
@@ -41,7 +41,7 @@ use sc_service::{
 use sp_core::hexdisplay::HexDisplay;
 use sp_runtime::traits::AccountIdConversion;
 use sp_runtime::traits::Block as BlockT;
-use std::{io::Write, net::SocketAddr};
+use std::net::SocketAddr;
 
 #[cfg(feature = "runtime-benchmarks")]
 use frame_benchmarking_cli::{BenchmarkCmd, ExtrinsicFactory, SUBSTRATE_REFERENCE_HARDWARE};
@@ -456,22 +456,32 @@ pub fn run() -> Result<()> {
             }
         }
         Some(Subcommand::ExportGenesisState(cmd)) => {
-            let spec = cli.load_spec(&cmd.shared_params.chain.clone().unwrap_or_default())?;
-            let state_version = Cli::runtime_version(&spec).state_version();
-
-            let block: Block = generate_genesis_block(&*spec, state_version)?;
-            let raw_header = block.header().encode();
-            let output_buf = if cmd.raw {
-                raw_header
+            let runner = cli.create_runner(cmd)?;
+            if runner.config().chain_spec.is_astar() {
+                runner.sync_run(|config| {
+                    let PartialComponents { client, .. } = parachain::new_partial::<astar::RuntimeApi, astar::Executor, _>(
+                        &config,
+                        parachain::build_import_queue,
+                    )?;
+                    cmd.run(config.chain_spec.as_ref(), client.as_ref())
+                })
+            } else if runner.config().chain_spec.is_shiden() {
+                runner.sync_run(|config| {
+                    let PartialComponents { client, .. } = parachain::new_partial::<shiden::RuntimeApi, shiden::Executor, _>(
+                        &config,
+                        parachain::build_import_queue,
+                    )?;
+                    cmd.run(config.chain_spec.as_ref(), client.as_ref())
+                })
             } else {
-                format!("0x{:?}", HexDisplay::from(&block.header().encode())).into_bytes()
-            };
-            if let Some(output) = &cmd.output {
-                std::fs::write(output, output_buf)?;
-            } else {
-                std::io::stdout().write_all(&output_buf)?;
+                runner.sync_run(|config| {
+                    let PartialComponents { client, .. } = parachain::new_partial::<shibuya::RuntimeApi, shibuya::Executor, _>(
+                        &config,
+                        parachain::build_import_queue,
+                    )?;
+                    cmd.run(config.chain_spec.as_ref(), client.as_ref())
+                })
             }
-            Ok(())
         }
         Some(Subcommand::ExportGenesisWasm(cmd)) => {
             let runner = cli.create_runner(cmd)?;

--- a/bin/collator/src/command.rs
+++ b/bin/collator/src/command.rs
@@ -459,26 +459,29 @@ pub fn run() -> Result<()> {
             let runner = cli.create_runner(cmd)?;
             if runner.config().chain_spec.is_astar() {
                 runner.sync_run(|config| {
-                    let PartialComponents { client, .. } = parachain::new_partial::<astar::RuntimeApi, astar::Executor, _>(
-                        &config,
-                        parachain::build_import_queue,
-                    )?;
+                    let PartialComponents { client, .. } =
+                        parachain::new_partial::<astar::RuntimeApi, astar::Executor, _>(
+                            &config,
+                            parachain::build_import_queue,
+                        )?;
                     cmd.run(config.chain_spec.as_ref(), client.as_ref())
                 })
             } else if runner.config().chain_spec.is_shiden() {
                 runner.sync_run(|config| {
-                    let PartialComponents { client, .. } = parachain::new_partial::<shiden::RuntimeApi, shiden::Executor, _>(
-                        &config,
-                        parachain::build_import_queue,
-                    )?;
+                    let PartialComponents { client, .. } =
+                        parachain::new_partial::<shiden::RuntimeApi, shiden::Executor, _>(
+                            &config,
+                            parachain::build_import_queue,
+                        )?;
                     cmd.run(config.chain_spec.as_ref(), client.as_ref())
                 })
             } else {
                 runner.sync_run(|config| {
-                    let PartialComponents { client, .. } = parachain::new_partial::<shibuya::RuntimeApi, shibuya::Executor, _>(
-                        &config,
-                        parachain::build_import_queue,
-                    )?;
+                    let PartialComponents { client, .. } =
+                        parachain::new_partial::<shibuya::RuntimeApi, shibuya::Executor, _>(
+                            &config,
+                            parachain::build_import_queue,
+                        )?;
                     cmd.run(config.chain_spec.as_ref(), client.as_ref())
                 })
             }


### PR DESCRIPTION
Use of state_version 1 is incorrect since chain was started with state_version 0.
Instead of generation genesis header manually we use substrate cmd
