### PR TITLE
burn extrinsic integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8159,7 +8159,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.3.0#401f8a3e9448db854f5605b679fa085b8f445039"
+source = "git+https://github.com/AstarNetwork/polkadot-sdk?branch=astar-release-polkadot-v1.3.0#87649c1ff697e139d3b6872fa24bfbe20b3b558c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8159,7 +8159,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/AstarNetwork/polkadot-sdk?branch=astar-release-polkadot-v1.3.0#87649c1ff697e139d3b6872fa24bfbe20b3b558c"
+source = "git+https://github.com/AstarNetwork/polkadot-sdk?branch=astar-release-polkadot-v1.3.0#158bd98d6fb530e91fbf555751cc0feec371062a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ homepage = "https://astar.network"
 repository = "https://github.com/AstarNetwork/Astar"
 
 [patch."https://github.com/paritytech/polkadot-sdk"]
+# Remove this after uplifting to polkadot-sdk version `v1.12.0` or higher.
 pallet-balances = { git = "https://github.com/AstarNetwork/polkadot-sdk", branch = "astar-release-polkadot-v1.3.0" }
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ edition = "2021"
 homepage = "https://astar.network"
 repository = "https://github.com/AstarNetwork/Astar"
 
+[patch."https://github.com/paritytech/polkadot-sdk"]
+pallet-balances = { git = "https://github.com/AstarNetwork/polkadot-sdk", branch = "astar-release-polkadot-v1.3.0" }
+
 [workspace.dependencies]
 # General deps
 # (wasm)

--- a/runtime/local/src/weights/pallet_balances.rs
+++ b/runtime/local/src/weights/pallet_balances.rs
@@ -150,4 +150,11 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for SubstrateWeight<T>
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(u.into())))
 			.saturating_add(Weight::from_parts(0, 2603).saturating_mul(u.into()))
 	}
+	fn burn() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 30_151_000 picoseconds.
+		Weight::from_parts(30_968_000, 0)
+	}
 }

--- a/runtime/shibuya/src/weights/pallet_balances.rs
+++ b/runtime/shibuya/src/weights/pallet_balances.rs
@@ -150,4 +150,11 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for SubstrateWeight<T>
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(u.into())))
 			.saturating_add(Weight::from_parts(0, 2603).saturating_mul(u.into()))
 	}
+	fn burn() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `0`
+		//  Estimated: `0`
+		// Minimum execution time: 30_151_000 picoseconds.
+		Weight::from_parts(30_968_000, 0)
+	}
 }


### PR DESCRIPTION
**Pull Request Summary**

Integrates `burn` extrinsic into all runtimes, using a custom fork of `pallet-balances` ([link](https://github.com/AstarNetwork/polkadot-sdk/tree/astar-release-polkadot-v1.3.0)).
