### PR TITLE
Fix/local custom genesis account

### DIFF
--- a/runtime/local/src/genesis_config.rs
+++ b/runtime/local/src/genesis_config.rs
@@ -21,6 +21,7 @@ use astar_primitives::{
     evm::EVM_REVERT_CODE,
     genesis::{get_from_seed, GenesisAccount},
 };
+use sp_core::crypto::Ss58Codec;
 
 /// Provides the JSON representation of predefined genesis config for given `id`.
 pub fn get_preset(id: &sp_genesis_builder::PresetId) -> Option<Vec<u8>> {
@@ -52,6 +53,12 @@ pub fn default_config() -> serde_json::Value {
         ),
         (
             CommunityTreasuryPalletId::get().into_account_truncating(),
+            1_000_000_000 * AST,
+        ),
+        (
+            // Private key: 0x01ab6e801c06e59ca97a14fc0a1978b27fa366fc87450e0b65459dd3515b7391
+            // H160 public address: 0xaaafB3972B05630fCceE866eC69CdADd9baC2771
+            AccountId::from_ss58check("5FQedkNQcF2fJPwkB6Z1ZcMgGti4vcJQNs6x85YPv3VhjBBT").unwrap(),
             1_000_000_000 * AST,
         ),
     ];


### PR DESCRIPTION
**Pull Request Summary**

Return the custom local runtime genesis account that's actually used by the frontier RPC tests.