### PR TITLE
Fix incorrect check for locked/frozen amount

### DIFF
--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -838,7 +838,7 @@ pub mod pallet {
 
             // Calculate & check amount available for locking
             let available_balance =
-                T::Currency::total_balance(&account).saturating_sub(ledger.active_locked_amount());
+                T::Currency::total_balance(&account).saturating_sub(ledger.total_locked_amount());
             let amount_to_lock = available_balance.min(amount);
             ensure!(!amount_to_lock.is_zero(), Error::<T>::ZeroAmount);
 

--- a/pallets/dapp-staking-v3/src/test/tests.rs
+++ b/pallets/dapp-staking-v3/src/test/tests.rs
@@ -3286,3 +3286,19 @@ fn unstake_correctly_reduces_future_contract_stake() {
         assert_unstake(staker_1, &smart_contract, amount_2 + 3);
     })
 }
+
+#[test]
+fn lock_correctly_considers_unlocking_amount() {
+    ExtBuilder::build().execute_with(|| {
+        // Lock the entire amount & immediately start the unlocking process
+        let (staker, unlock_amount) = (1, 13);
+        let total_balance = Balances::total_balance(&staker);
+        assert_lock(staker, total_balance);
+        assert_unlock(staker, unlock_amount);
+
+        assert_noop!(
+            DappStaking::lock(RuntimeOrigin::signed(staker), 1),
+            Error::<Test>::ZeroAmount
+        );
+    })
+}


### PR DESCRIPTION
**Pull Request Summary**

When `lock` is called, the `total_balance` needs to be compared against complete frozen balance in dApp staking.
RIght now, incorrect function was called which only returned amount which was actively locked (not undergoing the unlocking period).
