### PR TITLE
stakingv3: rank dapps in-between tiers

### DIFF
--- a/pallets/dapp-staking-v3/rpc/runtime-api/src/lib.rs
+++ b/pallets/dapp-staking-v3/rpc/runtime-api/src/lib.rs
@@ -18,7 +18,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use astar_primitives::dapp_staking::{DAppId, EraNumber, PeriodNumber, RankedTier};
+use astar_primitives::dapp_staking::{DAppId, EraNumber, PeriodNumber, RankedTier, TierId};
 use astar_primitives::BlockNumber;
 pub use sp_std::collections::btree_map::BTreeMap;
 
@@ -27,6 +27,7 @@ sp_api::decl_runtime_apis! {
     /// dApp Staking Api.
     ///
     /// Used to provide information otherwise not available via RPC.
+    #[api_version(2)]
     pub trait DappStakingApi {
 
         /// How many periods are there in one cycle.
@@ -42,6 +43,10 @@ sp_api::decl_runtime_apis! {
         fn blocks_per_era() -> BlockNumber;
 
         /// Get dApp tier assignment for the given dApp.
+        #[changed_in(2)]
+        fn get_dapp_tier_assignment() -> BTreeMap<DAppId, TierId>;
+
+        /// Get dApp ranked tier assignment for the given dApp.
         fn get_dapp_tier_assignment() -> BTreeMap<DAppId, RankedTier>;
     }
 }

--- a/pallets/dapp-staking-v3/rpc/runtime-api/src/lib.rs
+++ b/pallets/dapp-staking-v3/rpc/runtime-api/src/lib.rs
@@ -18,7 +18,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use astar_primitives::dapp_staking::{DAppId, EraNumber, PeriodNumber, TierAndRank};
+use astar_primitives::dapp_staking::{DAppId, EraNumber, PeriodNumber, RankedTier};
 use astar_primitives::BlockNumber;
 pub use sp_std::collections::btree_map::BTreeMap;
 
@@ -42,6 +42,6 @@ sp_api::decl_runtime_apis! {
         fn blocks_per_era() -> BlockNumber;
 
         /// Get dApp tier assignment for the given dApp.
-        fn get_dapp_tier_assignment() -> BTreeMap<DAppId, TierAndRank>;
+        fn get_dapp_tier_assignment() -> BTreeMap<DAppId, RankedTier>;
     }
 }

--- a/pallets/dapp-staking-v3/rpc/runtime-api/src/lib.rs
+++ b/pallets/dapp-staking-v3/rpc/runtime-api/src/lib.rs
@@ -18,7 +18,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use astar_primitives::dapp_staking::{DAppId, EraNumber, PeriodNumber, TierId};
+use astar_primitives::dapp_staking::{DAppId, EraNumber, PeriodNumber, TierAndRank};
 use astar_primitives::BlockNumber;
 pub use sp_std::collections::btree_map::BTreeMap;
 
@@ -42,6 +42,6 @@ sp_api::decl_runtime_apis! {
         fn blocks_per_era() -> BlockNumber;
 
         /// Get dApp tier assignment for the given dApp.
-        fn get_dapp_tier_assignment() -> BTreeMap<DAppId, TierId>;
+        fn get_dapp_tier_assignment() -> BTreeMap<DAppId, TierAndRank>;
     }
 }

--- a/pallets/dapp-staking-v3/src/benchmarking/mod.rs
+++ b/pallets/dapp-staking-v3/src/benchmarking/mod.rs
@@ -1041,8 +1041,8 @@ mod benchmarks {
             &cleanup_marker.dapp_tiers_index,
             DAppTierRewardsFor::<T> {
                 dapps: (0..T::MaxNumberOfContracts::get())
-                    .map(|dapp_id| (dapp_id as DAppId, 0))
-                    .collect::<BTreeMap<DAppId, TierId>>()
+                    .map(|dapp_id| (dapp_id as DAppId, TierAndRank::new(0, 0)))
+                    .collect::<BTreeMap<DAppId, TierAndRank>>()
                     .try_into()
                     .expect("Using `MaxNumberOfContracts` as length; QED."),
                 rewards: vec![1_000_000_000_000; T::NumberOfTiers::get() as usize]

--- a/pallets/dapp-staking-v3/src/benchmarking/mod.rs
+++ b/pallets/dapp-staking-v3/src/benchmarking/mod.rs
@@ -999,11 +999,12 @@ mod benchmarks {
 
         #[block]
         {
-            let (dapp_tiers, _) = Pallet::<T>::get_dapp_tier_assignment_and_rewards(
-                reward_era,
-                reward_period,
-                reward_pool,
-            );
+            let (dapp_tiers, _count, _rank_rewards) =
+                Pallet::<T>::get_dapp_tier_assignment_and_rewards(
+                    reward_era,
+                    reward_period,
+                    reward_pool,
+                );
             assert_eq!(dapp_tiers.dapps.len(), x as usize);
         }
     }

--- a/pallets/dapp-staking-v3/src/benchmarking/mod.rs
+++ b/pallets/dapp-staking-v3/src/benchmarking/mod.rs
@@ -1049,7 +1049,9 @@ mod benchmarks {
                     .try_into()
                     .expect("Using `NumberOfTiers` as length; QED."),
                 period: 1,
-                rank_rewards: vec![0; T::NumberOfTiers::get() as usize],
+                rank_rewards: vec![0; T::NumberOfTiers::get() as usize]
+                    .try_into()
+                    .expect("Using `NumberOfTiers` as length; QED."),
             },
         );
 

--- a/pallets/dapp-staking-v3/src/benchmarking/mod.rs
+++ b/pallets/dapp-staking-v3/src/benchmarking/mod.rs
@@ -999,12 +999,11 @@ mod benchmarks {
 
         #[block]
         {
-            let (dapp_tiers, _count, _rank_rewards) =
-                Pallet::<T>::get_dapp_tier_assignment_and_rewards(
-                    reward_era,
-                    reward_period,
-                    reward_pool,
-                );
+            let (dapp_tiers, _count) = Pallet::<T>::get_dapp_tier_assignment_and_rewards(
+                reward_era,
+                reward_period,
+                reward_pool,
+            );
             assert_eq!(dapp_tiers.dapps.len(), x as usize);
         }
     }

--- a/pallets/dapp-staking-v3/src/benchmarking/mod.rs
+++ b/pallets/dapp-staking-v3/src/benchmarking/mod.rs
@@ -1041,8 +1041,8 @@ mod benchmarks {
             &cleanup_marker.dapp_tiers_index,
             DAppTierRewardsFor::<T> {
                 dapps: (0..T::MaxNumberOfContracts::get())
-                    .map(|dapp_id| (dapp_id as DAppId, TierAndRank::new_saturated(0, 0)))
-                    .collect::<BTreeMap<DAppId, TierAndRank>>()
+                    .map(|dapp_id| (dapp_id as DAppId, RankedTier::new_saturated(0, 0)))
+                    .collect::<BTreeMap<DAppId, RankedTier>>()
                     .try_into()
                     .expect("Using `MaxNumberOfContracts` as length; QED."),
                 rewards: vec![1_000_000_000_000; T::NumberOfTiers::get() as usize]

--- a/pallets/dapp-staking-v3/src/benchmarking/mod.rs
+++ b/pallets/dapp-staking-v3/src/benchmarking/mod.rs
@@ -1041,7 +1041,7 @@ mod benchmarks {
             &cleanup_marker.dapp_tiers_index,
             DAppTierRewardsFor::<T> {
                 dapps: (0..T::MaxNumberOfContracts::get())
-                    .map(|dapp_id| (dapp_id as DAppId, TierAndRank::new(0, 0)))
+                    .map(|dapp_id| (dapp_id as DAppId, TierAndRank::new_saturated(0, 0)))
                     .collect::<BTreeMap<DAppId, TierAndRank>>()
                     .try_into()
                     .expect("Using `MaxNumberOfContracts` as length; QED."),

--- a/pallets/dapp-staking-v3/src/benchmarking/mod.rs
+++ b/pallets/dapp-staking-v3/src/benchmarking/mod.rs
@@ -1049,7 +1049,7 @@ mod benchmarks {
                     .try_into()
                     .expect("Using `NumberOfTiers` as length; QED."),
                 period: 1,
-                rank_rewards: vec![0; T::NumberOfTiers::get() as usize]
+                rank_rewards: vec![0; T::NumberOfTiers::get() as usize],
             },
         );
 

--- a/pallets/dapp-staking-v3/src/benchmarking/mod.rs
+++ b/pallets/dapp-staking-v3/src/benchmarking/mod.rs
@@ -1049,6 +1049,7 @@ mod benchmarks {
                     .try_into()
                     .expect("Using `NumberOfTiers` as length; QED."),
                 period: 1,
+                rank_rewards: vec![0; T::NumberOfTiers::get() as usize]
             },
         );
 

--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -72,7 +72,9 @@ mod benchmarking;
 mod types;
 pub use types::*;
 
+pub mod migration;
 pub mod weights;
+
 pub use weights::WeightInfo;
 
 const LOG_TARGET: &str = "dapp-staking";
@@ -92,7 +94,7 @@ pub mod pallet {
     use super::*;
 
     /// The current storage version.
-    pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(6);
+    pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(7);
 
     #[pallet::pallet]
     #[pallet::storage_version(STORAGE_VERSION)]

--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -1920,7 +1920,7 @@ pub mod pallet {
                         TierAssignment::Dummy => (
                             DAppTierRewardsFor::<T>::default(),
                             0,
-                            BoundedVec::truncate_from(vec![1]),
+                            BoundedVec::truncate_from([1].to_vec()),
                         ),
                     };
                     if rank_rewards.iter().any(|x| !x.is_zero()) {

--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -1382,7 +1382,7 @@ pub mod pallet {
                 Error::<T>::RewardExpired
             );
 
-            let (amount, tier_and_rank) =
+            let (amount, ranked_tier) =
                 dapp_tiers
                     .try_claim(dapp_info.id)
                     .map_err(|error| match error {
@@ -1390,7 +1390,7 @@ pub mod pallet {
                         _ => Error::<T>::InternalClaimDAppError,
                     })?;
 
-            let tier_id = tier_and_rank.tier_id();
+            let tier_id = ranked_tier.tier();
             // Get reward destination, and deposit the reward.
             let beneficiary = dapp_info.reward_beneficiary();
             T::StakingRewardHandler::payout_reward(&beneficiary, amount)

--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -1782,8 +1782,8 @@ pub mod pallet {
                 for (dapp_id, staked_amount) in dapp_stakes
                     .iter()
                     .skip(dapp_tiers.len())
-                    .take(*tier_capacity as usize)
                     .take_while(|(_, amount)| tier_threshold.is_satisfied(*amount))
+                    .take(*tier_capacity as usize)
                 {
                     let rank = RankedTier::find_rank(lower_bound, upper_bound, *staked_amount);
                     tier_slots.insert(*dapp_id, RankedTier::new_saturated(tier_id as u8, rank));

--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -187,6 +187,10 @@ pub mod pallet {
         #[pallet::constant]
         type NumberOfTiers: Get<u32>;
 
+        /// Tier ranking enabled.
+        #[pallet::constant]
+        type RankingEnabled: Get<bool>;
+
         /// Weight info for various calls & operations in the pallet.
         type WeightInfo: WeightInfo;
 
@@ -1397,7 +1401,7 @@ pub mod pallet {
             let (tier_id, rank) = ranked_tier.deconstruct();
 
             // if dapp is ranked and there's reward per rank then include the extra reward to the total amount
-            if !rank.is_zero() {
+            if T::RankingEnabled::get() && !rank.is_zero() {
                 if let Some(reward_per_rank) =
                     RankRewards::<T>::get(&era).get(tier_id as usize).copied()
                 {
@@ -1786,7 +1790,11 @@ pub mod pallet {
                     .take_while(|(_, amount)| tier_threshold.is_satisfied(*amount))
                     .take(*tier_capacity as usize)
                 {
-                    let rank = RankedTier::find_rank(lower_bound, upper_bound, *staked_amount);
+                    let rank = if T::RankingEnabled::get() {
+                        RankedTier::find_rank(lower_bound, upper_bound, *staked_amount)
+                    } else {
+                        0
+                    };
                     tier_slots.insert(*dapp_id, RankedTier::new_saturated(tier_id as u8, rank));
                 }
 

--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -1917,9 +1917,11 @@ pub mod pallet {
                             dapp_reward_pool,
                         ),
                         #[cfg(feature = "runtime-benchmarks")]
-                        TierAssignment::Dummy => {
-                            (DAppTierRewardsFor::<T>::default(), 0, BoundedVec::new())
-                        }
+                        TierAssignment::Dummy => (
+                            DAppTierRewardsFor::<T>::default(),
+                            0,
+                            BoundedVec::truncate_from(vec![1]),
+                        ),
                     };
                     if rank_rewards.iter().any(|x| !x.is_zero()) {
                         RankRewards::<T>::insert(&current_era, rank_rewards);

--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -1916,7 +1916,9 @@ pub mod pallet {
                             dapp_reward_pool,
                         ),
                         #[cfg(feature = "runtime-benchmarks")]
-                        TierAssignment::Dummy => (DAppTierRewardsFor::<T>::default(), 0),
+                        TierAssignment::Dummy => {
+                            (DAppTierRewardsFor::<T>::default(), 0, BoundedVec::new())
+                        }
                     };
                     if rank_rewards.iter().any(|x| !x.is_zero()) {
                         RankRewards::<T>::insert(&current_era, rank_rewards);

--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -54,7 +54,7 @@ pub use sp_std::vec::Vec;
 use astar_primitives::{
     dapp_staking::{
         AccountCheck, CycleConfiguration, DAppId, EraNumber, Observer as DAppStakingObserver,
-        PeriodNumber, RankedTier, SmartContractHandle, StakingRewardHandler, TierId,
+        PeriodNumber, Rank, RankedTier, SmartContractHandle, StakingRewardHandler, TierId,
         TierSlots as TierSlotFunc,
     },
     oracle::PriceProvider,
@@ -296,6 +296,7 @@ pub mod pallet {
             beneficiary: T::AccountId,
             smart_contract: T::SmartContract,
             tier_id: TierId,
+            rank: Rank,
             era: EraNumber,
             amount: Balance,
         },
@@ -1418,7 +1419,7 @@ pub mod pallet {
                         _ => Error::<T>::InternalClaimDAppError,
                     })?;
 
-            let (tier_id, _rank) = ranked_tier.deconstruct();
+            let (tier_id, rank) = ranked_tier.deconstruct();
 
             // Get reward destination, and deposit the reward.
             let beneficiary = dapp_info.reward_beneficiary();
@@ -1432,6 +1433,7 @@ pub mod pallet {
                 beneficiary: beneficiary.clone(),
                 smart_contract,
                 tier_id,
+                rank,
                 era,
                 amount,
             });

--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -1929,11 +1929,7 @@ pub mod pallet {
                             dapp_reward_pool,
                         ),
                         #[cfg(feature = "runtime-benchmarks")]
-                        TierAssignment::Dummy => (
-                            DAppTierRewardsFor::<T>::default(),
-                            0,
-                            BoundedVec::truncate_from([1].to_vec()),
-                        ),
+                        TierAssignment::Dummy => (DAppTierRewardsFor::<T>::default(), 0),
                     };
                     DAppTiers::<T>::insert(&current_era, dapp_tier_rewards);
 

--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -1783,10 +1783,8 @@ pub mod pallet {
                     .iter()
                     .skip(dapp_tiers.len())
                     .take(*tier_capacity as usize)
+                    .take_while(|(_, amount)| tier_threshold.is_satisfied(*amount))
                 {
-                    if !tier_threshold.is_satisfied(*staked_amount) {
-                        break;
-                    }
                     let rank = RankedTier::find_rank(lower_bound, upper_bound, *staked_amount);
                     tier_slots.insert(*dapp_id, RankedTier::new_saturated(tier_id as u8, rank));
                 }

--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -1396,6 +1396,7 @@ pub mod pallet {
 
             let (tier_id, rank) = ranked_tier.deconstruct();
 
+            // if dapp is ranked and there's reward per rank then include the extra reward to the total amount
             if !rank.is_zero() {
                 if let Some(reward_per_rank) =
                     RankRewards::<T>::get(&era).get(tier_id as usize).copied()

--- a/pallets/dapp-staking-v3/src/migration.rs
+++ b/pallets/dapp-staking-v3/src/migration.rs
@@ -34,7 +34,7 @@ pub mod versioned_migrations {
     pub type V6ToV7<T> = frame_support::migrations::VersionedMigration<
         6,
         7,
-        v7::VersionUncheckedMigrateV6ToV7<T>,
+        v7::VersionMigrateV6ToV7<T>,
         Pallet<T>,
         <T as frame_system::Config>::DbWeight,
     >;
@@ -45,9 +45,9 @@ mod v7 {
     use super::*;
     use crate::migration::v6::DAppTierRewards as DAppTierRewardsV6;
 
-    pub struct VersionUncheckedMigrateV6ToV7<T>(PhantomData<T>);
+    pub struct VersionMigrateV6ToV7<T>(PhantomData<T>);
 
-    impl<T: Config> OnRuntimeUpgrade for VersionUncheckedMigrateV6ToV7<T> {
+    impl<T: Config> OnRuntimeUpgrade for VersionMigrateV6ToV7<T> {
         fn on_runtime_upgrade() -> Weight {
             let current = Pallet::<T>::current_storage_version();
 

--- a/pallets/dapp-staking-v3/src/migration.rs
+++ b/pallets/dapp-staking-v3/src/migration.rs
@@ -57,11 +57,17 @@ mod v7 {
                 _,
             >(|_key, old_value| {
                 translated.saturating_inc();
+
+                // fill rank_rewards with zero
+                let mut rank_rewards = Vec::new();
+                rank_rewards.resize_with(old_value.rewards.len(), || Balance::zero());
+
                 Some(DAppTierRewards {
                     dapps: old_value.dapps,
                     rewards: old_value.rewards,
                     period: old_value.period,
-                    rank_rewards: Default::default(),
+                    rank_rewards: BoundedVec::<Balance, T::NumberOfTiers>::try_from(rank_rewards)
+                        .unwrap_or_default(),
                 })
             });
 

--- a/pallets/dapp-staking-v3/src/migration.rs
+++ b/pallets/dapp-staking-v3/src/migration.rs
@@ -1,0 +1,112 @@
+// This file is part of Astar.
+
+// Copyright (C) Stake Technologies Pte.Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Astar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Astar is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Astar. If not, see <http://www.gnu.org/licenses/>.
+
+use super::*;
+use frame_support::traits::OnRuntimeUpgrade;
+
+#[cfg(feature = "try-runtime")]
+use sp_std::vec::Vec;
+
+#[cfg(feature = "try-runtime")]
+use sp_runtime::TryRuntimeError;
+
+/// Exports for versioned migration `type`s for this pallet.
+pub mod versioned_migrations {
+    use super::*;
+
+    /// Migration V6 to V7 wrapped in a [`frame_support::migrations::VersionedMigration`], ensuring
+    /// the migration is only performed when on-chain version is 6.
+    pub type V6ToV7<T> = frame_support::migrations::VersionedMigration<
+        6,
+        7,
+        v7::VersionUncheckedMigrateV6ToV7<T>,
+        Pallet<T>,
+        <T as frame_system::Config>::DbWeight,
+    >;
+}
+
+/// Translate DAppTiers to include rank rewards.
+mod v7 {
+    use super::*;
+    use crate::migration::v6::DAppTierRewards as DAppTierRewardsV6;
+
+    pub struct VersionUncheckedMigrateV6ToV7<T>(PhantomData<T>);
+
+    impl<T: Config> OnRuntimeUpgrade for VersionUncheckedMigrateV6ToV7<T> {
+        fn on_runtime_upgrade() -> Weight {
+            let current = Pallet::<T>::current_storage_version();
+
+            let mut translated = 0usize;
+            DAppTiers::<T>::translate::<
+                DAppTierRewardsV6<T::MaxNumberOfContracts, T::NumberOfTiers>,
+                _,
+            >(|_key, old_value| {
+                translated.saturating_inc();
+                Some(DAppTierRewards {
+                    dapps: old_value.dapps,
+                    rewards: old_value.rewards,
+                    period: old_value.period,
+                    rank_rewards: Default::default(),
+                })
+            });
+
+            current.put::<Pallet<T>>();
+
+            log::info!("Upgraded {translated} dAppTiers to {current:?}");
+
+            T::DbWeight::get().reads_writes(1 + translated as u64, 1 + translated as u64)
+        }
+
+        #[cfg(feature = "try-runtime")]
+        fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+            Ok(Vec::new())
+        }
+
+        #[cfg(feature = "try-runtime")]
+        fn post_upgrade(_data: Vec<u8>) -> Result<(), TryRuntimeError> {
+            ensure!(
+                Pallet::<T>::on_chain_storage_version() >= 7,
+                "dapp-staking-v3::migration::v7: wrong storage version"
+            );
+            Ok(())
+        }
+    }
+}
+
+pub mod v6 {
+    use astar_primitives::{
+        dapp_staking::{DAppId, PeriodNumber, RankedTier},
+        Balance,
+    };
+    use frame_support::{
+        pallet_prelude::{Decode, Get},
+        BoundedBTreeMap, BoundedVec,
+    };
+
+    /// Information about all of the dApps that got into tiers, and tier rewards
+    #[derive(Decode)]
+    pub struct DAppTierRewards<MD: Get<u32>, NT: Get<u32>> {
+        /// DApps and their corresponding tiers (or `None` if they have been claimed in the meantime)
+        pub dapps: BoundedBTreeMap<DAppId, RankedTier, MD>,
+        /// Rewards for each tier. First entry refers to the first tier, and so on.
+        pub rewards: BoundedVec<Balance, NT>,
+        /// Period during which this struct was created.
+        #[codec(compact)]
+        pub period: PeriodNumber,
+    }
+}

--- a/pallets/dapp-staking-v3/src/test/mock.rs
+++ b/pallets/dapp-staking-v3/src/test/mock.rs
@@ -24,7 +24,7 @@ use crate::{
 
 use frame_support::{
     construct_runtime, parameter_types,
-    traits::{fungible::Mutate as FunMutate, ConstU128, ConstU32},
+    traits::{fungible::Mutate as FunMutate, ConstBool, ConstU128, ConstU32},
     weights::Weight,
 };
 use sp_arithmetic::fixed_point::FixedU128;
@@ -216,6 +216,7 @@ impl pallet_dapp_staking::Config for Test {
     type MaxNumberOfStakedContracts = ConstU32<5>;
     type MinimumStakeAmount = ConstU128<3>;
     type NumberOfTiers = ConstU32<4>;
+    type RankingEnabled = ConstBool<true>;
     type WeightInfo = weights::SubstrateWeight<Test>;
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = BenchmarkHelper<MockSmartContract, AccountId>;

--- a/pallets/dapp-staking-v3/src/test/testing_utils.rs
+++ b/pallets/dapp-staking-v3/src/test/testing_utils.rs
@@ -1015,7 +1015,7 @@ pub(crate) fn assert_claim_dapp_reward(
         .get(&era)
         .expect("Entry must exist.")
         .clone();
-    let (expected_reward, expected_tier_id) = {
+    let (expected_reward, expected_tier_and_rank) = {
         let mut info = pre_reward_info.clone();
         info.try_claim(dapp_info.id).unwrap()
     };
@@ -1029,7 +1029,7 @@ pub(crate) fn assert_claim_dapp_reward(
     System::assert_last_event(RuntimeEvent::DappStaking(Event::DAppReward {
         beneficiary: beneficiary.clone(),
         smart_contract: smart_contract.clone(),
-        tier_id: expected_tier_id,
+        tier_id: expected_tier_and_rank.tier_id(),
         era,
         amount: expected_reward,
     }));

--- a/pallets/dapp-staking-v3/src/test/testing_utils.rs
+++ b/pallets/dapp-staking-v3/src/test/testing_utils.rs
@@ -1015,7 +1015,7 @@ pub(crate) fn assert_claim_dapp_reward(
         .get(&era)
         .expect("Entry must exist.")
         .clone();
-    let (expected_reward, expected_tier_and_rank) = {
+    let (expected_reward, expected_ranked_tier) = {
         let mut info = pre_reward_info.clone();
         info.try_claim(dapp_info.id).unwrap()
     };
@@ -1029,7 +1029,7 @@ pub(crate) fn assert_claim_dapp_reward(
     System::assert_last_event(RuntimeEvent::DappStaking(Event::DAppReward {
         beneficiary: beneficiary.clone(),
         smart_contract: smart_contract.clone(),
-        tier_id: expected_tier_and_rank.tier_id(),
+        tier_id: expected_ranked_tier.tier(),
         era,
         amount: expected_reward,
     }));

--- a/pallets/dapp-staking-v3/src/test/testing_utils.rs
+++ b/pallets/dapp-staking-v3/src/test/testing_utils.rs
@@ -1030,6 +1030,7 @@ pub(crate) fn assert_claim_dapp_reward(
         beneficiary: beneficiary.clone(),
         smart_contract: smart_contract.clone(),
         tier_id: expected_ranked_tier.tier(),
+        rank: expected_ranked_tier.rank(),
         era,
         amount: expected_reward,
     }));

--- a/pallets/dapp-staking-v3/src/test/tests.rs
+++ b/pallets/dapp-staking-v3/src/test/tests.rs
@@ -2464,7 +2464,7 @@ fn get_dapp_tier_assignment_and_rewards_basic_example_works() {
         // Finally, the actual test
         let protocol_state = ActiveProtocolState::<Test>::get();
         let dapp_reward_pool = 1000000;
-        let (tier_assignment, counter, _rank_rewards) =
+        let (tier_assignment, counter, rank_rewards) =
             DappStaking::get_dapp_tier_assignment_and_rewards(
                 protocol_state.era + 1,
                 protocol_state.period_number(),
@@ -2486,16 +2486,26 @@ fn get_dapp_tier_assignment_and_rewards_basic_example_works() {
         let (dapp_1_tier, dapp_2_tier) = (tier_assignment.dapps[&0], tier_assignment.dapps[&1]);
         assert_eq!(dapp_1_tier, RankedTier::new_saturated(0, 0));
         assert_eq!(dapp_2_tier, RankedTier::new_saturated(0, 0));
+        assert_eq!(rank_rewards[0], 0); // tier 0 has no ranking therefor no reward for ranks
 
         // 2nd tier checks
         let (dapp_3_tier, dapp_4_tier) = (tier_assignment.dapps[&2], tier_assignment.dapps[&3]);
         assert_eq!(dapp_3_tier, RankedTier::new_saturated(1, 9));
         assert_eq!(dapp_4_tier, RankedTier::new_saturated(1, 9));
 
+        // There's enough reward to satisfy 100% reward per rank.
+        // Slot reward is 60_000 therefor expected rank reward is 6_000
+        assert_eq!(rank_rewards[1], 6000);
+        assert_eq!(
+            rank_rewards[1],
+            tier_assignment.rewards[1] / Into::<Balance>::into(RankedTier::MAX_RANK)
+        );
+
         // 4th tier checks
         let (dapp_5_tier, dapp_6_tier) = (tier_assignment.dapps[&4], tier_assignment.dapps[&5]);
         assert_eq!(dapp_5_tier, RankedTier::new_saturated(3, 0));
         assert_eq!(dapp_6_tier, RankedTier::new_saturated(3, 0));
+        assert_eq!(rank_rewards[3], 0); // tier 3 has no ranking therefor no reward for ranks
 
         // Sanity check - last dapp should not exists in the tier assignment
         assert!(tier_assignment

--- a/pallets/dapp-staking-v3/src/test/tests.rs
+++ b/pallets/dapp-staking-v3/src/test/tests.rs
@@ -2464,11 +2464,12 @@ fn get_dapp_tier_assignment_and_rewards_basic_example_works() {
         // Finally, the actual test
         let protocol_state = ActiveProtocolState::<Test>::get();
         let dapp_reward_pool = 1000000;
-        let (tier_assignment, counter) = DappStaking::get_dapp_tier_assignment_and_rewards(
-            protocol_state.era + 1,
-            protocol_state.period_number(),
-            dapp_reward_pool,
-        );
+        let (tier_assignment, counter, _rank_rewards) =
+            DappStaking::get_dapp_tier_assignment_and_rewards(
+                protocol_state.era + 1,
+                protocol_state.period_number(),
+                dapp_reward_pool,
+            );
 
         // Basic checks
         let number_of_tiers: u32 = <Test as Config>::NumberOfTiers::get();
@@ -2533,11 +2534,12 @@ fn get_dapp_tier_assignment_and_rewards_zero_slots_per_tier_works() {
         // Calculate tier assignment (we don't need dApps for this test)
         let protocol_state = ActiveProtocolState::<Test>::get();
         let dapp_reward_pool = 1000000;
-        let (tier_assignment, counter) = DappStaking::get_dapp_tier_assignment_and_rewards(
-            protocol_state.era,
-            protocol_state.period_number(),
-            dapp_reward_pool,
-        );
+        let (tier_assignment, counter, _rank_rewards) =
+            DappStaking::get_dapp_tier_assignment_and_rewards(
+                protocol_state.era,
+                protocol_state.period_number(),
+                dapp_reward_pool,
+            );
 
         // Basic checks
         let number_of_tiers: u32 = <Test as Config>::NumberOfTiers::get();

--- a/pallets/dapp-staking-v3/src/test/tests.rs
+++ b/pallets/dapp-staking-v3/src/test/tests.rs
@@ -35,7 +35,7 @@ use frame_support::{
 use sp_runtime::{traits::Zero, FixedU128};
 
 use astar_primitives::{
-    dapp_staking::{CycleConfiguration, EraNumber, SmartContractHandle, TierAndRank},
+    dapp_staking::{CycleConfiguration, EraNumber, RankedTier, SmartContractHandle},
     Balance, BlockNumber,
 };
 
@@ -2483,18 +2483,18 @@ fn get_dapp_tier_assignment_and_rewards_basic_example_works() {
 
         // 1st tier checks
         let (dapp_1_tier, dapp_2_tier) = (tier_assignment.dapps[&0], tier_assignment.dapps[&1]);
-        assert_eq!(dapp_1_tier, TierAndRank::new_saturated(0, 0));
-        assert_eq!(dapp_2_tier, TierAndRank::new_saturated(0, 0));
+        assert_eq!(dapp_1_tier, RankedTier::new_saturated(0, 0));
+        assert_eq!(dapp_2_tier, RankedTier::new_saturated(0, 0));
 
         // 2nd tier checks
         let (dapp_3_tier, dapp_4_tier) = (tier_assignment.dapps[&2], tier_assignment.dapps[&3]);
-        assert_eq!(dapp_3_tier, TierAndRank::new_saturated(1, 9));
-        assert_eq!(dapp_4_tier, TierAndRank::new_saturated(1, 9));
+        assert_eq!(dapp_3_tier, RankedTier::new_saturated(1, 9));
+        assert_eq!(dapp_4_tier, RankedTier::new_saturated(1, 9));
 
         // 4th tier checks
         let (dapp_5_tier, dapp_6_tier) = (tier_assignment.dapps[&4], tier_assignment.dapps[&5]);
-        assert_eq!(dapp_5_tier, TierAndRank::new_saturated(3, 0));
-        assert_eq!(dapp_6_tier, TierAndRank::new_saturated(3, 0));
+        assert_eq!(dapp_5_tier, RankedTier::new_saturated(3, 0));
+        assert_eq!(dapp_6_tier, RankedTier::new_saturated(3, 0));
 
         // Sanity check - last dapp should not exists in the tier assignment
         assert!(tier_assignment

--- a/pallets/dapp-staking-v3/src/test/tests.rs
+++ b/pallets/dapp-staking-v3/src/test/tests.rs
@@ -3161,7 +3161,7 @@ fn ranking_will_calc_reward_correctly() {
             assert_stake(account, smart_contract, amount);
         }
 
-        for (idx, amount) in [81, 82, 80, 79, 15, 15, 14].into_iter().enumerate() {
+        for (idx, amount) in [101, 102, 100, 99, 15, 16, 14].into_iter().enumerate() {
             lock_and_stake(idx, &smart_contracts[idx], amount)
         }
 
@@ -3213,7 +3213,7 @@ fn claim_dapp_reward_with_rank() {
         assert_register(1, &smart_contract);
 
         let alice = 2;
-        let amount = 79; // very close to tier 0 so will enter tier 1 with rank 9
+        let amount = 99; // very close to tier 0 so will enter tier 1 with rank 9
         assert_lock(alice, amount);
         assert_stake(alice, &smart_contract, amount);
 
@@ -3235,9 +3235,9 @@ fn claim_dapp_reward_with_rank() {
         let expected_rank = 9;
         let expected_total_reward =
             slot_reward + expected_rank * rank_rewards[expected_tier as usize];
-        assert_eq!(slot_reward, 10_000_000);
-        assert_eq!(rank_rewards[expected_tier as usize], 1_000_000); // slot_reward / 10
-        assert_eq!(expected_total_reward, 19_000_000);
+        assert_eq!(slot_reward, 15_000_000);
+        assert_eq!(rank_rewards[expected_tier as usize], 1_500_000); // slot_reward / 10
+        assert_eq!(expected_total_reward, 28_500_000);
 
         System::assert_last_event(RuntimeEvent::DappStaking(Event::DAppReward {
             beneficiary: 1,

--- a/pallets/dapp-staking-v3/src/test/tests.rs
+++ b/pallets/dapp-staking-v3/src/test/tests.rs
@@ -35,7 +35,7 @@ use frame_support::{
 use sp_runtime::{traits::Zero, FixedU128};
 
 use astar_primitives::{
-    dapp_staking::{CycleConfiguration, EraNumber, SmartContractHandle},
+    dapp_staking::{CycleConfiguration, EraNumber, SmartContractHandle, TierAndRank},
     Balance, BlockNumber,
 };
 
@@ -2483,18 +2483,18 @@ fn get_dapp_tier_assignment_and_rewards_basic_example_works() {
 
         // 1st tier checks
         let (dapp_1_tier, dapp_2_tier) = (tier_assignment.dapps[&0], tier_assignment.dapps[&1]);
-        assert_eq!(dapp_1_tier, 0);
-        assert_eq!(dapp_2_tier, 0);
+        assert_eq!(dapp_1_tier, TierAndRank::new_saturated(0, 0));
+        assert_eq!(dapp_2_tier, TierAndRank::new_saturated(0, 0));
 
         // 2nd tier checks
         let (dapp_3_tier, dapp_4_tier) = (tier_assignment.dapps[&2], tier_assignment.dapps[&3]);
-        assert_eq!(dapp_3_tier, 1);
-        assert_eq!(dapp_4_tier, 1);
+        assert_eq!(dapp_3_tier, TierAndRank::new_saturated(1, 9));
+        assert_eq!(dapp_4_tier, TierAndRank::new_saturated(1, 9));
 
         // 4th tier checks
         let (dapp_5_tier, dapp_6_tier) = (tier_assignment.dapps[&4], tier_assignment.dapps[&5]);
-        assert_eq!(dapp_5_tier, 3);
-        assert_eq!(dapp_6_tier, 3);
+        assert_eq!(dapp_5_tier, TierAndRank::new_saturated(3, 0));
+        assert_eq!(dapp_6_tier, TierAndRank::new_saturated(3, 0));
 
         // Sanity check - last dapp should not exists in the tier assignment
         assert!(tier_assignment

--- a/pallets/dapp-staking-v3/src/test/tests_types.rs
+++ b/pallets/dapp-staking-v3/src/test/tests_types.rs
@@ -2924,6 +2924,7 @@ fn dapp_tier_rewards_basic_tests() {
         dapps.clone(),
         tier_rewards.clone(),
         period,
+        vec![0, 0, 0],
     )
     .expect("Bounds are respected.");
 

--- a/pallets/dapp-staking-v3/src/test/tests_types.rs
+++ b/pallets/dapp-staking-v3/src/test/tests_types.rs
@@ -2925,22 +2925,16 @@ fn dapp_tier_rewards_basic_tests() {
     .expect("Bounds are respected.");
 
     // 1st scenario - claim reward for a dApps
-    let tier_and_rank = dapps[&1];
+    let ranked_tier = dapps[&1];
     assert_eq!(
         dapp_tier_rewards.try_claim(1),
-        Ok((
-            tier_rewards[tier_and_rank.tier_id() as usize],
-            tier_and_rank
-        ))
+        Ok((tier_rewards[ranked_tier.tier() as usize], ranked_tier))
     );
 
-    let tier_and_rank = dapps[&5];
+    let ranked_tier = dapps[&5];
     assert_eq!(
         dapp_tier_rewards.try_claim(5),
-        Ok((
-            tier_rewards[tier_and_rank.tier_id() as usize],
-            tier_and_rank
-        ))
+        Ok((tier_rewards[ranked_tier.tier() as usize], ranked_tier))
     );
 
     // 2nd scenario - try to claim already claimed reward

--- a/pallets/dapp-staking-v3/src/test/tests_types.rs
+++ b/pallets/dapp-staking-v3/src/test/tests_types.rs
@@ -17,7 +17,7 @@
 // along with Astar. If not, see <http://www.gnu.org/licenses/>.
 
 use astar_primitives::{
-    dapp_staking::{StandardTierSlots, TierAndRank},
+    dapp_staking::{RankedTier, StandardTierSlots},
     Balance,
 };
 use frame_support::assert_ok;
@@ -2907,12 +2907,12 @@ fn dapp_tier_rewards_basic_tests() {
     get_u32_type!(NumberOfTiers, 3);
 
     // Example dApps & rewards
-    let dapps = BTreeMap::<DAppId, TierAndRank>::from([
-        (1, TierAndRank::new_saturated(0, 0)),
-        (2, TierAndRank::new_saturated(0, 0)),
-        (3, TierAndRank::new_saturated(1, 0)),
-        (5, TierAndRank::new_saturated(1, 0)),
-        (6, TierAndRank::new_saturated(2, 0)),
+    let dapps = BTreeMap::<DAppId, RankedTier>::from([
+        (1, RankedTier::new_saturated(0, 0)),
+        (2, RankedTier::new_saturated(0, 0)),
+        (3, RankedTier::new_saturated(1, 0)),
+        (5, RankedTier::new_saturated(1, 0)),
+        (6, RankedTier::new_saturated(2, 0)),
     ]);
     let tier_rewards = vec![300, 20, 1];
     let period = 2;

--- a/pallets/dapp-staking-v3/src/test/tests_types.rs
+++ b/pallets/dapp-staking-v3/src/test/tests_types.rs
@@ -16,7 +16,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Astar. If not, see <http://www.gnu.org/licenses/>.
 
-use astar_primitives::{dapp_staking::StandardTierSlots, Balance};
+use astar_primitives::{
+    dapp_staking::{StandardTierSlots, TierAndRank},
+    Balance,
+};
 use frame_support::assert_ok;
 use sp_arithmetic::fixed_point::FixedU128;
 use sp_runtime::Permill;
@@ -2904,7 +2907,13 @@ fn dapp_tier_rewards_basic_tests() {
     get_u32_type!(NumberOfTiers, 3);
 
     // Example dApps & rewards
-    let dapps = BTreeMap::from([(1 as DAppId, 0 as TierId), (2, 0), (3, 1), (5, 1), (6, 2)]);
+    let dapps = BTreeMap::<DAppId, TierAndRank>::from([
+        (1, TierAndRank::new_saturated(0, 0)),
+        (2, TierAndRank::new_saturated(0, 0)),
+        (3, TierAndRank::new_saturated(1, 0)),
+        (5, TierAndRank::new_saturated(1, 0)),
+        (6, TierAndRank::new_saturated(2, 0)),
+    ]);
     let tier_rewards = vec![300, 20, 1];
     let period = 2;
 
@@ -2916,16 +2925,22 @@ fn dapp_tier_rewards_basic_tests() {
     .expect("Bounds are respected.");
 
     // 1st scenario - claim reward for a dApps
-    let tier_id = dapps[&1];
+    let tier_and_rank = dapps[&1];
     assert_eq!(
         dapp_tier_rewards.try_claim(1),
-        Ok((tier_rewards[tier_id as usize], tier_id))
+        Ok((
+            tier_rewards[tier_and_rank.tier_id() as usize],
+            tier_and_rank
+        ))
     );
 
-    let tier_id = dapps[&5];
+    let tier_and_rank = dapps[&5];
     assert_eq!(
         dapp_tier_rewards.try_claim(5),
-        Ok((tier_rewards[tier_id as usize], tier_id))
+        Ok((
+            tier_rewards[tier_and_rank.tier_id() as usize],
+            tier_and_rank
+        ))
     );
 
     // 2nd scenario - try to claim already claimed reward

--- a/pallets/dapp-staking-v3/src/types.rs
+++ b/pallets/dapp-staking-v3/src/types.rs
@@ -1782,26 +1782,11 @@ impl<MD: Get<u32>, NT: Get<u32>> DAppTierRewards<MD, NT> {
             .remove(&dapp_id)
             .ok_or(DAppTierError::NoDAppInTiers)?;
 
-        let (tier_id, rank) = ranked_tier.deconstruct();
-
-        let mut amount = self
+        let tier_id = ranked_tier.tier();
+        let amount = self
             .rewards
             .get(tier_id as usize)
             .map_or(Balance::zero(), |x| *x);
-
-        if !rank.is_zero() {
-            // TODO: make sure this is the correct approach & add tests
-            // (current_tier_reward - next_tier_reward) / MAX_RANK
-            let reward_per_rank = self
-                .rewards
-                .get(tier_id.saturating_sub(1) as usize) // previous tier reward
-                .map_or(Balance::zero(), |x| x.saturating_sub(amount)) // delta amount
-                .saturating_div(RankedTier::MAX_RANK.into()); // divided by ranks
-
-            let additional_reward = reward_per_rank.saturating_mul(rank.into());
-            amount = amount.saturating_add(additional_reward);
-        }
-
         Ok((amount, ranked_tier))
     }
 }

--- a/pallets/dapp-staking-v3/src/types.rs
+++ b/pallets/dapp-staking-v3/src/types.rs
@@ -1777,12 +1777,12 @@ impl<MD: Get<u32>, NT: Get<u32>> DAppTierRewards<MD, NT> {
     /// In case dapp isn't applicable for rewards, or they have already been consumed, returns `None`.
     pub fn try_claim(&mut self, dapp_id: DAppId) -> Result<(Balance, RankedTier), DAppTierError> {
         // Check if dApp Id exists.
-        let tier_and_rank = self
+        let ranked_tier = self
             .dapps
             .remove(&dapp_id)
             .ok_or(DAppTierError::NoDAppInTiers)?;
 
-        let (tier_id, rank) = tier_and_rank.destruct();
+        let (tier_id, rank) = ranked_tier.deconstruct();
 
         let mut amount = self
             .rewards
@@ -1802,7 +1802,7 @@ impl<MD: Get<u32>, NT: Get<u32>> DAppTierRewards<MD, NT> {
             amount = amount.saturating_add(additional_reward);
         }
 
-        Ok((amount, tier_and_rank))
+        Ok((amount, ranked_tier))
     }
 }
 

--- a/pallets/dapp-staking-v3/src/types.rs
+++ b/pallets/dapp-staking-v3/src/types.rs
@@ -1794,11 +1794,11 @@ impl<MD: Get<u32>, NT: Get<u32>> DAppTierRewards<MD, NT> {
             // (current_tier_reward - next_tier_reward) / MAX_RANK
             let reward_per_rank = self
                 .rewards
-                .get(tier_id.saturating_add(1) as usize) // next tier reward
-                .map_or(Balance::zero(), |x| amount.saturating_sub(*x)) // delta amount
+                .get(tier_id.saturating_sub(1) as usize) // previous tier reward
+                .map_or(Balance::zero(), |x| x.saturating_sub(amount)) // delta amount
                 .saturating_div(TierAndRank::MAX_RANK.into()); // divided by ranks
 
-            let additional_reward = reward_per_rank.saturating_sub(rank.into());
+            let additional_reward = reward_per_rank.saturating_mul(rank.into());
             amount = amount.saturating_add(additional_reward);
         }
 

--- a/precompiles/dapp-staking-v3/src/test/mock.rs
+++ b/precompiles/dapp-staking-v3/src/test/mock.rs
@@ -23,7 +23,7 @@ use frame_support::{
     assert_ok, construct_runtime, parameter_types,
     traits::{
         fungible::{Mutate as FunMutate, Unbalanced as FunUnbalanced},
-        ConstU128, ConstU64, Hooks,
+        ConstBool, ConstU128, ConstU64, Hooks,
     },
     weights::{RuntimeDbWeight, Weight},
 };
@@ -266,6 +266,7 @@ impl pallet_dapp_staking_v3::Config for Test {
     type MaxNumberOfStakedContracts = ConstU32<5>;
     type MinimumStakeAmount = ConstU128<3>;
     type NumberOfTiers = ConstU32<4>;
+    type RankingEnabled = ConstBool<true>;
     type WeightInfo = pallet_dapp_staking_v3::weights::SubstrateWeight<Test>;
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = BenchmarkHelper<MockSmartContract, AccountId>;

--- a/primitives/src/dapp_staking.rs
+++ b/primitives/src/dapp_staking.rs
@@ -218,7 +218,7 @@ impl RankedTier {
     }
 
     #[inline(always)]
-    pub fn tier_id(&self) -> TierId {
+    pub fn tier(&self) -> TierId {
         self.0 & 0x0f
     }
 
@@ -228,15 +228,15 @@ impl RankedTier {
     }
 
     #[inline(always)]
-    pub fn destruct(&self) -> (TierId, Rank) {
-        (self.tier_id(), self.rank())
+    pub fn deconstruct(&self) -> (TierId, Rank) {
+        (self.tier(), self.rank())
     }
 }
 
 impl core::fmt::Debug for RankedTier {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("TierAndRank")
-            .field("tier", &self.tier_id())
+            .field("tier", &self.tier())
             .field("rank", &self.rank())
             .finish()
     }
@@ -271,26 +271,26 @@ mod tests {
     #[test]
     fn tier_and_rank() {
         let t = RankedTier::new(0, 0).unwrap();
-        assert_eq!(t.destruct(), (0, 0));
+        assert_eq!(t.deconstruct(), (0, 0));
 
         let t = RankedTier::new(15, 10).unwrap();
-        assert_eq!(t.destruct(), (15, 10));
+        assert_eq!(t.deconstruct(), (15, 10));
 
         assert_eq!(RankedTier::new(16, 10), Err(ArithmeticError::Overflow));
         assert_eq!(RankedTier::new(15, 11), Err(ArithmeticError::Overflow));
 
         let t = RankedTier::new_saturated(0, 0);
-        assert_eq!(t.destruct(), (0, 0));
+        assert_eq!(t.deconstruct(), (0, 0));
 
         let t = RankedTier::new_saturated(1, 1);
-        assert_eq!(t.destruct(), (1, 1));
+        assert_eq!(t.deconstruct(), (1, 1));
 
         let t = RankedTier::new_saturated(3, 15);
-        assert_eq!(t.destruct(), (3, 10));
+        assert_eq!(t.deconstruct(), (3, 10));
 
         // max value for tier and rank
         let t = RankedTier::new_saturated(16, 16);
-        assert_eq!(t.destruct(), (15, 10));
+        assert_eq!(t.deconstruct(), (15, 10));
     }
 
     #[test]

--- a/primitives/src/dapp_staking.rs
+++ b/primitives/src/dapp_staking.rs
@@ -235,7 +235,7 @@ impl RankedTier {
 
 impl core::fmt::Debug for RankedTier {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("TierAndRank")
+        f.debug_struct("RankedTier")
             .field("tier", &self.tier())
             .field("rank", &self.rank())
             .finish()
@@ -255,7 +255,7 @@ impl RankedTier {
         } else {
             <Balance as TryInto<u8>>::try_into(
                 stake_amount
-                    .saturating_sub(lower_bound.saturating_add(1))
+                    .saturating_sub(lower_bound)
                     .saturating_div(rank_threshold),
             )
             .unwrap_or_default()
@@ -296,11 +296,11 @@ mod tests {
     #[test]
     fn find_rank() {
         assert_eq!(RankedTier::find_rank(0, 0, 0), 0);
-        assert_eq!(RankedTier::find_rank(0, 100, 10), 0);
+        assert_eq!(RankedTier::find_rank(0, 100, 9), 0);
+        assert_eq!(RankedTier::find_rank(0, 100, 10), 1);
         assert_eq!(RankedTier::find_rank(0, 100, 49), 4);
-        assert_eq!(RankedTier::find_rank(0, 100, 50), 4);
+        assert_eq!(RankedTier::find_rank(0, 100, 50), 5);
         assert_eq!(RankedTier::find_rank(0, 100, 51), 5);
-        assert_eq!(RankedTier::find_rank(0, 100, 100), 9);
         assert_eq!(RankedTier::find_rank(0, 100, 101), 10);
 
         assert_eq!(RankedTier::find_rank(100, 100, 100), 0);

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -377,6 +377,7 @@ impl pallet_dapp_staking_v3::Config for Runtime {
     type MaxNumberOfStakedContracts = ConstU32<16>;
     type MinimumStakeAmount = MinimumStakingAmount;
     type NumberOfTiers = ConstU32<4>;
+    type RankingEnabled = ();
     type WeightInfo = weights::pallet_dapp_staking_v3::SubstrateWeight<Runtime>;
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = BenchmarkHelper<SmartContract<AccountId>, AccountId>;

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -1174,7 +1174,7 @@ pub type Executive = frame_executive::Executive<
 /// All migrations that will run on the next runtime upgrade.
 ///
 /// Once done, migrations should be removed from the tuple.
-pub type Migrations = ();
+pub type Migrations = (pallet_dapp_staking_v3::migration::versioned_migrations::V6ToV7<Runtime>);
 
 type EventRecord = frame_system::EventRecord<
     <Runtime as frame_system::Config>::RuntimeEvent,

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -1174,7 +1174,10 @@ pub type Executive = frame_executive::Executive<
 /// All migrations that will run on the next runtime upgrade.
 ///
 /// Once done, migrations should be removed from the tuple.
-pub type Migrations = (pallet_dapp_staking_v3::migration::versioned_migrations::V6ToV7<Runtime>);
+pub type Migrations = (
+    // Migrate to ranking system
+    pallet_dapp_staking_v3::migration::versioned_migrations::V6ToV7<Runtime>,
+);
 
 type EventRecord = frame_system::EventRecord<
     <Runtime as frame_system::Config>::RuntimeEvent,

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -71,7 +71,7 @@ use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 use astar_primitives::{
     dapp_staking::{
         AccountCheck as DappStakingAccountCheck, CycleConfiguration, DAppId, EraNumber,
-        PeriodNumber, SmartContract, StandardTierSlots, TierAndRank,
+        PeriodNumber, RankedTier, SmartContract, StandardTierSlots,
     },
     evm::EvmRevertCodeHandler,
     oracle::{CurrencyAmount, CurrencyId, DummyCombineData},
@@ -1758,7 +1758,7 @@ impl_runtime_apis! {
             InflationCycleConfig::blocks_per_era()
         }
 
-        fn get_dapp_tier_assignment() -> BTreeMap<DAppId, TierAndRank> {
+        fn get_dapp_tier_assignment() -> BTreeMap<DAppId, RankedTier> {
             DappStaking::get_dapp_tier_assignment()
         }
     }

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -71,7 +71,7 @@ use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 use astar_primitives::{
     dapp_staking::{
         AccountCheck as DappStakingAccountCheck, CycleConfiguration, DAppId, EraNumber,
-        PeriodNumber, SmartContract, StandardTierSlots, TierId,
+        PeriodNumber, SmartContract, StandardTierSlots, TierAndRank,
     },
     evm::EvmRevertCodeHandler,
     oracle::{CurrencyAmount, CurrencyId, DummyCombineData},
@@ -1758,7 +1758,7 @@ impl_runtime_apis! {
             InflationCycleConfig::blocks_per_era()
         }
 
-        fn get_dapp_tier_assignment() -> BTreeMap<DAppId, TierId> {
+        fn get_dapp_tier_assignment() -> BTreeMap<DAppId, TierAndRank> {
             DappStaking::get_dapp_tier_assignment()
         }
     }

--- a/runtime/astar/src/weights/pallet_dapp_staking_v3.rs
+++ b/runtime/astar/src/weights/pallet_dapp_staking_v3.rs
@@ -55,8 +55,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
-		// Minimum execution time: 6_275_000 picoseconds.
-		Weight::from_parts(6_550_000, 0)
+		// Minimum execution time: 6_901_000 picoseconds.
+		Weight::from_parts(7_110_000, 0)
 	}
 	/// Storage: `DappStaking::IntegratedDApps` (r:1 w:1)
 	/// Proof: `DappStaking::IntegratedDApps` (`max_values`: Some(65535), `max_size`: Some(116), added: 2096, mode: `MaxEncodedLen`)
@@ -68,8 +68,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `3086`
-		// Minimum execution time: 12_188_000 picoseconds.
-		Weight::from_parts(12_421_000, 3086)
+		// Minimum execution time: 12_920_000 picoseconds.
+		Weight::from_parts(13_049_000, 3086)
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -79,8 +79,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `97`
 		//  Estimated: `3086`
-		// Minimum execution time: 11_078_000 picoseconds.
-		Weight::from_parts(11_242_000, 3086)
+		// Minimum execution time: 11_575_000 picoseconds.
+		Weight::from_parts(11_820_000, 3086)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -90,8 +90,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `97`
 		//  Estimated: `3086`
-		// Minimum execution time: 11_509_000 picoseconds.
-		Weight::from_parts(11_795_000, 3086)
+		// Minimum execution time: 12_043_000 picoseconds.
+		Weight::from_parts(12_399_000, 3086)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -105,8 +105,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `97`
 		//  Estimated: `3086`
-		// Minimum execution time: 15_050_000 picoseconds.
-		Weight::from_parts(15_299_000, 3086)
+		// Minimum execution time: 15_665_000 picoseconds.
+		Weight::from_parts(15_923_000, 3086)
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -124,8 +124,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `138`
 		//  Estimated: `4764`
-		// Minimum execution time: 27_558_000 picoseconds.
-		Weight::from_parts(28_143_000, 4764)
+		// Minimum execution time: 28_847_000 picoseconds.
+		Weight::from_parts(29_269_000, 4764)
 			.saturating_add(T::DbWeight::get().reads(5_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -141,8 +141,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `158`
 		//  Estimated: `4764`
-		// Minimum execution time: 31_462_000 picoseconds.
-		Weight::from_parts(31_799_000, 4764)
+		// Minimum execution time: 32_150_000 picoseconds.
+		Weight::from_parts(32_483_000, 4764)
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -158,8 +158,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `158`
 		//  Estimated: `4764`
-		// Minimum execution time: 28_350_000 picoseconds.
-		Weight::from_parts(28_942_000, 4764)
+		// Minimum execution time: 29_439_000 picoseconds.
+		Weight::from_parts(30_316_000, 4764)
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -176,10 +176,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `190`
 		//  Estimated: `4764`
-		// Minimum execution time: 30_972_000 picoseconds.
-		Weight::from_parts(32_215_872, 4764)
-			// Standard Error: 2_399
-			.saturating_add(Weight::from_parts(103_494, 0).saturating_mul(x.into()))
+		// Minimum execution time: 29_286_000 picoseconds.
+		Weight::from_parts(30_396_033, 4764)
+			// Standard Error: 2_822
+			.saturating_add(Weight::from_parts(117_982, 0).saturating_mul(x.into()))
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -195,8 +195,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `200`
 		//  Estimated: `4764`
-		// Minimum execution time: 28_220_000 picoseconds.
-		Weight::from_parts(28_659_000, 4764)
+		// Minimum execution time: 26_357_000 picoseconds.
+		Weight::from_parts(26_804_000, 4764)
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -218,8 +218,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `274`
 		//  Estimated: `4764`
-		// Minimum execution time: 39_918_000 picoseconds.
-		Weight::from_parts(40_583_000, 4764)
+		// Minimum execution time: 39_953_000 picoseconds.
+		Weight::from_parts(40_495_000, 4764)
 			.saturating_add(T::DbWeight::get().reads(7_u64))
 			.saturating_add(T::DbWeight::get().writes(5_u64))
 	}
@@ -241,8 +241,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `459`
 		//  Estimated: `4764`
-		// Minimum execution time: 43_189_000 picoseconds.
-		Weight::from_parts(43_767_000, 4764)
+		// Minimum execution time: 43_935_000 picoseconds.
+		Weight::from_parts(44_485_000, 4764)
 			.saturating_add(T::DbWeight::get().reads(7_u64))
 			.saturating_add(T::DbWeight::get().writes(5_u64))
 	}
@@ -261,10 +261,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `541`
 		//  Estimated: `4764`
-		// Minimum execution time: 43_757_000 picoseconds.
-		Weight::from_parts(42_840_933, 4764)
-			// Standard Error: 3_343
-			.saturating_add(Weight::from_parts(1_914_215, 0).saturating_mul(x.into()))
+		// Minimum execution time: 44_282_000 picoseconds.
+		Weight::from_parts(43_704_387, 4764)
+			// Standard Error: 2_999
+			.saturating_add(Weight::from_parts(1_901_320, 0).saturating_mul(x.into()))
 			.saturating_add(T::DbWeight::get().reads(5_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
@@ -281,10 +281,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `519`
 		//  Estimated: `4764`
-		// Minimum execution time: 41_710_000 picoseconds.
-		Weight::from_parts(40_832_293, 4764)
-			// Standard Error: 4_171
-			.saturating_add(Weight::from_parts(1_909_528, 0).saturating_mul(x.into()))
+		// Minimum execution time: 42_099_000 picoseconds.
+		Weight::from_parts(41_482_351, 4764)
+			// Standard Error: 3_082
+			.saturating_add(Weight::from_parts(1_875_239, 0).saturating_mul(x.into()))
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
@@ -298,21 +298,21 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `275`
 		//  Estimated: `3775`
-		// Minimum execution time: 34_132_000 picoseconds.
-		Weight::from_parts(34_857_000, 3775)
+		// Minimum execution time: 32_801_000 picoseconds.
+		Weight::from_parts(33_233_000, 3775)
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
 	/// Storage: `DappStaking::IntegratedDApps` (r:1 w:0)
 	/// Proof: `DappStaking::IntegratedDApps` (`max_values`: Some(65535), `max_size`: Some(116), added: 2096, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::DAppTiers` (r:1 w:1)
-	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1583), added: 4058, mode: `MaxEncodedLen`)
+	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1648), added: 4123, mode: `MaxEncodedLen`)
 	fn claim_dapp_reward() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `2607`
-		//  Estimated: `5048`
-		// Minimum execution time: 49_123_000 picoseconds.
-		Weight::from_parts(50_433_000, 5048)
+		//  Measured:  `2672`
+		//  Estimated: `5113`
+		// Minimum execution time: 50_552_000 picoseconds.
+		Weight::from_parts(51_566_000, 5113)
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -332,8 +332,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `322`
 		//  Estimated: `4764`
-		// Minimum execution time: 35_718_000 picoseconds.
-		Weight::from_parts(36_261_000, 4764)
+		// Minimum execution time: 36_548_000 picoseconds.
+		Weight::from_parts(37_174_000, 4764)
 			.saturating_add(T::DbWeight::get().reads(6_u64))
 			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
@@ -350,10 +350,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `257 + x * (73 ±0)`
 		//  Estimated: `4764 + x * (2653 ±0)`
-		// Minimum execution time: 37_969_000 picoseconds.
-		Weight::from_parts(34_795_715, 4764)
-			// Standard Error: 7_200
-			.saturating_add(Weight::from_parts(4_915_109, 0).saturating_mul(x.into()))
+		// Minimum execution time: 36_536_000 picoseconds.
+		Weight::from_parts(32_923_068, 4764)
+			// Standard Error: 7_141
+			.saturating_add(Weight::from_parts(4_979_475, 0).saturating_mul(x.into()))
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(x.into())))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
@@ -366,8 +366,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `1486`
-		// Minimum execution time: 8_422_000 picoseconds.
-		Weight::from_parts(8_725_000, 1486)
+		// Minimum execution time: 8_966_000 picoseconds.
+		Weight::from_parts(9_216_000, 1486)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 	}
 	/// Storage: `DappStaking::CurrentEraInfo` (r:1 w:1)
@@ -376,15 +376,17 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `DappStaking::EraRewards` (`max_values`: None, `max_size`: Some(789), added: 3264, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::StaticTierParams` (r:1 w:0)
 	/// Proof: `DappStaking::StaticTierParams` (`max_values`: Some(1), `max_size`: Some(167), added: 662, mode: `MaxEncodedLen`)
+	/// Storage: `PriceAggregator::ValuesCircularBuffer` (r:1 w:0)
+	/// Proof: `PriceAggregator::ValuesCircularBuffer` (`max_values`: Some(1), `max_size`: Some(117), added: 612, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::TierConfig` (r:1 w:1)
 	/// Proof: `DappStaking::TierConfig` (`max_values`: Some(1), `max_size`: Some(161), added: 656, mode: `MaxEncodedLen`)
 	fn on_initialize_voting_to_build_and_earn() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `330`
+		//  Measured:  `334`
 		//  Estimated: `4254`
-		// Minimum execution time: 22_909_000 picoseconds.
-		Weight::from_parts(23_440_000, 4254)
-			.saturating_add(T::DbWeight::get().reads(4_u64))
+		// Minimum execution time: 25_581_000 picoseconds.
+		Weight::from_parts(26_206_000, 4254)
+			.saturating_add(T::DbWeight::get().reads(5_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
 	/// Storage: `DappStaking::CurrentEraInfo` (r:1 w:1)
@@ -397,17 +399,19 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `DappStaking::EraRewards` (`max_values`: None, `max_size`: Some(789), added: 3264, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::StaticTierParams` (r:1 w:0)
 	/// Proof: `DappStaking::StaticTierParams` (`max_values`: Some(1), `max_size`: Some(167), added: 662, mode: `MaxEncodedLen`)
+	/// Storage: `PriceAggregator::ValuesCircularBuffer` (r:1 w:0)
+	/// Proof: `PriceAggregator::ValuesCircularBuffer` (`max_values`: Some(1), `max_size`: Some(117), added: 612, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::TierConfig` (r:1 w:1)
 	/// Proof: `DappStaking::TierConfig` (`max_values`: Some(1), `max_size`: Some(161), added: 656, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::DAppTiers` (r:0 w:1)
-	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1583), added: 4058, mode: `MaxEncodedLen`)
+	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1648), added: 4123, mode: `MaxEncodedLen`)
 	fn on_initialize_build_and_earn_to_voting() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `837`
+		//  Measured:  `841`
 		//  Estimated: `4254`
-		// Minimum execution time: 36_610_000 picoseconds.
-		Weight::from_parts(37_596_000, 4254)
-			.saturating_add(T::DbWeight::get().reads(6_u64))
+		// Minimum execution time: 41_102_000 picoseconds.
+		Weight::from_parts(41_895_000, 4254)
+			.saturating_add(T::DbWeight::get().reads(7_u64))
 			.saturating_add(T::DbWeight::get().writes(7_u64))
 	}
 	/// Storage: `DappStaking::CurrentEraInfo` (r:1 w:1)
@@ -416,17 +420,19 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `DappStaking::EraRewards` (`max_values`: None, `max_size`: Some(789), added: 3264, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::StaticTierParams` (r:1 w:0)
 	/// Proof: `DappStaking::StaticTierParams` (`max_values`: Some(1), `max_size`: Some(167), added: 662, mode: `MaxEncodedLen`)
+	/// Storage: `PriceAggregator::ValuesCircularBuffer` (r:1 w:0)
+	/// Proof: `PriceAggregator::ValuesCircularBuffer` (`max_values`: Some(1), `max_size`: Some(117), added: 612, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::TierConfig` (r:1 w:1)
 	/// Proof: `DappStaking::TierConfig` (`max_values`: Some(1), `max_size`: Some(161), added: 656, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::DAppTiers` (r:0 w:1)
-	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1583), added: 4058, mode: `MaxEncodedLen`)
+	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1648), added: 4123, mode: `MaxEncodedLen`)
 	fn on_initialize_build_and_earn_to_build_and_earn() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `382`
+		//  Measured:  `386`
 		//  Estimated: `4254`
-		// Minimum execution time: 24_517_000 picoseconds.
-		Weight::from_parts(25_047_000, 4254)
-			.saturating_add(T::DbWeight::get().reads(4_u64))
+		// Minimum execution time: 28_342_000 picoseconds.
+		Weight::from_parts(28_987_000, 4254)
+			.saturating_add(T::DbWeight::get().reads(5_u64))
 			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
 	/// Storage: `DappStaking::ContractStake` (r:101 w:0)
@@ -438,10 +444,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `152 + x * (32 ±0)`
 		//  Estimated: `3061 + x * (2071 ±0)`
-		// Minimum execution time: 6_465_000 picoseconds.
-		Weight::from_parts(10_861_086, 3061)
-			// Standard Error: 3_452
-			.saturating_add(Weight::from_parts(2_283_463, 0).saturating_mul(x.into()))
+		// Minimum execution time: 6_941_000 picoseconds.
+		Weight::from_parts(11_645_090, 3061)
+			// Standard Error: 3_059
+			.saturating_add(Weight::from_parts(2_388_533, 0).saturating_mul(x.into()))
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(x.into())))
 			.saturating_add(Weight::from_parts(0, 2071).saturating_mul(x.into()))
@@ -451,13 +457,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Storage: `DappStaking::EraRewards` (r:1 w:1)
 	/// Proof: `DappStaking::EraRewards` (`max_values`: None, `max_size`: Some(789), added: 3264, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::DAppTiers` (r:0 w:1)
-	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1583), added: 4058, mode: `MaxEncodedLen`)
+	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1648), added: 4123, mode: `MaxEncodedLen`)
 	fn on_idle_cleanup() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `293`
 		//  Estimated: `4254`
-		// Minimum execution time: 7_431_000 picoseconds.
-		Weight::from_parts(7_562_000, 4254)
+		// Minimum execution time: 7_727_000 picoseconds.
+		Weight::from_parts(7_910_000, 4254)
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -469,6 +469,7 @@ impl pallet_dapp_staking_v3::Config for Runtime {
     type MaxNumberOfStakedContracts = ConstU32<3>;
     type MinimumStakeAmount = ConstU128<AST>;
     type NumberOfTiers = ConstU32<4>;
+    type RankingEnabled = ConstBool<true>;
     type WeightInfo = pallet_dapp_staking_v3::weights::SubstrateWeight<Runtime>;
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = BenchmarkHelper<SmartContract<AccountId>, AccountId>;

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -65,8 +65,8 @@ use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 
 use astar_primitives::{
     dapp_staking::{
-        CycleConfiguration, DAppId, EraNumber, PeriodNumber, SmartContract, StandardTierSlots,
-        TierAndRank,
+        CycleConfiguration, DAppId, EraNumber, PeriodNumber, RankedTier, SmartContract,
+        StandardTierSlots,
     },
     evm::{EvmRevertCodeHandler, HashedDefaultMappings},
     Address, AssetId, Balance, BlockNumber, Hash, Header, Nonce,
@@ -1517,7 +1517,7 @@ impl_runtime_apis! {
             InflationCycleConfig::blocks_per_era()
         }
 
-        fn get_dapp_tier_assignment() -> BTreeMap<DAppId, TierAndRank> {
+        fn get_dapp_tier_assignment() -> BTreeMap<DAppId, RankedTier> {
             DappStaking::get_dapp_tier_assignment()
         }
     }

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -66,7 +66,7 @@ use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 use astar_primitives::{
     dapp_staking::{
         CycleConfiguration, DAppId, EraNumber, PeriodNumber, SmartContract, StandardTierSlots,
-        TierId,
+        TierAndRank,
     },
     evm::{EvmRevertCodeHandler, HashedDefaultMappings},
     Address, AssetId, Balance, BlockNumber, Hash, Header, Nonce,
@@ -1517,7 +1517,7 @@ impl_runtime_apis! {
             InflationCycleConfig::blocks_per_era()
         }
 
-        fn get_dapp_tier_assignment() -> BTreeMap<DAppId, TierId> {
+        fn get_dapp_tier_assignment() -> BTreeMap<DAppId, TierAndRank> {
             DappStaking::get_dapp_tier_assignment()
         }
     }

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -1300,6 +1300,7 @@ pub type Executive = frame_executive::Executive<
 /// Once done, migrations should be removed from the tuple.
 pub type Migrations = (
     pallet_preimage::migration::v1::Migration<Runtime>,
+    // Migrate to ranking system
     pallet_dapp_staking_v3::migration::versioned_migrations::V6ToV7<Runtime>,
 );
 

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -71,7 +71,7 @@ use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 use astar_primitives::{
     dapp_staking::{
         AccountCheck as DappStakingAccountCheck, CycleConfiguration, DAppId, EraNumber,
-        PeriodNumber, SmartContract, StandardTierSlots, TierId,
+        PeriodNumber, SmartContract, StandardTierSlots, TierAndRank,
     },
     evm::{EvmRevertCodeHandler, HashedDefaultMappings},
     oracle::{CurrencyAmount, CurrencyId, DummyCombineData},
@@ -1876,7 +1876,7 @@ impl_runtime_apis! {
             InflationCycleConfig::blocks_per_era()
         }
 
-        fn get_dapp_tier_assignment() -> BTreeMap<DAppId, TierId> {
+        fn get_dapp_tier_assignment() -> BTreeMap<DAppId, TierAndRank> {
             DappStaking::get_dapp_tier_assignment()
         }
     }

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -71,7 +71,7 @@ use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 use astar_primitives::{
     dapp_staking::{
         AccountCheck as DappStakingAccountCheck, CycleConfiguration, DAppId, EraNumber,
-        PeriodNumber, SmartContract, StandardTierSlots, TierAndRank,
+        PeriodNumber, RankedTier, SmartContract, StandardTierSlots,
     },
     evm::{EvmRevertCodeHandler, HashedDefaultMappings},
     oracle::{CurrencyAmount, CurrencyId, DummyCombineData},
@@ -1876,7 +1876,7 @@ impl_runtime_apis! {
             InflationCycleConfig::blocks_per_era()
         }
 
-        fn get_dapp_tier_assignment() -> BTreeMap<DAppId, TierAndRank> {
+        fn get_dapp_tier_assignment() -> BTreeMap<DAppId, RankedTier> {
             DappStaking::get_dapp_tier_assignment()
         }
     }

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -442,6 +442,7 @@ impl pallet_dapp_staking_v3::Config for Runtime {
     type MaxNumberOfStakedContracts = ConstU32<8>;
     type MinimumStakeAmount = MinimumStakingAmount;
     type NumberOfTiers = ConstU32<4>;
+    type RankingEnabled = ConstBool<true>;
     type WeightInfo = weights::pallet_dapp_staking_v3::SubstrateWeight<Runtime>;
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = BenchmarkHelper<SmartContract<AccountId>, AccountId>;

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -1298,7 +1298,10 @@ pub type Executive = frame_executive::Executive<
 /// All migrations that will run on the next runtime upgrade.
 ///
 /// Once done, migrations should be removed from the tuple.
-pub type Migrations = ();
+pub type Migrations = (
+    pallet_preimage::migration::v1::Migration<Runtime>,
+    pallet_dapp_staking_v3::migration::versioned_migrations::V6ToV7<Runtime>,
+);
 
 type EventRecord = frame_system::EventRecord<
     <Runtime as frame_system::Config>::RuntimeEvent,

--- a/runtime/shibuya/src/weights/pallet_dapp_staking_v3.rs
+++ b/runtime/shibuya/src/weights/pallet_dapp_staking_v3.rs
@@ -55,8 +55,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
-		// Minimum execution time: 5_953_000 picoseconds.
-		Weight::from_parts(6_130_000, 0)
+		// Minimum execution time: 6_248_000 picoseconds.
+		Weight::from_parts(6_411_000, 0)
 	}
 	/// Storage: `DappStaking::IntegratedDApps` (r:1 w:1)
 	/// Proof: `DappStaking::IntegratedDApps` (`max_values`: Some(65535), `max_size`: Some(116), added: 2096, mode: `MaxEncodedLen`)
@@ -68,8 +68,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `3086`
-		// Minimum execution time: 12_077_000 picoseconds.
-		Weight::from_parts(12_378_000, 3086)
+		// Minimum execution time: 12_268_000 picoseconds.
+		Weight::from_parts(12_474_000, 3086)
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -79,8 +79,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `97`
 		//  Estimated: `3086`
-		// Minimum execution time: 10_630_000 picoseconds.
-		Weight::from_parts(10_828_000, 3086)
+		// Minimum execution time: 10_962_000 picoseconds.
+		Weight::from_parts(11_245_000, 3086)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -90,8 +90,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `97`
 		//  Estimated: `3086`
-		// Minimum execution time: 11_064_000 picoseconds.
-		Weight::from_parts(11_259_000, 3086)
+		// Minimum execution time: 11_415_000 picoseconds.
+		Weight::from_parts(11_557_000, 3086)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -105,8 +105,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `97`
 		//  Estimated: `3086`
-		// Minimum execution time: 14_678_000 picoseconds.
-		Weight::from_parts(14_986_000, 3086)
+		// Minimum execution time: 15_054_000 picoseconds.
+		Weight::from_parts(15_219_000, 3086)
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -124,8 +124,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `138`
 		//  Estimated: `4764`
-		// Minimum execution time: 31_103_000 picoseconds.
-		Weight::from_parts(31_358_000, 4764)
+		// Minimum execution time: 27_562_000 picoseconds.
+		Weight::from_parts(27_847_000, 4764)
 			.saturating_add(T::DbWeight::get().reads(5_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -141,8 +141,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `156`
 		//  Estimated: `4764`
-		// Minimum execution time: 30_623_000 picoseconds.
-		Weight::from_parts(31_023_000, 4764)
+		// Minimum execution time: 30_938_000 picoseconds.
+		Weight::from_parts(31_494_000, 4764)
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -158,8 +158,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `156`
 		//  Estimated: `4764`
-		// Minimum execution time: 27_612_000 picoseconds.
-		Weight::from_parts(28_332_000, 4764)
+		// Minimum execution time: 28_608_000 picoseconds.
+		Weight::from_parts(29_210_000, 4764)
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -176,10 +176,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `187`
 		//  Estimated: `4764`
-		// Minimum execution time: 27_956_000 picoseconds.
-		Weight::from_parts(28_811_940, 4764)
-			// Standard Error: 4_875
-			.saturating_add(Weight::from_parts(195_216, 0).saturating_mul(x.into()))
+		// Minimum execution time: 28_538_000 picoseconds.
+		Weight::from_parts(29_479_578, 4764)
+			// Standard Error: 4_546
+			.saturating_add(Weight::from_parts(186_430, 0).saturating_mul(x.into()))
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -195,8 +195,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `182`
 		//  Estimated: `4764`
-		// Minimum execution time: 25_300_000 picoseconds.
-		Weight::from_parts(25_606_000, 4764)
+		// Minimum execution time: 25_327_000 picoseconds.
+		Weight::from_parts(25_930_000, 4764)
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -218,8 +218,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `272`
 		//  Estimated: `4764`
-		// Minimum execution time: 38_627_000 picoseconds.
-		Weight::from_parts(39_162_000, 4764)
+		// Minimum execution time: 38_972_000 picoseconds.
+		Weight::from_parts(39_410_000, 4764)
 			.saturating_add(T::DbWeight::get().reads(7_u64))
 			.saturating_add(T::DbWeight::get().writes(5_u64))
 	}
@@ -241,8 +241,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `453`
 		//  Estimated: `4764`
-		// Minimum execution time: 43_750_000 picoseconds.
-		Weight::from_parts(44_381_000, 4764)
+		// Minimum execution time: 43_013_000 picoseconds.
+		Weight::from_parts(43_369_000, 4764)
 			.saturating_add(T::DbWeight::get().reads(7_u64))
 			.saturating_add(T::DbWeight::get().writes(5_u64))
 	}
@@ -261,10 +261,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `522`
 		//  Estimated: `4764`
-		// Minimum execution time: 42_554_000 picoseconds.
-		Weight::from_parts(42_253_711, 4764)
-			// Standard Error: 3_644
-			.saturating_add(Weight::from_parts(1_672_941, 0).saturating_mul(x.into()))
+		// Minimum execution time: 43_303_000 picoseconds.
+		Weight::from_parts(42_353_415, 4764)
+			// Standard Error: 4_034
+			.saturating_add(Weight::from_parts(1_894_887, 0).saturating_mul(x.into()))
 			.saturating_add(T::DbWeight::get().reads(5_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
@@ -281,10 +281,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `501`
 		//  Estimated: `4764`
-		// Minimum execution time: 40_539_000 picoseconds.
-		Weight::from_parts(39_724_447, 4764)
-			// Standard Error: 2_788
-			.saturating_add(Weight::from_parts(1_669_553, 0).saturating_mul(x.into()))
+		// Minimum execution time: 40_833_000 picoseconds.
+		Weight::from_parts(40_376_535, 4764)
+			// Standard Error: 4_977
+			.saturating_add(Weight::from_parts(1_875_635, 0).saturating_mul(x.into()))
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
@@ -298,21 +298,21 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `271`
 		//  Estimated: `3775`
-		// Minimum execution time: 31_127_000 picoseconds.
-		Weight::from_parts(31_427_000, 3775)
+		// Minimum execution time: 31_691_000 picoseconds.
+		Weight::from_parts(32_123_000, 3775)
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
 	/// Storage: `DappStaking::IntegratedDApps` (r:1 w:0)
 	/// Proof: `DappStaking::IntegratedDApps` (`max_values`: Some(65535), `max_size`: Some(116), added: 2096, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::DAppTiers` (r:1 w:1)
-	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1583), added: 4058, mode: `MaxEncodedLen`)
+	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1648), added: 4123, mode: `MaxEncodedLen`)
 	fn claim_dapp_reward() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `2607`
-		//  Estimated: `5048`
-		// Minimum execution time: 47_097_000 picoseconds.
-		Weight::from_parts(48_451_000, 5048)
+		//  Measured:  `2672`
+		//  Estimated: `5113`
+		// Minimum execution time: 50_729_000 picoseconds.
+		Weight::from_parts(51_933_000, 5113)
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -332,8 +332,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `317`
 		//  Estimated: `4764`
-		// Minimum execution time: 35_289_000 picoseconds.
-		Weight::from_parts(35_821_000, 4764)
+		// Minimum execution time: 35_712_000 picoseconds.
+		Weight::from_parts(35_993_000, 4764)
 			.saturating_add(T::DbWeight::get().reads(6_u64))
 			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
@@ -350,10 +350,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `255 + x * (73 ±0)`
 		//  Estimated: `4764 + x * (2653 ±0)`
-		// Minimum execution time: 35_223_000 picoseconds.
-		Weight::from_parts(31_212_862, 4764)
-			// Standard Error: 14_956
-			.saturating_add(Weight::from_parts(5_068_316, 0).saturating_mul(x.into()))
+		// Minimum execution time: 35_330_000 picoseconds.
+		Weight::from_parts(31_912_755, 4764)
+			// Standard Error: 12_633
+			.saturating_add(Weight::from_parts(4_919_251, 0).saturating_mul(x.into()))
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(x.into())))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
@@ -366,8 +366,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `1486`
-		// Minimum execution time: 8_034_000 picoseconds.
-		Weight::from_parts(8_224_000, 1486)
+		// Minimum execution time: 8_737_000 picoseconds.
+		Weight::from_parts(8_898_000, 1486)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 	}
 	/// Storage: `DappStaking::CurrentEraInfo` (r:1 w:1)
@@ -384,8 +384,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `334`
 		//  Estimated: `4254`
-		// Minimum execution time: 23_669_000 picoseconds.
-		Weight::from_parts(24_216_000, 4254)
+		// Minimum execution time: 24_461_000 picoseconds.
+		Weight::from_parts(25_019_000, 4254)
 			.saturating_add(T::DbWeight::get().reads(5_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -404,13 +404,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Storage: `DappStaking::TierConfig` (r:1 w:1)
 	/// Proof: `DappStaking::TierConfig` (`max_values`: Some(1), `max_size`: Some(161), added: 656, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::DAppTiers` (r:0 w:1)
-	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1583), added: 4058, mode: `MaxEncodedLen`)
+	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1648), added: 4123, mode: `MaxEncodedLen`)
 	fn on_initialize_build_and_earn_to_voting() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `631`
 		//  Estimated: `4254`
-		// Minimum execution time: 33_437_000 picoseconds.
-		Weight::from_parts(34_673_000, 4254)
+		// Minimum execution time: 37_507_000 picoseconds.
+		Weight::from_parts(38_532_000, 4254)
 			.saturating_add(T::DbWeight::get().reads(7_u64))
 			.saturating_add(T::DbWeight::get().writes(7_u64))
 	}
@@ -425,13 +425,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Storage: `DappStaking::TierConfig` (r:1 w:1)
 	/// Proof: `DappStaking::TierConfig` (`max_values`: Some(1), `max_size`: Some(161), added: 656, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::DAppTiers` (r:0 w:1)
-	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1583), added: 4058, mode: `MaxEncodedLen`)
+	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1648), added: 4123, mode: `MaxEncodedLen`)
 	fn on_initialize_build_and_earn_to_build_and_earn() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `386`
 		//  Estimated: `4254`
-		// Minimum execution time: 25_981_000 picoseconds.
-		Weight::from_parts(26_548_000, 4254)
+		// Minimum execution time: 27_753_000 picoseconds.
+		Weight::from_parts(28_097_000, 4254)
 			.saturating_add(T::DbWeight::get().reads(5_u64))
 			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
@@ -442,12 +442,12 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// The range of component `x` is `[0, 100]`.
 	fn dapp_tier_assignment(x: u32, ) -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `151 + x * (32 ±0)`
+		//  Measured:  `152 + x * (32 ±0)`
 		//  Estimated: `3061 + x * (2071 ±0)`
-		// Minimum execution time: 8_343_000 picoseconds.
-		Weight::from_parts(10_436_285, 3061)
-			// Standard Error: 2_503
-			.saturating_add(Weight::from_parts(2_305_219, 0).saturating_mul(x.into()))
+		// Minimum execution time: 6_671_000 picoseconds.
+		Weight::from_parts(11_257_216, 3061)
+			// Standard Error: 2_748
+			.saturating_add(Weight::from_parts(2_393_417, 0).saturating_mul(x.into()))
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(x.into())))
 			.saturating_add(Weight::from_parts(0, 2071).saturating_mul(x.into()))
@@ -457,13 +457,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Storage: `DappStaking::EraRewards` (r:1 w:1)
 	/// Proof: `DappStaking::EraRewards` (`max_values`: None, `max_size`: Some(789), added: 3264, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::DAppTiers` (r:0 w:1)
-	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1583), added: 4058, mode: `MaxEncodedLen`)
+	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1648), added: 4123, mode: `MaxEncodedLen`)
 	fn on_idle_cleanup() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `293`
 		//  Estimated: `4254`
-		// Minimum execution time: 7_552_000 picoseconds.
-		Weight::from_parts(7_669_000, 4254)
+		// Minimum execution time: 7_523_000 picoseconds.
+		Weight::from_parts(7_623_000, 4254)
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -70,7 +70,7 @@ use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 use astar_primitives::{
     dapp_staking::{
         AccountCheck as DappStakingAccountCheck, CycleConfiguration, DAppId, EraNumber,
-        PeriodNumber, SmartContract, TierAndRank, TierSlots as TierSlotsFunc,
+        PeriodNumber, RankedTier, SmartContract, TierSlots as TierSlotsFunc,
     },
     evm::EvmRevertCodeHandler,
     oracle::{CurrencyAmount, CurrencyId, DummyCombineData},
@@ -1761,7 +1761,7 @@ impl_runtime_apis! {
             InflationCycleConfig::blocks_per_era()
         }
 
-        fn get_dapp_tier_assignment() -> BTreeMap<DAppId, TierAndRank> {
+        fn get_dapp_tier_assignment() -> BTreeMap<DAppId, RankedTier> {
             DappStaking::get_dapp_tier_assignment()
         }
     }

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -389,6 +389,7 @@ impl pallet_dapp_staking_v3::Config for Runtime {
     type MaxNumberOfStakedContracts = ConstU32<16>;
     type MinimumStakeAmount = MinimumStakingAmount;
     type NumberOfTiers = ConstU32<4>;
+    type RankingEnabled = ();
     type WeightInfo = weights::pallet_dapp_staking_v3::SubstrateWeight<Runtime>;
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = BenchmarkHelper<SmartContract<AccountId>, AccountId>;

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -1175,7 +1175,10 @@ pub type Executive = frame_executive::Executive<
 /// All migrations that will run on the next runtime upgrade.
 ///
 /// Once done, migrations should be removed from the tuple.
-pub type Migrations = (pallet_dapp_staking_v3::migration::versioned_migrations::V6ToV7<Runtime>,);
+pub type Migrations = (
+    // Migrate to ranking system
+    pallet_dapp_staking_v3::migration::versioned_migrations::V6ToV7<Runtime>,
+);
 
 type EventRecord = frame_system::EventRecord<
     <Runtime as frame_system::Config>::RuntimeEvent,

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -70,7 +70,7 @@ use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 use astar_primitives::{
     dapp_staking::{
         AccountCheck as DappStakingAccountCheck, CycleConfiguration, DAppId, EraNumber,
-        PeriodNumber, SmartContract, TierId, TierSlots as TierSlotsFunc,
+        PeriodNumber, SmartContract, TierAndRank, TierSlots as TierSlotsFunc,
     },
     evm::EvmRevertCodeHandler,
     oracle::{CurrencyAmount, CurrencyId, DummyCombineData},
@@ -1761,7 +1761,7 @@ impl_runtime_apis! {
             InflationCycleConfig::blocks_per_era()
         }
 
-        fn get_dapp_tier_assignment() -> BTreeMap<DAppId, TierId> {
+        fn get_dapp_tier_assignment() -> BTreeMap<DAppId, TierAndRank> {
             DappStaking::get_dapp_tier_assignment()
         }
     }

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -1175,7 +1175,7 @@ pub type Executive = frame_executive::Executive<
 /// All migrations that will run on the next runtime upgrade.
 ///
 /// Once done, migrations should be removed from the tuple.
-pub type Migrations = ();
+pub type Migrations = (pallet_dapp_staking_v3::migration::versioned_migrations::V6ToV7<Runtime>,);
 
 type EventRecord = frame_system::EventRecord<
     <Runtime as frame_system::Config>::RuntimeEvent,

--- a/runtime/shiden/src/weights/pallet_dapp_staking_v3.rs
+++ b/runtime/shiden/src/weights/pallet_dapp_staking_v3.rs
@@ -55,8 +55,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
-		// Minimum execution time: 6_623_000 picoseconds.
-		Weight::from_parts(6_817_000, 0)
+		// Minimum execution time: 6_476_000 picoseconds.
+		Weight::from_parts(6_714_000, 0)
 	}
 	/// Storage: `DappStaking::IntegratedDApps` (r:1 w:1)
 	/// Proof: `DappStaking::IntegratedDApps` (`max_values`: Some(65535), `max_size`: Some(116), added: 2096, mode: `MaxEncodedLen`)
@@ -68,8 +68,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `3086`
-		// Minimum execution time: 12_683_000 picoseconds.
-		Weight::from_parts(13_128_000, 3086)
+		// Minimum execution time: 12_385_000 picoseconds.
+		Weight::from_parts(12_660_000, 3086)
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -79,8 +79,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `97`
 		//  Estimated: `3086`
-		// Minimum execution time: 11_333_000 picoseconds.
-		Weight::from_parts(11_518_000, 3086)
+		// Minimum execution time: 11_393_000 picoseconds.
+		Weight::from_parts(11_638_000, 3086)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -90,8 +90,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `97`
 		//  Estimated: `3086`
-		// Minimum execution time: 12_016_000 picoseconds.
-		Weight::from_parts(12_174_000, 3086)
+		// Minimum execution time: 11_834_000 picoseconds.
+		Weight::from_parts(12_176_000, 3086)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -105,8 +105,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `97`
 		//  Estimated: `3086`
-		// Minimum execution time: 15_467_000 picoseconds.
-		Weight::from_parts(15_809_000, 3086)
+		// Minimum execution time: 15_262_000 picoseconds.
+		Weight::from_parts(15_764_000, 3086)
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -124,8 +124,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `138`
 		//  Estimated: `4764`
-		// Minimum execution time: 28_164_000 picoseconds.
-		Weight::from_parts(28_529_000, 4764)
+		// Minimum execution time: 28_006_000 picoseconds.
+		Weight::from_parts(28_433_000, 4764)
 			.saturating_add(T::DbWeight::get().reads(5_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -141,8 +141,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `158`
 		//  Estimated: `4764`
-		// Minimum execution time: 32_219_000 picoseconds.
-		Weight::from_parts(32_685_000, 4764)
+		// Minimum execution time: 31_943_000 picoseconds.
+		Weight::from_parts(32_807_000, 4764)
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -158,8 +158,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `158`
 		//  Estimated: `4764`
-		// Minimum execution time: 29_290_000 picoseconds.
-		Weight::from_parts(29_714_000, 4764)
+		// Minimum execution time: 29_129_000 picoseconds.
+		Weight::from_parts(29_684_000, 4764)
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -176,10 +176,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `191`
 		//  Estimated: `4764`
-		// Minimum execution time: 31_731_000 picoseconds.
-		Weight::from_parts(32_963_184, 4764)
-			// Standard Error: 2_757
-			.saturating_add(Weight::from_parts(133_347, 0).saturating_mul(x.into()))
+		// Minimum execution time: 29_012_000 picoseconds.
+		Weight::from_parts(30_362_943, 4764)
+			// Standard Error: 3_354
+			.saturating_add(Weight::from_parts(102_645, 0).saturating_mul(x.into()))
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -195,8 +195,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `200`
 		//  Estimated: `4764`
-		// Minimum execution time: 28_893_000 picoseconds.
-		Weight::from_parts(29_595_000, 4764)
+		// Minimum execution time: 26_355_000 picoseconds.
+		Weight::from_parts(26_725_000, 4764)
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -218,8 +218,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `274`
 		//  Estimated: `4764`
-		// Minimum execution time: 40_108_000 picoseconds.
-		Weight::from_parts(40_741_000, 4764)
+		// Minimum execution time: 41_441_000 picoseconds.
+		Weight::from_parts(42_071_000, 4764)
 			.saturating_add(T::DbWeight::get().reads(7_u64))
 			.saturating_add(T::DbWeight::get().writes(5_u64))
 	}
@@ -241,8 +241,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `459`
 		//  Estimated: `4764`
-		// Minimum execution time: 44_355_000 picoseconds.
-		Weight::from_parts(45_247_000, 4764)
+		// Minimum execution time: 45_924_000 picoseconds.
+		Weight::from_parts(46_305_000, 4764)
 			.saturating_add(T::DbWeight::get().reads(7_u64))
 			.saturating_add(T::DbWeight::get().writes(5_u64))
 	}
@@ -261,10 +261,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `541`
 		//  Estimated: `4764`
-		// Minimum execution time: 44_827_000 picoseconds.
-		Weight::from_parts(43_946_653, 4764)
-			// Standard Error: 4_252
-			.saturating_add(Weight::from_parts(1_929_031, 0).saturating_mul(x.into()))
+		// Minimum execution time: 44_845_000 picoseconds.
+		Weight::from_parts(43_924_635, 4764)
+			// Standard Error: 4_382
+			.saturating_add(Weight::from_parts(1_983_419, 0).saturating_mul(x.into()))
 			.saturating_add(T::DbWeight::get().reads(5_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
@@ -281,10 +281,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `519`
 		//  Estimated: `4764`
-		// Minimum execution time: 42_489_000 picoseconds.
-		Weight::from_parts(41_694_539, 4764)
-			// Standard Error: 4_876
-			.saturating_add(Weight::from_parts(1_920_135, 0).saturating_mul(x.into()))
+		// Minimum execution time: 42_111_000 picoseconds.
+		Weight::from_parts(41_366_463, 4764)
+			// Standard Error: 4_231
+			.saturating_add(Weight::from_parts(2_000_021, 0).saturating_mul(x.into()))
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
@@ -298,21 +298,21 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `275`
 		//  Estimated: `3775`
-		// Minimum execution time: 35_956_000 picoseconds.
-		Weight::from_parts(36_515_000, 3775)
+		// Minimum execution time: 33_539_000 picoseconds.
+		Weight::from_parts(33_934_000, 3775)
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 	}
 	/// Storage: `DappStaking::IntegratedDApps` (r:1 w:0)
 	/// Proof: `DappStaking::IntegratedDApps` (`max_values`: Some(65535), `max_size`: Some(116), added: 2096, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::DAppTiers` (r:1 w:1)
-	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1583), added: 4058, mode: `MaxEncodedLen`)
+	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1648), added: 4123, mode: `MaxEncodedLen`)
 	fn claim_dapp_reward() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `2607`
-		//  Estimated: `5048`
-		// Minimum execution time: 49_702_000 picoseconds.
-		Weight::from_parts(51_260_000, 5048)
+		//  Measured:  `2672`
+		//  Estimated: `5113`
+		// Minimum execution time: 51_985_000 picoseconds.
+		Weight::from_parts(53_149_000, 5113)
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
@@ -332,8 +332,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `322`
 		//  Estimated: `4764`
-		// Minimum execution time: 35_957_000 picoseconds.
-		Weight::from_parts(36_705_000, 4764)
+		// Minimum execution time: 36_691_000 picoseconds.
+		Weight::from_parts(37_929_000, 4764)
 			.saturating_add(T::DbWeight::get().reads(6_u64))
 			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
@@ -350,10 +350,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `256 + x * (73 ±0)`
 		//  Estimated: `4764 + x * (2653 ±0)`
-		// Minimum execution time: 38_640_000 picoseconds.
-		Weight::from_parts(35_679_946, 4764)
-			// Standard Error: 7_706
-			.saturating_add(Weight::from_parts(4_965_134, 0).saturating_mul(x.into()))
+		// Minimum execution time: 36_617_000 picoseconds.
+		Weight::from_parts(33_285_190, 4764)
+			// Standard Error: 7_701
+			.saturating_add(Weight::from_parts(5_001_871, 0).saturating_mul(x.into()))
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(x.into())))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
@@ -366,8 +366,8 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `1486`
-		// Minimum execution time: 8_858_000 picoseconds.
-		Weight::from_parts(8_983_000, 1486)
+		// Minimum execution time: 8_736_000 picoseconds.
+		Weight::from_parts(9_057_000, 1486)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 	}
 	/// Storage: `DappStaking::CurrentEraInfo` (r:1 w:1)
@@ -376,15 +376,17 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `DappStaking::EraRewards` (`max_values`: None, `max_size`: Some(789), added: 3264, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::StaticTierParams` (r:1 w:0)
 	/// Proof: `DappStaking::StaticTierParams` (`max_values`: Some(1), `max_size`: Some(167), added: 662, mode: `MaxEncodedLen`)
+	/// Storage: `PriceAggregator::ValuesCircularBuffer` (r:1 w:0)
+	/// Proof: `PriceAggregator::ValuesCircularBuffer` (`max_values`: Some(1), `max_size`: Some(117), added: 612, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::TierConfig` (r:1 w:1)
 	/// Proof: `DappStaking::TierConfig` (`max_values`: Some(1), `max_size`: Some(161), added: 656, mode: `MaxEncodedLen`)
 	fn on_initialize_voting_to_build_and_earn() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `330`
+		//  Measured:  `334`
 		//  Estimated: `4254`
-		// Minimum execution time: 22_873_000 picoseconds.
-		Weight::from_parts(23_448_000, 4254)
-			.saturating_add(T::DbWeight::get().reads(4_u64))
+		// Minimum execution time: 24_552_000 picoseconds.
+		Weight::from_parts(25_267_000, 4254)
+			.saturating_add(T::DbWeight::get().reads(5_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
 	/// Storage: `DappStaking::CurrentEraInfo` (r:1 w:1)
@@ -397,17 +399,19 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `DappStaking::EraRewards` (`max_values`: None, `max_size`: Some(789), added: 3264, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::StaticTierParams` (r:1 w:0)
 	/// Proof: `DappStaking::StaticTierParams` (`max_values`: Some(1), `max_size`: Some(167), added: 662, mode: `MaxEncodedLen`)
+	/// Storage: `PriceAggregator::ValuesCircularBuffer` (r:1 w:0)
+	/// Proof: `PriceAggregator::ValuesCircularBuffer` (`max_values`: Some(1), `max_size`: Some(117), added: 612, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::TierConfig` (r:1 w:1)
 	/// Proof: `DappStaking::TierConfig` (`max_values`: Some(1), `max_size`: Some(161), added: 656, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::DAppTiers` (r:0 w:1)
-	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1583), added: 4058, mode: `MaxEncodedLen`)
+	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1648), added: 4123, mode: `MaxEncodedLen`)
 	fn on_initialize_build_and_earn_to_voting() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `838`
+		//  Measured:  `843`
 		//  Estimated: `4254`
-		// Minimum execution time: 37_126_000 picoseconds.
-		Weight::from_parts(38_123_000, 4254)
-			.saturating_add(T::DbWeight::get().reads(6_u64))
+		// Minimum execution time: 39_484_000 picoseconds.
+		Weight::from_parts(40_502_000, 4254)
+			.saturating_add(T::DbWeight::get().reads(7_u64))
 			.saturating_add(T::DbWeight::get().writes(7_u64))
 	}
 	/// Storage: `DappStaking::CurrentEraInfo` (r:1 w:1)
@@ -416,17 +420,19 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `DappStaking::EraRewards` (`max_values`: None, `max_size`: Some(789), added: 3264, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::StaticTierParams` (r:1 w:0)
 	/// Proof: `DappStaking::StaticTierParams` (`max_values`: Some(1), `max_size`: Some(167), added: 662, mode: `MaxEncodedLen`)
+	/// Storage: `PriceAggregator::ValuesCircularBuffer` (r:1 w:0)
+	/// Proof: `PriceAggregator::ValuesCircularBuffer` (`max_values`: Some(1), `max_size`: Some(117), added: 612, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::TierConfig` (r:1 w:1)
 	/// Proof: `DappStaking::TierConfig` (`max_values`: Some(1), `max_size`: Some(161), added: 656, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::DAppTiers` (r:0 w:1)
-	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1583), added: 4058, mode: `MaxEncodedLen`)
+	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1648), added: 4123, mode: `MaxEncodedLen`)
 	fn on_initialize_build_and_earn_to_build_and_earn() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `381`
+		//  Measured:  `386`
 		//  Estimated: `4254`
-		// Minimum execution time: 25_108_000 picoseconds.
-		Weight::from_parts(25_775_000, 4254)
-			.saturating_add(T::DbWeight::get().reads(4_u64))
+		// Minimum execution time: 27_598_000 picoseconds.
+		Weight::from_parts(28_216_000, 4254)
+			.saturating_add(T::DbWeight::get().reads(5_u64))
 			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
 	/// Storage: `DappStaking::ContractStake` (r:101 w:0)
@@ -438,10 +444,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Proof Size summary in bytes:
 		//  Measured:  `152 + x * (32 ±0)`
 		//  Estimated: `3061 + x * (2071 ±0)`
-		// Minimum execution time: 6_463_000 picoseconds.
-		Weight::from_parts(11_094_548, 3061)
-			// Standard Error: 3_157
-			.saturating_add(Weight::from_parts(2_330_865, 0).saturating_mul(x.into()))
+		// Minimum execution time: 6_648_000 picoseconds.
+		Weight::from_parts(11_329_597, 3061)
+			// Standard Error: 3_005
+			.saturating_add(Weight::from_parts(2_383_797, 0).saturating_mul(x.into()))
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(x.into())))
 			.saturating_add(Weight::from_parts(0, 2071).saturating_mul(x.into()))
@@ -451,13 +457,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Storage: `DappStaking::EraRewards` (r:1 w:1)
 	/// Proof: `DappStaking::EraRewards` (`max_values`: None, `max_size`: Some(789), added: 3264, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::DAppTiers` (r:0 w:1)
-	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1583), added: 4058, mode: `MaxEncodedLen`)
+	/// Proof: `DappStaking::DAppTiers` (`max_values`: None, `max_size`: Some(1648), added: 4123, mode: `MaxEncodedLen`)
 	fn on_idle_cleanup() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `293`
 		//  Estimated: `4254`
-		// Minimum execution time: 7_533_000 picoseconds.
-		Weight::from_parts(7_744_000, 4254)
+		// Minimum execution time: 7_521_000 picoseconds.
+		Weight::from_parts(7_677_000, 4254)
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}

--- a/tests/xcm-simulator/src/mocks/parachain.rs
+++ b/tests/xcm-simulator/src/mocks/parachain.rs
@@ -730,6 +730,7 @@ impl pallet_dapp_staking_v3::Config for Runtime {
     type MaxNumberOfStakedContracts = ConstU32<5>;
     type MinimumStakeAmount = ConstU128<3>;
     type NumberOfTiers = ConstU32<4>;
+    type RankingEnabled = ConstBool<true>;
     type WeightInfo = ();
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = BenchmarkHelper<MockSmartContract, AccountId>;


### PR DESCRIPTION
In order to preserve `u8` for DAppTierRewards we can use each byte of u8 for `tier` and `rank`. This way there's no need for migration and it's backward compatible.

Since u8 has 2 bytes `0xff` `0b1111_1111` we can use the 1st byte for `tier` and 2nd byte for `rank`. Rank goes from `0..10` (higher is better). Meaning if you just enter a tier your rank is `0` and more staking will increase your ranking as you become close to next tier.

```rust
// RankedTier { tier: 1, rank: 10 } is represented as 0xa1
let tier: u8 = 0xa1 & 0x0f; // tier  1
let rank: u8 = 0xa1 >> 4;   // rank 10
```

Currently all values will be from `0..3` so `rank` will be zero. Rank will take place once we deploy it.

The simplest solution for reward distribution between ranks will be to define an additional reward per rank. Let’s say Tier 2 reward portion is 50K ASTR and slot capacity is 5 then reward per slot will be 10K ASTR, therefor rank reward will be `rank_reward = max(slot_reward, tier_remaining_reward) / 10 = 1K` . If you classify for rank 0 then you get 10K (slot reward), if you classify rank 3 you get `10K + 3 * rank_reward = 13K`. All the reward to support ranked tier comes from tier reward portion itself. If tier has 5 slots with 3 occupied then reward of 2 slots will be used for ranking. e.i. slots occupied`[rank_0, rank_3, rank_10]` then calculated reward will be `[10k, 13K, 20K]` . In cases when there’s not enough remaining reward to satisfy full reward per rank then it will be adjust based on remaining reward, so rank reward will be less than 1K.  If all slots are occupied then all dapps will make equal 10K each (slot reward).

- [x] benchmarking
- [ ] docs