### PR TITLE
remove genesis state print

### DIFF
--- a/bin/collator/src/command.rs
+++ b/bin/collator/src/command.rs
@@ -818,11 +818,6 @@ pub fn run() -> Result<()> {
                 let parachain_account =
                     AccountIdConversion::<polkadot_primitives::AccountId>::into_account_truncating(&para_id);
 
-                let state_version = Cli::runtime_version(&config.chain_spec).state_version();
-                let block: Block = generate_genesis_block(&*config.chain_spec, state_version)
-                    .map_err(|e| format!("{:?}", e))?;
-                let genesis_state = format!("0x{:?}", HexDisplay::from(&block.header().encode()));
-
                 let polkadot_config = SubstrateCli::create_configuration(
                     &polkadot_cli,
                     &polkadot_cli,
@@ -832,7 +827,6 @@ pub fn run() -> Result<()> {
 
                 info!("Parachain id: {:?}", para_id);
                 info!("Parachain Account: {}", parachain_account);
-                info!("Parachain genesis state: {}", genesis_state);
                 info!(
                     "Is collating: {}",
                     if config.role.is_authority() {


### PR DESCRIPTION
This genesis state generated is incorrect. If we don't need it then better remove it
closes #1234 