### PR TITLE
Minor governance param adjustment

### DIFF
--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -978,10 +978,10 @@ impl pallet_collective::Config<CommunityCouncilCollectiveInst> for Runtime {
 impl pallet_democracy::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type Currency = Balances;
-    type EnactmentPeriod = ConstU32<{ 1 * MINUTES }>;
-    type LaunchPeriod = ConstU32<{ 1 * MINUTES }>;
-    type VotingPeriod = ConstU32<{ 3 * MINUTES }>;
-    type VoteLockingPeriod = ConstU32<{ 10 * MINUTES }>;
+    type EnactmentPeriod = ConstU32<{ 5 * MINUTES }>;
+    type LaunchPeriod = ConstU32<{ 5 * MINUTES }>;
+    type VotingPeriod = ConstU32<{ 5 * MINUTES }>;
+    type VoteLockingPeriod = ConstU32<{ 2 * MINUTES }>;
     type MinimumDeposit = ConstU128<{ 10 * AST }>;
     type FastTrackVotingPeriod = ConstU32<{ MINUTES / 2 }>;
     type CooloffPeriod = ConstU32<{ 2 * MINUTES }>;

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -1175,12 +1175,11 @@ impl orml_oracle::Config for Runtime {
 
 impl pallet_membership::Config<OracleMembershipInst> for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type AddOrigin = EnsureRoot<AccountId>;
-    type RemoveOrigin = EnsureRoot<AccountId>;
-    type SwapOrigin = EnsureRoot<AccountId>;
-    type ResetOrigin = EnsureRoot<AccountId>;
-    type PrimeOrigin = EnsureRoot<AccountId>;
-
+    type AddOrigin = EnsureRootOrTwoThirdsMainCouncil;
+    type RemoveOrigin = EnsureRootOrTwoThirdsMainCouncil;
+    type SwapOrigin = EnsureRootOrTwoThirdsMainCouncil;
+    type ResetOrigin = EnsureRootOrTwoThirdsMainCouncil;
+    type PrimeOrigin = EnsureRootOrTwoThirdsMainCouncil;
     type MembershipInitialized = ();
     type MembershipChanged = ();
     type MaxMembers = ConstU32<16>;
@@ -1307,10 +1306,10 @@ impl pallet_collective::Config<CommunityCouncilCollectiveInst> for Runtime {
 impl pallet_democracy::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type Currency = Balances;
-    type EnactmentPeriod = ConstU32<{ 1 * HOURS }>;
-    type LaunchPeriod = ConstU32<{ 1 * DAYS }>;
-    type VotingPeriod = ConstU32<{ 1 * DAYS }>;
-    type VoteLockingPeriod = ConstU32<{ 2 * DAYS }>;
+    type EnactmentPeriod = ConstU32<{ 2 * HOURS }>;
+    type LaunchPeriod = ConstU32<{ 3 * DAYS }>;
+    type VotingPeriod = ConstU32<{ 3 * DAYS }>;
+    type VoteLockingPeriod = ConstU32<{ 1 * DAYS }>;
     type MinimumDeposit = ConstU128<{ 10 * SBY }>;
     type FastTrackVotingPeriod = ConstU32<{ 1 * HOURS }>;
     type CooloffPeriod = ConstU32<{ 1 * DAYS }>;


### PR DESCRIPTION
**Pull Request Summary**

Adjusted `local` runtime params to make testing scenarios described in the docs easier.
Current timing was sometimes too fast, which made it difficult to detect certain changes.

Also added missing settings for `Shibuya` runtime in respect with setting oracle members.
Slightly modified timing params for democracy.