### PR TITLE
Base native currency price for dApp Staking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,7 @@ dependencies = [
 
 [[package]]
 name = "astar-collator"
-version = "5.39.0"
+version = "5.39.1"
 dependencies = [
  "astar-primitives",
  "astar-runtime",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "astar-runtime"
-version = "5.39.0"
+version = "5.39.1"
 dependencies = [
  "array-bytes 6.1.0",
  "astar-primitives",
@@ -6697,7 +6697,7 @@ dependencies = [
 
 [[package]]
 name = "local-runtime"
-version = "5.39.0"
+version = "5.39.1"
 dependencies = [
  "array-bytes 6.1.0",
  "astar-primitives",
@@ -13961,7 +13961,7 @@ dependencies = [
 
 [[package]]
 name = "shibuya-runtime"
-version = "5.39.0"
+version = "5.39.1"
 dependencies = [
  "array-bytes 6.1.0",
  "astar-primitives",
@@ -14077,7 +14077,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "5.39.0"
+version = "5.39.1"
 dependencies = [
  "array-bytes 6.1.0",
  "astar-primitives",

--- a/bin/collator/Cargo.toml
+++ b/bin/collator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-collator"
-version = "5.39.0"
+version = "5.39.1"
 description = "Astar collator implementation in Rust."
 build = "build.rs"
 default-run = "astar-collator"

--- a/pallets/dapp-staking-v3/src/benchmarking/utils.rs
+++ b/pallets/dapp-staking-v3/src/benchmarking/utils.rs
@@ -197,13 +197,14 @@ pub(super) fn init_tier_settings<T: Config>() {
     };
 
     // Init tier config, based on the initial params
-    let init_tier_config = TiersConfiguration::<T::NumberOfTiers, T::TierSlots> {
-        number_of_slots: NUMBER_OF_SLOTS.try_into().unwrap(),
-        slots_per_tier: BoundedVec::try_from(vec![10, 20, 30, 40]).unwrap(),
-        reward_portion: tier_params.reward_portion.clone(),
-        tier_thresholds: tier_params.tier_thresholds.clone(),
-        _phantom: Default::default(),
-    };
+    let init_tier_config =
+        TiersConfiguration::<T::NumberOfTiers, T::TierSlots, T::BaseNativeCurrencyPrice> {
+            number_of_slots: NUMBER_OF_SLOTS.try_into().unwrap(),
+            slots_per_tier: BoundedVec::try_from(vec![10, 20, 30, 40]).unwrap(),
+            reward_portion: tier_params.reward_portion.clone(),
+            tier_thresholds: tier_params.tier_thresholds.clone(),
+            _phantom: Default::default(),
+        };
 
     assert!(tier_params.is_valid());
     assert!(init_tier_config.is_valid());

--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -44,6 +44,7 @@ use frame_support::{
     weights::Weight,
 };
 use frame_system::pallet_prelude::*;
+use sp_arithmetic::fixed_point::FixedU128;
 use sp_runtime::{
     traits::{BadOrigin, One, Saturating, UniqueSaturatedInto, Zero},
     Perbill, Permill, SaturatedConversion,
@@ -147,6 +148,11 @@ pub mod pallet {
 
         /// Used to calculate total number of tier slots for some price.
         type TierSlots: TierSlotFunc;
+
+        /// Base native currency price used to calculate base number of slots.
+        /// This is used to adjust tier configuration, tier thresholds specifically, based on the native token price changes.
+        #[pallet::constant]
+        type BaseNativeCurrencyPrice: Get<FixedU128>;
 
         /// Maximum length of a single era reward span length entry.
         #[pallet::constant]
@@ -446,8 +452,11 @@ pub mod pallet {
 
     /// Tier configuration user for current & preceding eras.
     #[pallet::storage]
-    pub type TierConfig<T: Config> =
-        StorageValue<_, TiersConfiguration<T::NumberOfTiers, T::TierSlots>, ValueQuery>;
+    pub type TierConfig<T: Config> = StorageValue<
+        _,
+        TiersConfiguration<T::NumberOfTiers, T::TierSlots, T::BaseNativeCurrencyPrice>,
+        ValueQuery,
+    >;
 
     /// Information about which tier a dApp belonged to in a specific era.
     #[pallet::storage]
@@ -509,16 +518,17 @@ pub mod pallet {
             let number_of_slots = self.slots_per_tier.iter().fold(0_u16, |acc, &slots| {
                 acc.checked_add(slots).expect("Overflow")
             });
-            let tier_config = TiersConfiguration::<T::NumberOfTiers, T::TierSlots> {
-                number_of_slots,
-                slots_per_tier: BoundedVec::<u16, T::NumberOfTiers>::try_from(
-                    self.slots_per_tier.clone(),
-                )
-                .expect("Invalid number of slots per tier entries provided."),
-                reward_portion: tier_params.reward_portion.clone(),
-                tier_thresholds: tier_params.tier_thresholds.clone(),
-                _phantom: Default::default(),
-            };
+            let tier_config =
+                TiersConfiguration::<T::NumberOfTiers, T::TierSlots, T::BaseNativeCurrencyPrice> {
+                    number_of_slots,
+                    slots_per_tier: BoundedVec::<u16, T::NumberOfTiers>::try_from(
+                        self.slots_per_tier.clone(),
+                    )
+                    .expect("Invalid number of slots per tier entries provided."),
+                    reward_portion: tier_params.reward_portion.clone(),
+                    tier_thresholds: tier_params.tier_thresholds.clone(),
+                    _phantom: Default::default(),
+                };
             assert!(
                 tier_params.is_valid(),
                 "Invalid tier config values provided."

--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -151,6 +151,12 @@ pub mod pallet {
 
         /// Base native currency price used to calculate base number of slots.
         /// This is used to adjust tier configuration, tier thresholds specifically, based on the native token price changes.
+        ///
+        /// When dApp staking thresholds were modeled, a base price was set from which the initial configuration is derived.
+        /// E.g. for a price of 0.05$, we get 100 slots, and certain tier thresholds.
+        /// Using these values as the base, we can adjust the configuration based on the current price.
+        ///
+        /// This is connected with the `TierSlots` associated type, since it's used to calculate the total number of slots for the given price.
         #[pallet::constant]
         type BaseNativeCurrencyPrice: Get<FixedU128>;
 

--- a/pallets/dapp-staking-v3/src/test/mock.rs
+++ b/pallets/dapp-staking-v3/src/test/mock.rs
@@ -115,7 +115,7 @@ impl PriceProvider for DummyPriceProvider {
 thread_local! {
     pub(crate) static DOES_PAYOUT_SUCCEED: RefCell<bool> = RefCell::new(false);
     pub(crate) static BLOCK_BEFORE_NEW_ERA: RefCell<EraNumber> = RefCell::new(0);
-    pub(crate) static NATIVE_PRICE: RefCell<FixedU128> = RefCell::new(FixedU128::from_rational(1, 10));
+    pub(crate) static NATIVE_PRICE: RefCell<FixedU128> = RefCell::new(BaseNativeCurrencyPrice::get());
 }
 
 pub struct DummyStakingRewardHandler;
@@ -195,6 +195,10 @@ impl AccountCheck<AccountId> for DummyAccountCheck {
     }
 }
 
+parameter_types! {
+    pub const BaseNativeCurrencyPrice: FixedU128 = FixedU128::from_rational(5, 100);
+}
+
 impl pallet_dapp_staking::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type RuntimeFreezeReason = RuntimeFreezeReason;
@@ -207,6 +211,7 @@ impl pallet_dapp_staking::Config for Test {
     type Observers = DummyDappStakingObserver;
     type AccountCheck = DummyAccountCheck;
     type TierSlots = StandardTierSlots;
+    type BaseNativeCurrencyPrice = BaseNativeCurrencyPrice;
     type EraRewardSpanLength = ConstU32<8>;
     type RewardRetentionInPeriods = ConstU32<2>;
     type MaxNumberOfContracts = ConstU32<10>;
@@ -315,6 +320,7 @@ impl ExtBuilder {
             let init_tier_config = TiersConfiguration::<
                 <Test as Config>::NumberOfTiers,
                 <Test as Config>::TierSlots,
+                <Test as Config>::BaseNativeCurrencyPrice,
             > {
                 number_of_slots: 40,
                 slots_per_tier: BoundedVec::try_from(vec![2, 5, 13, 20]).unwrap(),

--- a/pallets/dapp-staking-v3/src/test/tests_types.rs
+++ b/pallets/dapp-staking-v3/src/test/tests_types.rs
@@ -17,7 +17,7 @@
 // along with Astar. If not, see <http://www.gnu.org/licenses/>.
 
 use astar_primitives::{dapp_staking::StandardTierSlots, Balance};
-use frame_support::assert_ok;
+use frame_support::{assert_ok, parameter_types};
 use sp_arithmetic::fixed_point::FixedU128;
 use sp_runtime::Permill;
 
@@ -2877,7 +2877,10 @@ fn tier_configuration_basic_tests() {
     assert!(params.is_valid(), "Example params must be valid!");
 
     // Create a configuration with some values
-    let init_config = TiersConfiguration::<TiersNum, StandardTierSlots> {
+    parameter_types! {
+        pub const BaseNativeCurrencyPrice: FixedU128 = FixedU128::from_rational(5, 100);
+    }
+    let init_config = TiersConfiguration::<TiersNum, StandardTierSlots, BaseNativeCurrencyPrice> {
         number_of_slots: 100,
         slots_per_tier: BoundedVec::try_from(vec![10, 20, 30, 40]).unwrap(),
         reward_portion: params.reward_portion.clone(),

--- a/pallets/dapp-staking-v3/src/types.rs
+++ b/pallets/dapp-staking-v3/src/types.rs
@@ -1657,9 +1657,9 @@ impl<NT: Get<u32>, T: TierSlotsFunc, P: Get<FixedU128>> TiersConfiguration<NT, T
         //
         // When these entries are put into the threshold formula, we get:
         // = 1 / ( 1 - (base_num_slots - new_num_slots) / base_num_slots ) - 1
-        // = 1 / ( new / old) - 1
-        // = old / new - 1
-        // = (old - new) / new
+        // = 1 / ( new / base) - 1
+        // = base / new - 1
+        // = (base - new) / new
         //
         // This number can be negative. In order to keep all operations in unsigned integer domain,
         // formulas are adjusted like:

--- a/pallets/dapp-staking-v3/src/types.rs
+++ b/pallets/dapp-staking-v3/src/types.rs
@@ -1698,7 +1698,7 @@ impl<NT: Get<u32>, T: TierSlotsFunc, P: Get<FixedU128>> TiersConfiguration<NT, T
                 });
 
             new_tier_thresholds
-        } else if new_number_of_slots < base_number_of_slots {
+        } else {
             let delta_threshold_increase = FixedU128::from_rational(
                 (base_number_of_slots - new_number_of_slots).into(),
                 new_number_of_slots.into(),
@@ -1716,8 +1716,6 @@ impl<NT: Get<u32>, T: TierSlotsFunc, P: Get<FixedU128>> TiersConfiguration<NT, T
                 });
 
             new_tier_thresholds
-        } else {
-            self.tier_thresholds.clone()
         };
 
         Self {

--- a/pallets/dapp-staking-v3/src/types.rs
+++ b/pallets/dapp-staking-v3/src/types.rs
@@ -1579,8 +1579,8 @@ impl<NT: Get<u32>> Default for TierParameters<NT> {
     CloneNoBound,
     TypeInfo,
 )]
-#[scale_info(skip_type_params(NT, T))]
-pub struct TiersConfiguration<NT: Get<u32>, T: TierSlotsFunc> {
+#[scale_info(skip_type_params(NT, T, P))]
+pub struct TiersConfiguration<NT: Get<u32>, T: TierSlotsFunc, P: Get<FixedU128>> {
     /// Total number of slots.
     #[codec(compact)]
     pub number_of_slots: u16,
@@ -1596,10 +1596,10 @@ pub struct TiersConfiguration<NT: Get<u32>, T: TierSlotsFunc> {
     pub tier_thresholds: BoundedVec<TierThreshold, NT>,
     /// Phantom data to keep track of the tier slots function.
     #[codec(skip)]
-    pub(crate) _phantom: PhantomData<T>,
+    pub(crate) _phantom: PhantomData<(T, P)>,
 }
 
-impl<NT: Get<u32>, T: TierSlotsFunc> Default for TiersConfiguration<NT, T> {
+impl<NT: Get<u32>, T: TierSlotsFunc, P: Get<FixedU128>> Default for TiersConfiguration<NT, T, P> {
     fn default() -> Self {
         Self {
             number_of_slots: 0,
@@ -1616,7 +1616,7 @@ impl<NT: Get<u32>, T: TierSlotsFunc> Default for TiersConfiguration<NT, T> {
 // * There's no need to keep thresholds in two separate storage items since the calculation can always be done compared to the
 //    anchor value of 5 cents. This still needs to be checked & investigated, but it's worth a try.
 
-impl<NT: Get<u32>, T: TierSlotsFunc> TiersConfiguration<NT, T> {
+impl<NT: Get<u32>, T: TierSlotsFunc, P: Get<FixedU128>> TiersConfiguration<NT, T, P> {
     /// Check if parameters are valid.
     pub fn is_valid(&self) -> bool {
         let number_of_tiers: usize = NT::get() as usize;
@@ -1651,10 +1651,12 @@ impl<NT: Get<u32>, T: TierSlotsFunc> TiersConfiguration<NT, T> {
         //
         // According to formula: %_threshold = (100% / (100% - delta_%_slots) - 1) * 100%
         //
-        // where delta_%_slots is simply: (old_num_slots - new_num_slots) / old_num_slots
+        // where delta_%_slots is simply: (base_num_slots - new_num_slots) / base_num_slots
+        //
+        // `base_num_slots` is the number of slots at the base native currency price.
         //
         // When these entries are put into the threshold formula, we get:
-        // = 1 / ( 1 - (old_num_slots - new_num_slots) / old_num_slots ) - 1
+        // = 1 / ( 1 - (base_num_slots - new_num_slots) / base_num_slots ) - 1
         // = 1 / ( new / old) - 1
         // = old / new - 1
         // = (old - new) / new
@@ -1663,20 +1665,24 @@ impl<NT: Get<u32>, T: TierSlotsFunc> TiersConfiguration<NT, T> {
         // formulas are adjusted like:
         //
         // 1. Number of slots has increased, threshold is expected to decrease
-        // %_threshold = (new_num_slots - old_num_slots) / new_num_slots
-        // new_threshold = old_threshold * (1 - %_threshold)
+        // %_threshold = (new_num_slots - base_num_slots) / new_num_slots
+        // new_threshold = base_threshold * (1 - %_threshold)
         //
         // 2. Number of slots has decreased, threshold is expected to increase
-        // %_threshold = (old_num_slots - new_num_slots) / new_num_slots
-        // new_threshold = old_threshold * (1 + %_threshold)
+        // %_threshold = (base_num_slots - new_num_slots) / new_num_slots
+        // new_threshold = base_threshold * (1 + %_threshold)
         //
-        let new_tier_thresholds = if new_number_of_slots > self.number_of_slots {
+        let base_number_of_slots = T::number_of_slots(P::get()).max(1);
+
+        // NOTE: even though we could ignore the situation when the new & base slot numbers are equal, it's necessary to re-calculate it since
+        // other params related to calculation might have changed.
+        let new_tier_thresholds = if new_number_of_slots >= base_number_of_slots {
             let delta_threshold_decrease = FixedU128::from_rational(
-                (new_number_of_slots - self.number_of_slots).into(),
+                (new_number_of_slots - base_number_of_slots).into(),
                 new_number_of_slots.into(),
             );
 
-            let mut new_tier_thresholds = self.tier_thresholds.clone();
+            let mut new_tier_thresholds = params.tier_thresholds.clone();
             new_tier_thresholds
                 .iter_mut()
                 .for_each(|threshold| match threshold {
@@ -1692,13 +1698,13 @@ impl<NT: Get<u32>, T: TierSlotsFunc> TiersConfiguration<NT, T> {
                 });
 
             new_tier_thresholds
-        } else if new_number_of_slots < self.number_of_slots {
+        } else if new_number_of_slots < base_number_of_slots {
             let delta_threshold_increase = FixedU128::from_rational(
-                (self.number_of_slots - new_number_of_slots).into(),
+                (base_number_of_slots - new_number_of_slots).into(),
                 new_number_of_slots.into(),
             );
 
-            let mut new_tier_thresholds = self.tier_thresholds.clone();
+            let mut new_tier_thresholds = params.tier_thresholds.clone();
             new_tier_thresholds
                 .iter_mut()
                 .for_each(|threshold| match threshold {

--- a/precompiles/dapp-staking-v3/src/test/mock.rs
+++ b/precompiles/dapp-staking-v3/src/test/mock.rs
@@ -245,6 +245,10 @@ impl pallet_dapp_staking_v3::BenchmarkHelper<MockSmartContract, AccountId>
     fn set_balance(_account: &AccountId, _amount: Balance) {}
 }
 
+parameter_types! {
+    pub const BaseNativeCurrencyPrice: FixedU128 = FixedU128::from_rational(5, 100);
+}
+
 impl pallet_dapp_staking_v3::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type RuntimeFreezeReason = RuntimeFreezeReason;
@@ -257,6 +261,7 @@ impl pallet_dapp_staking_v3::Config for Test {
     type Observers = ();
     type AccountCheck = ();
     type TierSlots = StandardTierSlots;
+    type BaseNativeCurrencyPrice = BaseNativeCurrencyPrice;
     type EraRewardSpanLength = ConstU32<8>;
     type RewardRetentionInPeriods = ConstU32<2>;
     type MaxNumberOfContracts = ConstU32<10>;

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-runtime"
-version = "5.39.0"
+version = "5.39.1"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -154,7 +154,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("astar"),
     impl_name: create_runtime_str!("astar"),
     authoring_version: 1,
-    spec_version: 87,
+    spec_version: 88,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -64,7 +64,7 @@ use sp_runtime::{
         DispatchInfoOf, Dispatchable, OpaqueKeys, PostDispatchInfoOf, UniqueSaturatedInto, Zero,
     },
     transaction_validity::{TransactionSource, TransactionValidity, TransactionValidityError},
-    ApplyExtrinsicResult, FixedPointNumber, Perbill, Permill, Perquintill, RuntimeDebug,
+    ApplyExtrinsicResult, FixedPointNumber, FixedU128, Perbill, Permill, Perquintill, RuntimeDebug,
 };
 use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 
@@ -326,6 +326,7 @@ impl pallet_multisig::Config for Runtime {
 
 parameter_types! {
     pub const MinimumStakingAmount: Balance = 500 * ASTR;
+    pub const BaseNativeCurrencyPrice: FixedU128 = FixedU128::from_rational(5, 100);
 }
 
 #[cfg(feature = "runtime-benchmarks")]
@@ -368,6 +369,7 @@ impl pallet_dapp_staking_v3::Config for Runtime {
     type Observers = Inflation;
     type AccountCheck = AccountCheck;
     type TierSlots = StandardTierSlots;
+    type BaseNativeCurrencyPrice = BaseNativeCurrencyPrice;
     type EraRewardSpanLength = ConstU32<16>;
     type RewardRetentionInPeriods = ConstU32<4>;
     type MaxNumberOfContracts = ConstU32<500>;

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -1170,38 +1170,10 @@ pub type Executive = frame_executive::Executive<
     Migrations,
 >;
 
-parameter_types! {
-    pub const StaticPriceProviderName: &'static str = "StaticPriceProvider";
-    // 0.18 $
-    pub const InitPrice: CurrencyAmount = CurrencyAmount::from_rational(18, 100);
-}
-
 /// All migrations that will run on the next runtime upgrade.
 ///
 /// Once done, migrations should be removed from the tuple.
-pub type Migrations = (
-    frame_support::migrations::RemovePallet<
-        StaticPriceProviderName,
-        <Runtime as frame_system::Config>::DbWeight,
-    >,
-    OracleIntegrationLogic,
-    pallet_price_aggregator::PriceAggregatorInitializer<Runtime, InitPrice>,
-);
-
-use frame_support::traits::OnRuntimeUpgrade;
-pub struct OracleIntegrationLogic;
-impl OnRuntimeUpgrade for OracleIntegrationLogic {
-    fn on_runtime_upgrade() -> Weight {
-        // 1. Set initial storage versions for the membership pallet
-        use frame_support::traits::StorageVersion;
-        StorageVersion::new(4)
-            .put::<pallet_membership::Pallet<Runtime, OracleMembershipInstance>>();
-
-        // No storage version for the `orml_oracle` pallet, it's essentially 0
-
-        <Runtime as frame_system::Config>::DbWeight::get().writes(1)
-    }
-}
+pub type Migrations = ();
 
 type EventRecord = frame_system::EventRecord<
     <Runtime as frame_system::Config>::RuntimeEvent,

--- a/runtime/local/Cargo.toml
+++ b/runtime/local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-runtime"
-version = "5.39.0"
+version = "5.39.1"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -59,7 +59,7 @@ use sp_runtime::{
         DispatchInfoOf, Dispatchable, NumberFor, PostDispatchInfoOf, UniqueSaturatedInto,
     },
     transaction_validity::{TransactionSource, TransactionValidity, TransactionValidityError},
-    ApplyExtrinsicResult, FixedPointNumber, Perbill, Permill, Perquintill, RuntimeDebug,
+    ApplyExtrinsicResult, FixedPointNumber, FixedU128, Perbill, Permill, Perquintill, RuntimeDebug,
 };
 use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 
@@ -448,6 +448,10 @@ impl pallet_dapp_staking_v3::BenchmarkHelper<SmartContract<AccountId>, AccountId
     }
 }
 
+parameter_types! {
+    pub const BaseNativeCurrencyPrice: FixedU128 = FixedU128::from_rational(5, 100);
+}
+
 impl pallet_dapp_staking_v3::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type RuntimeFreezeReason = RuntimeFreezeReason;
@@ -460,6 +464,7 @@ impl pallet_dapp_staking_v3::Config for Runtime {
     type Observers = Inflation;
     type AccountCheck = ();
     type TierSlots = StandardTierSlots;
+    type BaseNativeCurrencyPrice = BaseNativeCurrencyPrice;
     type EraRewardSpanLength = ConstU32<8>;
     type RewardRetentionInPeriods = ConstU32<2>;
     type MaxNumberOfContracts = ConstU32<100>;

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "5.39.0"
+version = "5.39.1"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -176,7 +176,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shibuya"),
     impl_name: create_runtime_str!("shibuya"),
     authoring_version: 1,
-    spec_version: 129,
+    spec_version: 130,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -64,7 +64,7 @@ use sp_runtime::{
         DispatchInfoOf, Dispatchable, OpaqueKeys, PostDispatchInfoOf, UniqueSaturatedInto,
     },
     transaction_validity::{TransactionSource, TransactionValidity, TransactionValidityError},
-    ApplyExtrinsicResult, FixedPointNumber, Perbill, Permill, Perquintill, RuntimeDebug,
+    ApplyExtrinsicResult, FixedPointNumber, FixedU128, Perbill, Permill, Perquintill, RuntimeDebug,
 };
 use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 
@@ -419,6 +419,7 @@ impl DappStakingAccountCheck<AccountId> for AccountCheck {
 
 parameter_types! {
     pub const MinimumStakingAmount: Balance = 5 * SBY;
+    pub const BaseNativeCurrencyPrice: FixedU128 = FixedU128::from_rational(5, 100);
 }
 
 impl pallet_dapp_staking_v3::Config for Runtime {
@@ -433,6 +434,7 @@ impl pallet_dapp_staking_v3::Config for Runtime {
     type Observers = Inflation;
     type AccountCheck = AccountCheck;
     type TierSlots = StandardTierSlots;
+    type BaseNativeCurrencyPrice = BaseNativeCurrencyPrice;
     type EraRewardSpanLength = ConstU32<16>;
     type RewardRetentionInPeriods = ConstU32<2>;
     type MaxNumberOfContracts = ConstU32<500>;

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "5.39.0"
+version = "5.39.1"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -63,7 +63,7 @@ use sp_runtime::{
         DispatchInfoOf, Dispatchable, OpaqueKeys, PostDispatchInfoOf, UniqueSaturatedInto,
     },
     transaction_validity::{TransactionSource, TransactionValidity, TransactionValidityError},
-    ApplyExtrinsicResult, FixedPointNumber, Perbill, Permill, Perquintill, RuntimeDebug,
+    ApplyExtrinsicResult, FixedPointNumber, FixedU128, Perbill, Permill, Perquintill, RuntimeDebug,
 };
 use sp_std::{collections::btree_map::BTreeMap, prelude::*};
 
@@ -366,6 +366,7 @@ impl TierSlotsFunc for ShidenTierSlots {
 
 parameter_types! {
     pub const MinimumStakingAmount: Balance = 50 * SDN;
+    pub const BaseNativeCurrencyPrice: FixedU128 = FixedU128::from_rational(5, 100);
 }
 
 impl pallet_dapp_staking_v3::Config for Runtime {
@@ -380,6 +381,7 @@ impl pallet_dapp_staking_v3::Config for Runtime {
     type Observers = Inflation;
     type AccountCheck = AccountCheck;
     type TierSlots = ShidenTierSlots;
+    type BaseNativeCurrencyPrice = BaseNativeCurrencyPrice;
     type EraRewardSpanLength = ConstU32<16>;
     type RewardRetentionInPeriods = ConstU32<3>;
     type MaxNumberOfContracts = ConstU32<500>;

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -155,7 +155,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shiden"),
     impl_name: create_runtime_str!("shiden"),
     authoring_version: 1,
-    spec_version: 126,
+    spec_version: 127,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 2,

--- a/tests/xcm-simulator/src/mocks/parachain.rs
+++ b/tests/xcm-simulator/src/mocks/parachain.rs
@@ -709,6 +709,10 @@ impl pallet_dapp_staking_v3::BenchmarkHelper<MockSmartContract, AccountId>
     }
 }
 
+parameter_types! {
+    pub const BaseNativeCurrencyPrice: FixedU128 = FixedU128::from_rational(5, 100);
+}
+
 impl pallet_dapp_staking_v3::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type RuntimeFreezeReason = RuntimeFreezeReason;
@@ -721,6 +725,7 @@ impl pallet_dapp_staking_v3::Config for Runtime {
     type Observers = ();
     type AccountCheck = DummyAccountCheck;
     type TierSlots = astar_primitives::dapp_staking::StandardTierSlots;
+    type BaseNativeCurrencyPrice = BaseNativeCurrencyPrice;
     type EraRewardSpanLength = ConstU32<1>;
     type RewardRetentionInPeriods = ConstU32<2>;
     type MaxNumberOfContracts = ConstU32<10>;


### PR DESCRIPTION
## Pull Request Summary

Fixes an issue with threshold calculation in dApp staking.

The issue happens because the formula for tier threshold update did not account for threshold value saturation.
As `ASTR` price increased, so did the number of available slots, and as a result, thresholds saturated at the minimum possible value. Number of slots could keep increasing, while the thresholds remained the same.

But as ASTR price dropped, this brought a negative change in the number of slots. Since number of slots was way
larger than the base number of slots, this seemed as a larger change that it was supposed to be, in respect to the current threshold.

This fix changes the way threshold is calculated so that the `new_number_of_slots` is always compared to the `base_number_of_slots`. This way ensures thresholds are always updated in respect to what the _baseline_ is.

## Note

* issue was reproduced first using the new unit test
* fix was verified on a chain fork using chopsticks
