### PR TITLE
fix shiden genesis sync

### DIFF
--- a/bin/collator/src/local/service.rs
+++ b/bin/collator/src/local/service.rs
@@ -368,15 +368,10 @@ pub fn start_node(
                 enable_evm_rpc: true, // enable EVM RPC for dev node by default
             };
 
-            let pending_consensus_data_provider = Box::new(
-                fc_rpc::pending::AuraConsensusDataProvider::new(client.clone()),
-            );
-
             crate::rpc::create_full(
                 deps,
                 subscription,
                 pubsub_notification_sinks.clone(),
-                pending_consensus_data_provider,
                 rpc_config.clone(),
             )
             .map_err::<ServiceError, _>(Into::into)
@@ -656,17 +651,8 @@ pub fn start_node(config: Configuration) -> Result<TaskManager, ServiceError> {
                 enable_evm_rpc: true, // enable EVM RPC for dev node by default
             };
 
-            let pending_consensus_data_provider = Box::new(
-                fc_rpc::pending::AuraConsensusDataProvider::new(client.clone()),
-            );
-
-            crate::rpc::create_full(
-                deps,
-                subscription,
-                pubsub_notification_sinks.clone(),
-                pending_consensus_data_provider,
-            )
-            .map_err::<ServiceError, _>(Into::into)
+            crate::rpc::create_full(deps, subscription, pubsub_notification_sinks.clone())
+                .map_err::<ServiceError, _>(Into::into)
         })
     };
 

--- a/bin/collator/src/parachain/mod.rs
+++ b/bin/collator/src/parachain/mod.rs
@@ -31,3 +31,5 @@ pub use service::{
     astar, build_import_queue, new_partial, shibuya, shiden, start_astar_node, start_shibuya_node,
     start_shiden_node, HostFunctions,
 };
+
+pub(crate) use shell_upgrade::{AuraConsensusDataProviderFallback, PendingCrateInherentDataProvider};

--- a/bin/collator/src/parachain/mod.rs
+++ b/bin/collator/src/parachain/mod.rs
@@ -32,4 +32,6 @@ pub use service::{
     start_shiden_node, HostFunctions,
 };
 
-pub(crate) use shell_upgrade::{AuraConsensusDataProviderFallback, PendingCrateInherentDataProvider};
+pub(crate) use shell_upgrade::{
+    AuraConsensusDataProviderFallback, PendingCrateInherentDataProvider,
+};

--- a/bin/collator/src/parachain/service.rs
+++ b/bin/collator/src/parachain/service.rs
@@ -494,17 +494,8 @@ where
                 enable_evm_rpc: additional_config.enable_evm_rpc,
             };
 
-            let pending_consensus_data_provider = Box::new(
-                fc_rpc::pending::AuraConsensusDataProvider::new(client.clone()),
-            );
-
-            crate::rpc::create_full(
-                deps,
-                subscription,
-                pubsub_notification_sinks.clone(),
-                pending_consensus_data_provider,
-            )
-            .map_err(Into::into)
+            crate::rpc::create_full(deps, subscription, pubsub_notification_sinks.clone())
+                .map_err(Into::into)
         })
     };
 
@@ -845,15 +836,10 @@ where
                 enable_evm_rpc: additional_config.enable_evm_rpc,
             };
 
-            let pending_consensus_data_provider = Box::new(
-                fc_rpc::pending::AuraConsensusDataProvider::new(client.clone()),
-            );
-
             crate::rpc::create_full(
                 deps,
                 subscription,
                 pubsub_notification_sinks.clone(),
-                pending_consensus_data_provider,
                 rpc_config.clone(),
             )
             .map_err(Into::into)

--- a/bin/collator/src/parachain/shell_upgrade.rs
+++ b/bin/collator/src/parachain/shell_upgrade.rs
@@ -21,12 +21,21 @@
 use astar_primitives::*;
 use cumulus_client_consensus_common::{ParachainCandidate, ParachainConsensus};
 use cumulus_primitives_core::relay_chain::{Hash as PHash, PersistedValidationData};
+use cumulus_primitives_core::BlockT;
+use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
+use fc_rpc::pending::ConsensusDataProvider;
 use futures::lock::Mutex;
+use sc_client_api::{AuxStore, UsageProvider};
 use sc_consensus::{import_queue::Verifier as VerifierT, BlockImportParams, ForkChoiceStrategy};
-use sp_api::ApiExt;
+use sp_api::{ApiExt, ProvideRuntimeApi};
+use sp_consensus_aura::digests::CompatibleDigestItem;
+use sp_consensus_aura::sr25519::AuthoritySignature;
 use sp_consensus_aura::{sr25519::AuthorityId as AuraId, AuraApi};
+use sp_inherents::{CreateInherentDataProviders, Error, InherentData};
 use sp_runtime::traits::Header as HeaderT;
-use std::sync::Arc;
+use sp_runtime::{Digest, DigestItem};
+use sp_timestamp::TimestampInherentData;
+use std::{marker::PhantomData, sync::Arc};
 
 pub enum BuildOnAccess<R> {
     Uninitialized(Option<Box<dyn FnOnce() -> R + Send + Sync>>),
@@ -136,5 +145,142 @@ where
         } else {
             self.relay_chain_verifier.verify(block_import).await
         }
+    }
+}
+
+/// AuraConsensusDataProvider custom implementation which awaits for AuraApi to become available,
+/// until then it will return error. Shiden genesis did not start with AuraApi, therefore this
+/// implementation makes sure to return digest after AuraApi becomes available.
+/// This is currently required by EVM RPC.
+pub struct AuraConsensusDataProviderFallback<B, C> {
+    client: Arc<C>,
+    phantom_data: PhantomData<B>,
+}
+
+impl<B, C> AuraConsensusDataProviderFallback<B, C>
+where
+    B: BlockT,
+    C: AuxStore + ProvideRuntimeApi<B> + UsageProvider<B> + Send + Sync,
+    C::Api: AuraApi<B, AuraId>,
+{
+    pub fn new(client: Arc<C>) -> Self {
+        Self {
+            client,
+            phantom_data: Default::default(),
+        }
+    }
+}
+
+impl<B, C> ConsensusDataProvider<B> for AuraConsensusDataProviderFallback<B, C>
+where
+    B: BlockT,
+    C: AuxStore + ProvideRuntimeApi<B> + UsageProvider<B> + Send + Sync,
+    C::Api: AuraApi<B, AuraId>,
+{
+    fn create_digest(&self, parent: &B::Header, data: &InherentData) -> Result<Digest, Error> {
+        if self
+            .client
+            .runtime_api()
+            .has_api::<dyn AuraApi<Block, AuraId>>(parent.hash())
+            .unwrap_or_default()
+        {
+            let slot_duration = sc_consensus_aura::slot_duration(&*self.client)
+                .expect("slot_duration should be present at this point; qed.");
+            let timestamp = data
+                .timestamp_inherent_data()?
+                .expect("Timestamp is always present; qed");
+
+            let digest_item =
+                <DigestItem as CompatibleDigestItem<AuthoritySignature>>::aura_pre_digest(
+                    sp_consensus_aura::Slot::from_timestamp(timestamp, slot_duration),
+                );
+
+            return Ok(Digest {
+                logs: vec![digest_item],
+            });
+        }
+        Err(Error::Application("AuraApi is not present".into()))
+    }
+}
+
+/// Shiden genesis did not start with AuraApi, therefore this implementation makes sure to return
+/// inherent data after AuraApi becomes available.
+/// This is currently required by EVM RPC.
+pub struct PendingCrateInherentDataProvider<B, C> {
+    client: Arc<C>,
+    phantom_data: PhantomData<B>,
+}
+
+impl<B, C> PendingCrateInherentDataProvider<B, C>
+where
+    B: BlockT,
+    C: AuxStore + ProvideRuntimeApi<B> + UsageProvider<B> + Send + Sync,
+    C::Api: AuraApi<B, AuraId>,
+{
+    pub fn new(client: Arc<C>) -> Self {
+        Self {
+            client,
+            phantom_data: Default::default(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<B, C> CreateInherentDataProviders<B, ()> for PendingCrateInherentDataProvider<B, C>
+where
+    B: BlockT,
+    C: AuxStore + ProvideRuntimeApi<B> + UsageProvider<B> + Send + Sync,
+    C::Api: AuraApi<B, AuraId>,
+{
+    type InherentDataProviders = (
+        sp_consensus_aura::inherents::InherentDataProvider,
+        sp_timestamp::InherentDataProvider,
+        cumulus_primitives_parachain_inherent::ParachainInherentData,
+    );
+
+    async fn create_inherent_data_providers(
+        &self,
+        parent: B::Hash,
+        _extra_args: (),
+    ) -> Result<Self::InherentDataProviders, Box<dyn std::error::Error + Send + Sync>> {
+        if !self
+            .client
+            .runtime_api()
+            .has_api::<dyn AuraApi<Block, AuraId>>(parent)
+            .unwrap_or_default()
+        {
+            return Err("AuraApi is not present".into());
+        }
+
+        let slot_duration = sc_consensus_aura::slot_duration(&*self.client)
+            .expect("slot_duration should be present at this point; qed.");
+        let current = sp_timestamp::InherentDataProvider::from_system_time();
+        let next_slot = current.timestamp().as_millis() + slot_duration.as_millis();
+        let timestamp = sp_timestamp::InherentDataProvider::new(next_slot.into());
+        let slot =
+            sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
+                *timestamp,
+                slot_duration,
+            );
+        // Create a dummy parachain inherent data provider which is required to pass
+        // the checks by the para chain system. We use dummy values because in the 'pending context'
+        // neither do we have access to the real values nor do we need them.
+        let (relay_parent_storage_root, relay_chain_state) =
+            RelayStateSproofBuilder::default().into_state_root_and_proof();
+        let vfp = PersistedValidationData {
+            // This is a hack to make `cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases`
+            // happy. Relay parent number can't be bigger than u32::MAX.
+            relay_parent_number: u32::MAX,
+            relay_parent_storage_root,
+            ..Default::default()
+        };
+        let parachain_inherent_data =
+            cumulus_primitives_parachain_inherent::ParachainInherentData {
+                validation_data: vfp,
+                relay_chain_state,
+                downward_messages: Default::default(),
+                horizontal_messages: Default::default(),
+            };
+        Ok((slot, timestamp, parachain_inherent_data))
     }
 }

--- a/bin/collator/src/parachain/shell_upgrade.rs
+++ b/bin/collator/src/parachain/shell_upgrade.rs
@@ -21,19 +21,22 @@
 use astar_primitives::*;
 use cumulus_client_consensus_common::{ParachainCandidate, ParachainConsensus};
 use cumulus_primitives_core::relay_chain::{Hash as PHash, PersistedValidationData};
-use cumulus_primitives_core::BlockT;
 use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 use fc_rpc::pending::ConsensusDataProvider;
 use futures::lock::Mutex;
 use sc_client_api::{AuxStore, UsageProvider};
 use sc_consensus::{import_queue::Verifier as VerifierT, BlockImportParams, ForkChoiceStrategy};
 use sp_api::{ApiExt, ProvideRuntimeApi};
-use sp_consensus_aura::digests::CompatibleDigestItem;
-use sp_consensus_aura::sr25519::AuthoritySignature;
-use sp_consensus_aura::{sr25519::AuthorityId as AuraId, AuraApi};
+use sp_consensus_aura::{
+    digests::CompatibleDigestItem,
+    sr25519::{AuthorityId as AuraId, AuthoritySignature},
+    AuraApi,
+};
 use sp_inherents::{CreateInherentDataProviders, Error, InherentData};
-use sp_runtime::traits::Header as HeaderT;
-use sp_runtime::{Digest, DigestItem};
+use sp_runtime::{
+    traits::{Block as BlockT, Header as HeaderT},
+    Digest, DigestItem,
+};
 use sp_timestamp::TimestampInherentData;
 use std::{marker::PhantomData, sync::Arc};
 

--- a/bin/collator/src/rpc.rs
+++ b/bin/collator/src/rpc.rs
@@ -18,11 +18,11 @@
 
 //! Astar RPCs implementation.
 
-use cumulus_primitives_parachain_inherent::ParachainInherentData;
 use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 use fc_rpc::{
-    Eth, EthApiServer, EthBlockDataCacheTask, EthFilter, EthFilterApiServer, EthPubSub,
-    EthPubSubApiServer, Net, NetApiServer, OverrideHandle, Web3, Web3ApiServer,
+    pending::ConsensusDataProvider, Eth, EthApiServer, EthBlockDataCacheTask, EthFilter,
+    EthFilterApiServer, EthPubSub, EthPubSubApiServer, Net, NetApiServer, OverrideHandle, Web3,
+    Web3ApiServer,
 };
 use fc_rpc_core::types::{FeeHistoryCache, FilterPool};
 use jsonrpsee::RpcModule;
@@ -42,9 +42,18 @@ use sp_block_builder::BlockBuilder;
 use sp_blockchain::{
     Backend as BlockchainBackend, Error as BlockChainError, HeaderBackend, HeaderMetadata,
 };
-use sp_consensus_aura::{sr25519::AuthorityId as AuraId, AuraApi};
-use sp_runtime::traits::BlakeTwo256;
-use std::sync::Arc;
+use sp_consensus_aura::{
+    digests::CompatibleDigestItem,
+    sr25519::{AuthorityId as AuraId, AuthoritySignature},
+    AuraApi,
+};
+use sp_inherents::{CreateInherentDataProviders, Error, InherentData};
+use sp_runtime::{
+    traits::{BlakeTwo256, Block as BlockT, Header},
+    Digest, DigestItem,
+};
+use sp_timestamp::TimestampInherentData;
+use std::{marker::PhantomData, sync::Arc};
 use substrate_frame_rpc_system::{System, SystemApiServer};
 
 #[cfg(feature = "evm-tracing")]
@@ -305,45 +314,6 @@ where
 
     let no_tx_converter: Option<fp_rpc::NoTransactionConverter> = None;
 
-    if !client
-        .runtime_api()
-        .has_api::<dyn AuraApi<Block, AuraId>>(client.info().best_hash)
-        .unwrap_or_default()
-    {
-        return Err("EVM RPC cannot be enable at the current state. Please sync at least 200K blocks before enabling it.".into());
-    }
-
-    let slot_duration = sc_consensus_aura::slot_duration(&*client)?;
-    let pending_create_inherent_data_providers = move |_, _| async move {
-        let current = sp_timestamp::InherentDataProvider::from_system_time();
-        let next_slot = current.timestamp().as_millis() + slot_duration.as_millis();
-        let timestamp = sp_timestamp::InherentDataProvider::new(next_slot.into());
-        let slot =
-            sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
-                *timestamp,
-                slot_duration,
-            );
-        // Create a dummy parachain inherent data provider which is required to pass
-        // the checks by the para chain system. We use dummy values because in the 'pending context'
-        // neither do we have access to the real values nor do we need them.
-        let (relay_parent_storage_root, relay_chain_state) =
-            RelayStateSproofBuilder::default().into_state_root_and_proof();
-        let vfp = PersistedValidationData {
-            // This is a hack to make `cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases`
-            // happy. Relay parent number can't be bigger than u32::MAX.
-            relay_parent_number: u32::MAX,
-            relay_parent_storage_root,
-            ..Default::default()
-        };
-        let parachain_inherent_data = ParachainInherentData {
-            validation_data: vfp,
-            relay_chain_state,
-            downward_messages: Default::default(),
-            horizontal_messages: Default::default(),
-        };
-        Ok((slot, timestamp, parachain_inherent_data))
-    };
-
     io.merge(
         Eth::<_, _, _, _, _, _, _, ()>::new(
             client.clone(),
@@ -361,8 +331,8 @@ where
             // Allow 10x max allowed weight for non-transactional calls
             10,
             None,
-            pending_create_inherent_data_providers,
-            Some(Box::new(fc_rpc::pending::AuraConsensusDataProvider::new(
+            PendingCrateInherentDataProvider::new(client.clone()),
+            Some(Box::new(AuraConsensusDataProviderFallback::new(
                 client.clone(),
             ))),
         )
@@ -402,4 +372,134 @@ where
     )?;
 
     Ok(io)
+}
+
+struct AuraConsensusDataProviderFallback<B, C> {
+    client: Arc<C>,
+    phantom_data: PhantomData<B>,
+}
+
+impl<B, C> AuraConsensusDataProviderFallback<B, C>
+where
+    B: BlockT,
+    C: AuxStore + ProvideRuntimeApi<B> + UsageProvider<B> + Send + Sync,
+    C::Api: AuraApi<B, AuraId>,
+{
+    fn new(client: Arc<C>) -> Self {
+        Self {
+            client,
+            phantom_data: Default::default(),
+        }
+    }
+}
+
+impl<B, C> ConsensusDataProvider<B> for AuraConsensusDataProviderFallback<B, C>
+where
+    B: BlockT,
+    C: AuxStore + ProvideRuntimeApi<B> + UsageProvider<B> + Send + Sync,
+    C::Api: AuraApi<B, AuraId>,
+{
+    fn create_digest(&self, parent: &B::Header, data: &InherentData) -> Result<Digest, Error> {
+        if self
+            .client
+            .runtime_api()
+            .has_api::<dyn AuraApi<Block, AuraId>>(parent.hash())
+            .unwrap_or_default()
+        {
+            let slot_duration = sc_consensus_aura::slot_duration(&*self.client)
+                .expect("slot_duration should be present at this point; qed.");
+            let timestamp = data
+                .timestamp_inherent_data()?
+                .expect("Timestamp is always present; qed");
+
+            let digest_item =
+                <DigestItem as CompatibleDigestItem<AuthoritySignature>>::aura_pre_digest(
+                    sp_consensus_aura::Slot::from_timestamp(timestamp, slot_duration),
+                );
+
+            return Ok(Digest {
+                logs: vec![digest_item],
+            });
+        }
+        Err(Error::Application("AuraApi is not present".into()))
+    }
+}
+
+struct PendingCrateInherentDataProvider<B, C> {
+    client: Arc<C>,
+    phantom_data: PhantomData<B>,
+}
+
+impl<B, C> PendingCrateInherentDataProvider<B, C>
+where
+    B: BlockT,
+    C: AuxStore + ProvideRuntimeApi<B> + UsageProvider<B> + Send + Sync,
+    C::Api: AuraApi<B, AuraId>,
+{
+    fn new(client: Arc<C>) -> Self {
+        Self {
+            client,
+            phantom_data: Default::default(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<B, C> CreateInherentDataProviders<B, ()> for PendingCrateInherentDataProvider<B, C>
+where
+    B: BlockT,
+    C: AuxStore + ProvideRuntimeApi<B> + UsageProvider<B> + Send + Sync,
+    C::Api: AuraApi<B, AuraId>,
+{
+    type InherentDataProviders = (
+        sp_consensus_aura::inherents::InherentDataProvider,
+        sp_timestamp::InherentDataProvider,
+        cumulus_primitives_parachain_inherent::ParachainInherentData,
+    );
+
+    async fn create_inherent_data_providers(
+        &self,
+        parent: B::Hash,
+        _extra_args: (),
+    ) -> Result<Self::InherentDataProviders, Box<dyn std::error::Error + Send + Sync>> {
+        if !self
+            .client
+            .runtime_api()
+            .has_api::<dyn AuraApi<Block, AuraId>>(parent)
+            .unwrap_or_default()
+        {
+            return Err("AuraApi is not present".into());
+        }
+
+        let slot_duration = sc_consensus_aura::slot_duration(&*self.client)
+            .expect("slot_duration should be present at this point; qed.");
+        let current = sp_timestamp::InherentDataProvider::from_system_time();
+        let next_slot = current.timestamp().as_millis() + slot_duration.as_millis();
+        let timestamp = sp_timestamp::InherentDataProvider::new(next_slot.into());
+        let slot =
+            sp_consensus_aura::inherents::InherentDataProvider::from_timestamp_and_slot_duration(
+                *timestamp,
+                slot_duration,
+            );
+        // Create a dummy parachain inherent data provider which is required to pass
+        // the checks by the para chain system. We use dummy values because in the 'pending context'
+        // neither do we have access to the real values nor do we need them.
+        let (relay_parent_storage_root, relay_chain_state) =
+            RelayStateSproofBuilder::default().into_state_root_and_proof();
+        let vfp = PersistedValidationData {
+            // This is a hack to make `cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases`
+            // happy. Relay parent number can't be bigger than u32::MAX.
+            relay_parent_number: u32::MAX,
+            relay_parent_storage_root,
+            ..Default::default()
+        };
+        let parachain_inherent_data =
+            cumulus_primitives_parachain_inherent::ParachainInherentData {
+                validation_data: vfp,
+                relay_chain_state,
+                downward_messages: Default::default(),
+                horizontal_messages: Default::default(),
+            };
+        Ok((slot, timestamp, parachain_inherent_data))
+    }
 }


### PR DESCRIPTION
Custom PendingCrateInherentDataProvider and AuraConsensusDataProvider implementation required by EVM RPC to support Shiden sync from genesis block when there was no AuraApi. The implementation returns error instead of panic