### PR TITLE
Fix account call for freeze/lock inconsistency

### DIFF
--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -1619,17 +1619,10 @@ pub mod pallet {
                 Ledger::<T>::insert(&account, ledger);
 
                 // 2. Execute the unlock call, clearing all of the unlocking chunks.
-                let result = Self::internal_claim_unlocked(account);
+                Self::internal_claim_unlocked(account)?;
 
-                // 3. Adjust consumed weight to consume the max possible weight (as defined in the weight macro).
-                match result {
-                    Ok(mut info) => {
-                        info.pays_fee = Pays::No;
-                        info.actual_weight = None;
-                    }
-                    Err(mut info) => info.post_info.actual_weight = None,
-                }
-                result
+                // 3. In case of success, ensure no fee is paid.
+                Ok(Pays::No.into())
             } else {
                 // The above logic is designed for a specific scenario and cannot be used otherwise.
                 Err(Error::<T>::AccountNotInconsistent.into())

--- a/pallets/dapp-staking-v3/src/lib.rs
+++ b/pallets/dapp-staking-v3/src/lib.rs
@@ -387,7 +387,7 @@ pub mod pallet {
         /// Force call is not allowed in production.
         ForceNotAllowed,
         /// Account doesn't have the freeze inconsistency
-        InvalidAccount, // TODO: can be removed after call `fix_account` is removed
+        AccountNotInconsistent, // TODO: can be removed after call `fix_account` is removed
     }
 
     /// General information about dApp staking protocol state.
@@ -1596,7 +1596,7 @@ pub mod pallet {
         /// The benchmarked weight of the `claim_unlocked` call is used as a base, and additional overestimated weight is added.
         /// Call doesn't touch any storage items that aren't already touched by the `claim_unlocked` call, hence the simplified approach.
         #[pallet::call_index(100)]
-        #[pallet::weight(T::WeightInfo::claim_unlocked(T::MaxNumberOfStakedContracts::get()).saturating_add(Weight::from_parts(1_000_000_000, 0)))]
+        #[pallet::weight(T::DbWeight::get().reads_writes(4, 1))]
         pub fn fix_account(
             origin: OriginFor<T>,
             account: T::AccountId,
@@ -1632,7 +1632,7 @@ pub mod pallet {
                 result
             } else {
                 // The above logic is designed for a specific scenario and cannot be used otherwise.
-                Err(Error::<T>::InvalidAccount.into())
+                Err(Error::<T>::AccountNotInconsistent.into())
             }
         }
     }

--- a/pallets/dapp-staking-v3/src/test/tests.rs
+++ b/pallets/dapp-staking-v3/src/test/tests.rs
@@ -3311,13 +3311,13 @@ fn fix_account_scenarios_work() {
         assert_lock(account_1, lock_1);
         assert_noop!(
             DappStaking::fix_account(RuntimeOrigin::signed(11), account_1),
-            Error::<Test>::InvalidAccount
+            Error::<Test>::AccountNotInconsistent
         );
 
         assert_unlock(account_1, lock_1);
         assert_noop!(
             DappStaking::fix_account(RuntimeOrigin::signed(11), account_1),
-            Error::<Test>::InvalidAccount
+            Error::<Test>::AccountNotInconsistent
         );
 
         // 2. Reproduce the issue where the account has more frozen than balance
@@ -3370,7 +3370,7 @@ fn fix_account_scenarios_work() {
         // Cannot fix the same account again.
         assert_noop!(
             DappStaking::fix_account(RuntimeOrigin::signed(11), account_2),
-            Error::<Test>::InvalidAccount
+            Error::<Test>::AccountNotInconsistent
         );
     })
 }

--- a/pallets/dapp-staking-v3/src/test/tests.rs
+++ b/pallets/dapp-staking-v3/src/test/tests.rs
@@ -3288,6 +3288,22 @@ fn unstake_correctly_reduces_future_contract_stake() {
 }
 
 #[test]
+fn lock_correctly_considers_unlocking_amount() {
+    ExtBuilder::build().execute_with(|| {
+        // Lock the entire amount & immediately start the unlocking process
+        let (staker, unlock_amount) = (1, 13);
+        let total_balance = Balances::total_balance(&staker);
+        assert_lock(staker, total_balance);
+        assert_unlock(staker, unlock_amount);
+
+        assert_noop!(
+            DappStaking::lock(RuntimeOrigin::signed(staker), 1),
+            Error::<Test>::ZeroAmount
+        );
+    })
+}
+
+#[test]
 fn fix_account_scenarios_work() {
     ExtBuilder::build().execute_with(|| {
         // 1. Lock some amount correctly, unstake it, try to fix it, and ensure the call fails
@@ -3355,21 +3371,6 @@ fn fix_account_scenarios_work() {
         assert_noop!(
             DappStaking::fix_account(RuntimeOrigin::signed(11), account_2),
             Error::<Test>::InvalidAccount
-        );
-    })
-}
-
-fn lock_correctly_considers_unlocking_amount() {
-    ExtBuilder::build().execute_with(|| {
-        // Lock the entire amount & immediately start the unlocking process
-        let (staker, unlock_amount) = (1, 13);
-        let total_balance = Balances::total_balance(&staker);
-        assert_lock(staker, total_balance);
-        assert_unlock(staker, unlock_amount);
-
-        assert_noop!(
-            DappStaking::lock(RuntimeOrigin::signed(staker), 1),
-            Error::<Test>::ZeroAmount
         );
     })
 }


### PR DESCRIPTION
**Pull Request Summary**

Provide an approach to fix the account within an incosistent freeze state.

The approach is as simple as possible, reusing the `claim_unlocked` logic to clear unlocking chunks which are forcefully set to be immediately claimable.
