### PR TITLE
Re-enable on-chain-release-build flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,7 +259,7 @@ jobs:
       id: srtool_build
       uses: chevdor/srtool-actions@v0.8.0
       env:
-        needed to enable metadata hash generation
+        # needed to enable metadata hash generation
         BUILD_OPTS: "--features on-chain-release-build"
       with:
         chain: ${{ matrix.chain }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,9 +258,9 @@ jobs:
     - name: Srtool build
       id: srtool_build
       uses: chevdor/srtool-actions@v0.8.0
-      # env:
-        # needed to enable metadata hash generation
-        # BUILD_OPTS: "--features on-chain-release-build"
+      env:
+        needed to enable metadata hash generation
+        BUILD_OPTS: "--features on-chain-release-build"
       with:
         chain: ${{ matrix.chain }}
         runtime_dir: runtime/${{ matrix.chain }}


### PR DESCRIPTION
**Pull Request Summary**

The issue with improperly propagated _features_ isn't present in `polkadot-v1.11.0` so we can re-enable the feature `on-chain-release-build`.

Tested locally by building only runtimes (previously it didn't work).