### PR TITLE
fix evm tracing for older runtimes

### DIFF
--- a/vendor/rpc/debug/src/lib.rs
+++ b/vendor/rpc/debug/src/lib.rs
@@ -381,7 +381,8 @@ where
             } else {
                 // Old "trace_block" api did not initialize block before applying transactions,
                 // so we need to do it here before calling "trace_block".
-                api.initialize_block(parent_block_hash, &header)
+                #[allow(deprecated)]
+                api.initialize_block_before_version_5(parent_block_hash, &header)
                     .map_err(|e| internal_err(format!("Runtime api access error: {:?}", e)))?;
 
                 #[allow(deprecated)]
@@ -529,13 +530,13 @@ where
                     } else {
                         // Old "trace_transaction" api did not initialize block before applying transactions,
                         // so we need to do it here before calling "trace_transaction".
-                        api.initialize_block(parent_block_hash, &header)
+                        #[allow(deprecated)]
+                        api.initialize_block_before_version_5(parent_block_hash, &header)
                             .map_err(|e| {
                                 internal_err(format!("Runtime api access error: {:?}", e))
                             })?;
 
                         if trace_api_version == 4 {
-                            // Pre pallet-message-queue
                             #[allow(deprecated)]
                             api.trace_transaction_before_version_5(
                                 parent_block_hash,

--- a/vendor/rpc/trace/src/lib.rs
+++ b/vendor/rpc/trace/src/lib.rs
@@ -859,7 +859,7 @@ where
         // Trace the block.
         let f = || -> Result<_, String> {
             let result = if trace_api_version >= 5 {
-                // The block is initialized inside "trace_transaction"
+                // The block is initialized inside "trace_block"
                 api.trace_block(
                     substrate_parent_hash,
                     extrinsics,
@@ -869,7 +869,8 @@ where
             } else {
                 // Old "trace_block" api did not initialize block before applying transactions,
                 // so we need to do it here before calling "trace_block".
-                api.initialize_block(substrate_parent_hash, &block_header)
+                #[allow(deprecated)]
+                api.initialize_block_before_version_5(substrate_parent_hash, &block_header)
                     .map_err(|e| format!("Runtime api access error: {:?}", e))?;
 
                 #[allow(deprecated)]


### PR DESCRIPTION
**Pull Request Summary**

Fix EVM tracing for older runtimes.
https://github.com/paritytech/polkadot-sdk/pull/1781 updated `initialize_block` to return `ExtrinsicInclusionMode` so for old runtimes we need to call older `initialize_block_before_version_5`
