### PR TITLE
Missing governance permissions for Shibuya

### DIFF
--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -1113,7 +1113,9 @@ impl InstanceFilter<RuntimeCall> for CommunityCouncilCallFilter {
     fn filter(&self, c: &RuntimeCall) -> bool {
         matches!(
             c,
-            RuntimeCall::DappStaking(..) | RuntimeCall::System(frame_system::Call::remark { .. })
+            RuntimeCall::DappStaking(..)
+                | RuntimeCall::System(frame_system::Call::remark { .. })
+                | RuntimeCall::Utility(..)
         )
     }
 }

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -438,9 +438,9 @@ impl pallet_dapp_staking_v3::Config for Runtime {
     type RuntimeFreezeReason = RuntimeFreezeReason;
     type Currency = Balances;
     type SmartContract = SmartContract<AccountId>;
-    type ContractRegisterOrigin = frame_system::EnsureRoot<AccountId>;
+    type ContractRegisterOrigin = EnsureRootOrTwoThirdsCommunityCouncil;
     type ContractUnregisterOrigin = frame_system::EnsureRoot<AccountId>;
-    type ManagerOrigin = frame_system::EnsureRoot<AccountId>;
+    type ManagerOrigin = EnsureRootOrTwoThirdsTechnicalCommittee;
     type NativePriceProvider = PriceAggregator;
     type StakingRewardHandler = Inflation;
     type CycleConfiguration = InflationCycleConfig;
@@ -1441,7 +1441,9 @@ impl InstanceFilter<RuntimeCall> for CommunityCouncilCallFilter {
     fn filter(&self, c: &RuntimeCall) -> bool {
         matches!(
             c,
-            RuntimeCall::DappStaking(..) | RuntimeCall::System(frame_system::Call::remark { .. })
+            RuntimeCall::DappStaking(..)
+                | RuntimeCall::System(frame_system::Call::remark { .. })
+                | RuntimeCall::Utility(..)
         )
     }
 }


### PR DESCRIPTION
**Pull Request Summary**

Added missing tech committee permission for Shibuya & local.
Also allowed utility pallet to be used in collective proxy calls for easier lock/stake/unstake/unlock operations.
