### PR TITLE
revert node id

### DIFF
--- a/bin/collator/res/shibuya.json
+++ b/bin/collator/res/shibuya.json
@@ -5,10 +5,10 @@
   "bootNodes": [
     "/ip4/65.108.46.114/tcp/38333/ws/p2p/12D3KooWLBLYreWVnWUvV5xvTgbhr5zSPn33LQhexGW28zj83GjH",
     "/ip4/103.243.173.186/tcp/30333/ws/p2p/12D3KooWDuAQkahaTsN8XHg4k7qe8rttoXrTW5jpJke275S2YA1a",
-    "/ip4/134.209.98.231/tcp/30333/ws/p2p/12D3KooWHuBMCcRqAChQ1fGBJ76QKF2u1yZPs6ZX93Qgn24jDq3Q",
+    "/ip4/134.209.98.231/tcp/30333/ws/p2p/12D3KooWNfADqVKZFtiTDvR4CYF6pro5KVXeBEKYBHh5ohLAHrqk",
     "/dns/bootnode-01.shibuya.astar.network/tcp/443/wss/p2p/12D3KooWLBLYreWVnWUvV5xvTgbhr5zSPn33LQhexGW28zj83GjH",
     "/dns/bootnode-02.shibuya.astar.network/tcp/443/wss/p2p/12D3KooWDuAQkahaTsN8XHg4k7qe8rttoXrTW5jpJke275S2YA1a",
-    "/dns/bootnode-03.shibuya.astar.network/tcp/443/wss/p2p/12D3KooWHuBMCcRqAChQ1fGBJ76QKF2u1yZPs6ZX93Qgn24jDq3Q"
+    "/dns/bootnode-03.shibuya.astar.network/tcp/443/wss/p2p/12D3KooWNfADqVKZFtiTDvR4CYF6pro5KVXeBEKYBHh5ohLAHrqk"
   ],
   "telemetryEndpoints": null,
   "protocolId": "shibuya",

--- a/bin/collator/res/shibuya.raw.json
+++ b/bin/collator/res/shibuya.raw.json
@@ -5,10 +5,10 @@
   "bootNodes": [
     "/ip4/65.108.46.114/tcp/38333/ws/p2p/12D3KooWLBLYreWVnWUvV5xvTgbhr5zSPn33LQhexGW28zj83GjH",
     "/ip4/103.243.173.186/tcp/30333/ws/p2p/12D3KooWDuAQkahaTsN8XHg4k7qe8rttoXrTW5jpJke275S2YA1a",
-    "/ip4/134.209.98.231/tcp/30333/ws/p2p/12D3KooWHuBMCcRqAChQ1fGBJ76QKF2u1yZPs6ZX93Qgn24jDq3Q",
+    "/ip4/134.209.98.231/tcp/30333/ws/p2p/12D3KooWNfADqVKZFtiTDvR4CYF6pro5KVXeBEKYBHh5ohLAHrqk",
     "/dns/bootnode-01.shibuya.astar.network/tcp/443/wss/p2p/12D3KooWLBLYreWVnWUvV5xvTgbhr5zSPn33LQhexGW28zj83GjH",
     "/dns/bootnode-02.shibuya.astar.network/tcp/443/wss/p2p/12D3KooWDuAQkahaTsN8XHg4k7qe8rttoXrTW5jpJke275S2YA1a",
-    "/dns/bootnode-03.shibuya.astar.network/tcp/443/wss/p2p/12D3KooWHuBMCcRqAChQ1fGBJ76QKF2u1yZPs6ZX93Qgn24jDq3Q"
+    "/dns/bootnode-03.shibuya.astar.network/tcp/443/wss/p2p/12D3KooWNfADqVKZFtiTDvR4CYF6pro5KVXeBEKYBHh5ohLAHrqk"
   ],
   "telemetryEndpoints": null,
   "protocolId": "shibuya",


### PR DESCRIPTION
Wrong  node ID set on boot node shibuya 03. We need to revert the old node id setup.

**Pull Request Summary**


**Check list**
- [ ] added or updated unit tests
- [ ] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [ ] added benchmarks & weights for any modified runtime logics.
