### PR TITLE
Upd/shibuya specs

### DIFF
--- a/bin/collator/res/shibuya.json
+++ b/bin/collator/res/shibuya.json
@@ -5,10 +5,10 @@
   "bootNodes": [
     "/ip4/65.108.46.114/tcp/38333/ws/p2p/12D3KooWLBLYreWVnWUvV5xvTgbhr5zSPn33LQhexGW28zj83GjH",
     "/ip4/103.243.173.186/tcp/30333/ws/p2p/12D3KooWDuAQkahaTsN8XHg4k7qe8rttoXrTW5jpJke275S2YA1a",
-    "/ip4/80.253.161.89/tcp/30333/ws/p2p/12D3KooWNfADqVKZFtiTDvR4CYF6pro5KVXeBEKYBHh5ohLAHrqk",
+    "/ip4/134.209.98.231/tcp/30333/ws/p2p/12D3KooWHuBMCcRqAChQ1fGBJ76QKF2u1yZPs6ZX93Qgn24jDq3Q",
     "/dns/bootnode-01.shibuya.astar.network/tcp/443/wss/p2p/12D3KooWLBLYreWVnWUvV5xvTgbhr5zSPn33LQhexGW28zj83GjH",
     "/dns/bootnode-02.shibuya.astar.network/tcp/443/wss/p2p/12D3KooWDuAQkahaTsN8XHg4k7qe8rttoXrTW5jpJke275S2YA1a",
-    "/dns/bootnode-03.shibuya.astar.network/tcp/443/wss/p2p/12D3KooWNfADqVKZFtiTDvR4CYF6pro5KVXeBEKYBHh5ohLAHrqk"
+    "/dns/bootnode-03.shibuya.astar.network/tcp/443/wss/p2p/12D3KooWHuBMCcRqAChQ1fGBJ76QKF2u1yZPs6ZX93Qgn24jDq3Q"
   ],
   "telemetryEndpoints": null,
   "protocolId": "shibuya",

--- a/bin/collator/res/shibuya.raw.json
+++ b/bin/collator/res/shibuya.raw.json
@@ -5,10 +5,10 @@
   "bootNodes": [
     "/ip4/65.108.46.114/tcp/38333/ws/p2p/12D3KooWLBLYreWVnWUvV5xvTgbhr5zSPn33LQhexGW28zj83GjH",
     "/ip4/103.243.173.186/tcp/30333/ws/p2p/12D3KooWDuAQkahaTsN8XHg4k7qe8rttoXrTW5jpJke275S2YA1a",
-    "/ip4/80.253.161.89/tcp/30333/ws/p2p/12D3KooWNfADqVKZFtiTDvR4CYF6pro5KVXeBEKYBHh5ohLAHrqk",
+    "/ip4/134.209.98.231/tcp/30333/ws/p2p/12D3KooWHuBMCcRqAChQ1fGBJ76QKF2u1yZPs6ZX93Qgn24jDq3Q",
     "/dns/bootnode-01.shibuya.astar.network/tcp/443/wss/p2p/12D3KooWLBLYreWVnWUvV5xvTgbhr5zSPn33LQhexGW28zj83GjH",
     "/dns/bootnode-02.shibuya.astar.network/tcp/443/wss/p2p/12D3KooWDuAQkahaTsN8XHg4k7qe8rttoXrTW5jpJke275S2YA1a",
-    "/dns/bootnode-03.shibuya.astar.network/tcp/443/wss/p2p/12D3KooWNfADqVKZFtiTDvR4CYF6pro5KVXeBEKYBHh5ohLAHrqk"
+    "/dns/bootnode-03.shibuya.astar.network/tcp/443/wss/p2p/12D3KooWHuBMCcRqAChQ1fGBJ76QKF2u1yZPs6ZX93Qgn24jDq3Q"
   ],
   "telemetryEndpoints": null,
   "protocolId": "shibuya",


### PR DESCRIPTION
**Pull Request Summary**
We changed collator. New name is:  shibuya-collator-boot-03-do on IP 134.209.98.231. 
This is also a boot node so that is why we are changing shibuya specs.
