### PR TITLE
gh action to run e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -17,12 +17,6 @@ jobs:
     - name: Checkout the source code
       uses: actions/checkout@v4
 
-    - name: setup node
-      uses: actions/setup-node@v4
-      with:
-        node-version: 18.x
-        cache: 'yarn'
-
     - name: Install deps
       run: sudo apt -y install protobuf-compiler
 
@@ -42,6 +36,13 @@ jobs:
       run: |
         cp target/release/wbuild/astar-runtime/astar_runtime.compact.compressed.wasm e2e-tests/wasm/astar_runtime.wasm
         cp target/release/wbuild/shiden-runtime/shiden_runtime.compact.compressed.wasm e2e-tests/wasm/shiden_runtime.wasm
+
+    - name: Setup node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18.x
+        cache: 'yarn'
+        cache-dependency-path: e2e-tests/yarn.lock
 
     - name: Run e2e test with new runtimes
       env:

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -1,0 +1,52 @@
+name: E2E Tests
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - '*'
+
+concurrency:
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v4
+
+    - name: setup node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18.x
+        cache: 'yarn'
+
+    - name: Install deps
+      run: sudo apt -y install protobuf-compiler
+
+    - name: Install & display rust toolchain
+      run: rustup show
+
+    - name: Check targets are installed correctly
+      run: rustup target list --installed
+
+    - name: Build runtimes
+      run: cargo build --release --features astar,shiden
+
+    - name: Clone Astar E2E tests
+      run: git clone https://github.com/AstarNetwork/e2e-tests.git --depth 1
+
+    - nme: Copy runtimes
+      run: |
+        cp target/release/wbuild/astar-runtime/astar_runtime.compact.compressed.wasm e2e-tests/wasm/astar_runtime.wasm
+        cp target/release/wbuild/shiden-runtime/shiden_runtime.compact.compressed.wasm e2e-tests/wasm/shiden_runtime.wasm
+
+    - name: Run e2e test with new runtimes
+      env:
+        ASTAR_WASM: wasm/astar_runtime.wasm
+        SHIDEN_WASM: wasm/astar_runtime.wasm
+      run: |
+        cd e2e-tests
+        yarn --immutable
+        yarn update-env
+        yarn test

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -3,8 +3,6 @@ on:
   workflow_dispatch:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -11,11 +11,20 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
-  tests:
+  e2e-tests:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the source code
       uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Setup node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18.x
+        cache: 'yarn'
+        cache-dependency-path: e2e-tests/yarn.lock
 
     - name: Install deps
       run: sudo apt -y install protobuf-compiler
@@ -26,30 +35,25 @@ jobs:
     - name: Check targets are installed correctly
       run: rustup target list --installed
 
-    - name: Build runtimes
+    - name: Build Astar & Shiden runtimes
       run: cargo build --release --features astar,shiden
 
-    - name: Clone Astar E2E tests
-      run: git clone https://github.com/AstarNetwork/e2e-tests.git --depth 1
-
-    - name: Copy runtimes
+    - name: Copy runtimes into test folder
       run: |
         cp target/release/wbuild/astar-runtime/astar_runtime.compact.compressed.wasm e2e-tests/wasm/astar_runtime.wasm
         cp target/release/wbuild/shiden-runtime/shiden_runtime.compact.compressed.wasm e2e-tests/wasm/shiden_runtime.wasm
 
-    - name: Setup node
-      uses: actions/setup-node@v4
-      with:
-        node-version: 18.x
-        cache: 'yarn'
-        cache-dependency-path: e2e-tests/yarn.lock
+    - name: Install dependencies
+      working-directory: e2e-tests
+      run: yarn --immutable
 
-    - name: Run e2e test with new runtimes
+    - name: Update env
+      working-directory: e2e-tests
+      run: yarn update-env
+
+    - name: Run e2e test with the new runtimes
+      working-directory: e2e-tests
+      run: yarn test
       env:
         ASTAR_WASM: wasm/astar_runtime.wasm
         SHIDEN_WASM: wasm/astar_runtime.wasm
-      run: |
-        cd e2e-tests
-        yarn --immutable
-        yarn update-env
-        yarn test

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -2,10 +2,12 @@ name: E2E Tests
 on:
   workflow_dispatch:
   push:
-    branches:
-      - '*'
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
@@ -36,7 +38,7 @@ jobs:
     - name: Clone Astar E2E tests
       run: git clone https://github.com/AstarNetwork/e2e-tests.git --depth 1
 
-    - nme: Copy runtimes
+    - name: Copy runtimes
       run: |
         cp target/release/wbuild/astar-runtime/astar_runtime.compact.compressed.wasm e2e-tests/wasm/astar_runtime.wasm
         cp target/release/wbuild/shiden-runtime/shiden_runtime.compact.compressed.wasm e2e-tests/wasm/shiden_runtime.wasm

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -16,8 +16,9 @@ jobs:
     steps:
     - name: Checkout the source code
       uses: actions/checkout@v4
-      with:
-        submodules: true
+
+    - name: Clone e2e-tests
+      run: git clone https://github.com/AstarNetwork/e2e-tests.git --depth 1
 
     - name: Setup node
       uses: actions/setup-node@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "e2e-tests"]
-	path = e2e-tests
-	url = git@github.com:AstarNetwork/e2e-tests.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "e2e-tests"]
+	path = e2e-tests
+	url = git@github.com:AstarNetwork/e2e-tests.git


### PR DESCRIPTION
GH action will build Astar & Shiden runtimes and then runs e2e tests using newest runtime. This will give us insight if something changes. This doesn't affect anything on the project, just runs some tests. Although I may change this later when I have a better idea how to deal with snapshot changes.