### PR TITLE
update tests to use cargo-nextest if present

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,14 @@ jobs:
     - name: Check targets are installed correctly
       run: rustup target list --installed
 
+    - name: Install cargo-nextest
+      run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+
     - name: Check all features compilation
       run: cargo check --verbose --features try-runtime,runtime-benchmarks --locked
 
     - name: Run all tests
-      run: cargo test --features try-runtime,runtime-benchmarks --locked
+      run: make test-all
 
   native-linux:
     needs: checks-and-tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
-  test-runtimes:
+  tests:
     runs-on: [self-hosted, Linux, X64]
     steps:
     - name: Checkout the source code
@@ -26,5 +26,8 @@ jobs:
     - name: Check targets are installed correctly
       run: rustup target list --installed
 
-    - name: Runtime integration tests
-      run: make test-runtimes
+    - name: Install cargo-nextest
+      run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+
+    - name: Run all tests
+      run: make test-all

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,27 @@ runtime-upgrade-test:
 	cargo build -p $(runtime)-runtime --release --locked
 	cd tests/e2e && yarn --frozen-lockfile && yarn test:runtime-upgrade-$(runtime)
 
+# use `cargo nextest run` if cargo-nextest is installed, fallback cargo test
+cargo_test = $(shell which cargo-nextest >/dev/null && echo "cargo nextest run" || echo "cargo test")
+
+.PHONY: test
+test:
+	SKIP_WASM_BUILD= ${cargo_test} --all
+
+.PHONY: try-runtime
+try-runtime:
+	SKIP_WASM_BUILD= ${cargo_test} --all --features try-runtime
+
+.PHONY: test-benchmarks
+test-benchmarks:
+	SKIP_WASM_BUILD= ${cargo_test} --all --features runtime-benchmarks
+
+
 .PHONY: test-runtimes
 test-runtimes:
-	SKIP_WASM_BUILD= cargo test -p integration-tests --features=shibuya
-	SKIP_WASM_BUILD= cargo test -p integration-tests --features=shiden
-	SKIP_WASM_BUILD= cargo test -p integration-tests --features=astar
+	SKIP_WASM_BUILD= ${cargo_test} -p integration-tests --features=shibuya
+	SKIP_WASM_BUILD= ${cargo_test} -p integration-tests --features=shiden
+	SKIP_WASM_BUILD= ${cargo_test} -p integration-tests --features=astar
+
+.PHONY: test-all
+test-all: test test-runtimes try-runtime test-benchmarks

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ cargo_test = $(shell which cargo-nextest >/dev/null && echo "cargo nextest run" 
 
 .PHONY: test
 test:
-	SKIP_WASM_BUILD= ${cargo_test} --workspace
+	${cargo_test} --workspace
 
 .PHONY: test-features
 test-features:

--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,7 @@ cargo_test = $(shell which cargo-nextest >/dev/null && echo "cargo nextest run" 
 
 .PHONY: test
 test:
-	SKIP_WASM_BUILD= ${cargo_test} --all
-
-.PHONY: try-runtime
-try-runtime:
-	SKIP_WASM_BUILD= ${cargo_test} --all --features try-runtime
-
-.PHONY: test-benchmarks
-test-benchmarks:
-	SKIP_WASM_BUILD= ${cargo_test} --all --features runtime-benchmarks
-
+	SKIP_WASM_BUILD= ${cargo_test} --workspace
 
 .PHONY: test-runtimes
 test-runtimes:
@@ -26,4 +17,5 @@ test-runtimes:
 	SKIP_WASM_BUILD= ${cargo_test} -p integration-tests --features=astar
 
 .PHONY: test-all
-test-all: test test-runtimes try-runtime test-benchmarks
+test-all: test test-runtimes
+	SKIP_WASM_BUILD= ${cargo_test} --workspace --features try-runtime,runtime-benchmarks

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ cargo_test = $(shell which cargo-nextest >/dev/null && echo "cargo nextest run" 
 test:
 	SKIP_WASM_BUILD= ${cargo_test} --workspace
 
+.PHONY: test-features
+test-features:
+	SKIP_WASM_BUILD= ${cargo_test} --workspace --features try-runtime,runtime-benchmarks,evm-tracing
+
 .PHONY: test-runtimes
 test-runtimes:
 	SKIP_WASM_BUILD= ${cargo_test} -p integration-tests --features=shibuya
@@ -17,5 +21,4 @@ test-runtimes:
 	SKIP_WASM_BUILD= ${cargo_test} -p integration-tests --features=astar
 
 .PHONY: test-all
-test-all: test test-runtimes
-	SKIP_WASM_BUILD= ${cargo_test} --workspace --features try-runtime,runtime-benchmarks
+test-all: test test-runtimes test-features

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test:
 
 .PHONY: test-features
 test-features:
-	SKIP_WASM_BUILD= ${cargo_test} --workspace --features try-runtime,runtime-benchmarks,evm-tracing
+	${cargo_test} --workspace --features try-runtime,runtime-benchmarks,evm-tracing
 
 .PHONY: test-runtimes
 test-runtimes:

--- a/bin/collator/src/local/chain_spec.rs
+++ b/bin/collator/src/local/chain_spec.rs
@@ -194,7 +194,6 @@ pub(crate) mod tests {
     use sp_runtime::BuildStorage;
 
     #[test]
-    #[ignore]
     fn test_create_development_chain_spec() {
         development_config().build_storage().unwrap();
     }

--- a/bin/collator/src/local/chain_spec.rs
+++ b/bin/collator/src/local/chain_spec.rs
@@ -194,6 +194,7 @@ pub(crate) mod tests {
     use sp_runtime::BuildStorage;
 
     #[test]
+    #[ignore]
     fn test_create_development_chain_spec() {
         development_config().build_storage().unwrap();
     }


### PR DESCRIPTION
Make `cargo-nextest` preferred option to run tests with fallback to `cargo test`.
`cargo-nextest` makes it easy to identify slow and leaky test and tests results are easy to read.