### PR TITLE
Fix clippy lints

### DIFF
--- a/pallets/collator-selection/src/mock.rs
+++ b/pallets/collator-selection/src/mock.rs
@@ -207,11 +207,7 @@ parameter_types! {
 pub struct IsRegistered;
 impl ValidatorRegistration<u64> for IsRegistered {
     fn is_registered(id: &u64) -> bool {
-        if *id == 7u64 {
-            false
-        } else {
-            true
-        }
+        *id != 7u64
     }
 }
 

--- a/pallets/dapp-staking/src/test/tests_types.rs
+++ b/pallets/dapp-staking/src/test/tests_types.rs
@@ -2913,7 +2913,6 @@ fn tier_configuration_basic_tests() {
             },
         ])
         .unwrap(),
-        ..TierParameters::default()
     };
     assert!(params.is_valid(), "Example params must be valid!");
 

--- a/pallets/vesting-mbm/src/mock.rs
+++ b/pallets/vesting-mbm/src/mock.rs
@@ -123,7 +123,7 @@ impl ExtBuilder {
 }
 
 pub fn new_test_ext() -> sp_io::TestExternalities {
-    ExtBuilder::default().build()
+    ExtBuilder.build()
 }
 
 #[allow(dead_code)]

--- a/precompiles/dispatch-lockdrop/src/tests.rs
+++ b/precompiles/dispatch-lockdrop/src/tests.rs
@@ -36,7 +36,7 @@ fn precompiles() -> TestPrecompileSet<TestRuntime> {
 
 #[test]
 fn dispatch_calls_on_behalf_of_lockdrop_works() {
-    ExtBuilder::default().build().execute_with(|| {
+    ExtBuilder.build().execute_with(|| {
         // Transfer balance to Alice
         let call = RuntimeCall::Balances(pallet_balances::Call::transfer_keep_alive {
             dest: ALICE,
@@ -73,7 +73,7 @@ fn dispatch_calls_on_behalf_of_lockdrop_works() {
 
 #[test]
 fn proper_gas_is_charged() {
-    ExtBuilder::default().build().execute_with(|| {
+    ExtBuilder.build().execute_with(|| {
         let call = RuntimeCall::Balances(pallet_balances::Call::transfer_keep_alive {
             dest: ALICE,
             value: 15 * ONE,
@@ -109,7 +109,7 @@ fn proper_gas_is_charged() {
 
 #[test]
 fn pubkey_does_not_match_caller_address() {
-    ExtBuilder::default().build().execute_with(|| {
+    ExtBuilder.build().execute_with(|| {
         // Transfer balance to Alice
         let call = RuntimeCall::Balances(pallet_balances::Call::transfer_keep_alive {
             dest: ALICE,
@@ -146,7 +146,7 @@ fn pubkey_does_not_match_caller_address() {
 
 #[test]
 fn pubkey_derive_to_proper_ss58() {
-    ExtBuilder::default().build().execute_with(|| {
+    ExtBuilder.build().execute_with(|| {
         // Transfer balance to Alice
         let call = RuntimeCall::Balances(pallet_balances::Call::transfer_keep_alive {
             dest: ALICE,
@@ -187,7 +187,7 @@ fn pubkey_derive_to_proper_ss58() {
 
 #[test]
 fn decode_limit_too_high() {
-    ExtBuilder::default().build().execute_with(|| {
+    ExtBuilder.build().execute_with(|| {
         let mut nested_call =
             RuntimeCall::System(frame_system::Call::remark { remark: Vec::new() });
 
@@ -224,7 +224,7 @@ fn decode_limit_too_high() {
 
 #[test]
 fn decode_limit_bounded() {
-    ExtBuilder::default().build().execute_with(|| {
+    ExtBuilder.build().execute_with(|| {
         let calls: Vec<_> = (0..681)
             .map(|_| RuntimeCall::System(frame_system::Call::remark { remark: Vec::new() }))
             .collect();
@@ -273,7 +273,7 @@ fn decode_limit_bounded() {
 
 #[test]
 fn decode_limit_ok() {
-    ExtBuilder::default().build().execute_with(|| {
+    ExtBuilder.build().execute_with(|| {
         let mut nested_call =
             RuntimeCall::System(frame_system::Call::remark { remark: Vec::new() });
 
@@ -309,7 +309,7 @@ fn decode_limit_ok() {
 
 #[test]
 fn only_whitelisted_calls_can_be_dispatched() {
-    ExtBuilder::default().build().execute_with(|| {
+    ExtBuilder.build().execute_with(|| {
         // Transfer balance to Alice
         let call = RuntimeCall::System(frame_system::Call::remark_with_event {
             remark: b"Hello World".to_vec(),

--- a/precompiles/sr25519/src/tests.rs
+++ b/precompiles/sr25519/src/tests.rs
@@ -29,7 +29,7 @@ fn precompiles() -> TestPrecompileSet<Runtime> {
 
 #[test]
 fn wrong_signature_length_returns_false() {
-    ExtBuilder::default().build().execute_with(|| {
+    ExtBuilder.build().execute_with(|| {
         let pair = sr25519::Pair::from_seed(b"12345678901234567890123456789012");
         let public = pair.public();
         let signature = hex!["0042"];
@@ -52,7 +52,7 @@ fn wrong_signature_length_returns_false() {
 
 #[test]
 fn bad_signature_returns_false() {
-    ExtBuilder::default().build().execute_with(|| {
+    ExtBuilder.build().execute_with(|| {
         let pair = sr25519::Pair::from_seed(b"12345678901234567890123456789012");
         let public = pair.public();
         let message = hex!("2f8c6129d816cf51c374bc7f08c3e63ed156cf78aefb4a6550d97b87997977ee00000000000000000200d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a4500000000000000");
@@ -78,7 +78,7 @@ fn bad_signature_returns_false() {
 
 #[test]
 fn substrate_test_vector_works() {
-    ExtBuilder::default().build().execute_with(|| {
+    ExtBuilder.build().execute_with(|| {
         let pair = sr25519::Pair::from_seed(b"12345678901234567890123456789012");
         let public = pair.public();
         assert_eq!(

--- a/precompiles/substrate-ecdsa/src/tests.rs
+++ b/precompiles/substrate-ecdsa/src/tests.rs
@@ -29,7 +29,7 @@ fn precompiles() -> TestPrecompileSet<Runtime> {
 
 #[test]
 fn wrong_signature_length_returns_false() {
-    ExtBuilder::default().build().execute_with(|| {
+    ExtBuilder.build().execute_with(|| {
         let pair = ecdsa::Pair::from_seed(b"12345678901234567890123456789012");
         let public = pair.public();
         let signature = hex!["0042"];
@@ -52,7 +52,7 @@ fn wrong_signature_length_returns_false() {
 
 #[test]
 fn bad_signature_returns_false() {
-    ExtBuilder::default().build().execute_with(|| {
+    ExtBuilder.build().execute_with(|| {
         let pair = ecdsa::Pair::from_seed(b"12345678901234567890123456789012");
         let public = pair.public();
         let message = hex!("2f8c6129d816cf51c374bc7f08c3e63ed156cf78aefb4a6550d97b87997977ee00000000000000000200d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a4500000000000000");
@@ -78,7 +78,7 @@ fn bad_signature_returns_false() {
 
 #[test]
 fn substrate_test_vector_works() {
-    ExtBuilder::default().build().execute_with(|| {
+    ExtBuilder.build().execute_with(|| {
         let pair = ecdsa::Pair::from_seed(&hex!(
             "1d2187216832d1ee14be2e677f9e3ebceca715510ba1460a20d6fce07ba36b1e"
         ));

--- a/precompiles/unified-accounts/src/tests.rs
+++ b/precompiles/unified-accounts/src/tests.rs
@@ -29,7 +29,7 @@ fn precompiles() -> TestPrecompileSet<TestRuntime> {
 #[test]
 fn test_get_evm_address() {
     // Case 1 : Address Not Mapped
-    ExtBuilder::default().build().execute_with(|| {
+    ExtBuilder.build().execute_with(|| {
         let alice_default_evm =
             <TestRuntime as pallet_unified_accounts::Config>::DefaultMappings::to_default_h160(
                 &ALICE,
@@ -49,7 +49,7 @@ fn test_get_evm_address() {
     });
 
     // Case 2 : Address Mapped
-    ExtBuilder::default().build().execute_with(|| {
+    ExtBuilder.build().execute_with(|| {
         let alice_eth = UnifiedAccounts::eth_address(&alice_secret());
         let signature = get_evm_signature(&ALICE, &alice_secret());
 
@@ -77,7 +77,7 @@ fn test_get_evm_address() {
 #[test]
 fn test_get_native_address() {
     // Case 1: not mapped native address (default address)
-    ExtBuilder::default().build().execute_with(|| {
+    ExtBuilder.build().execute_with(|| {
         let alice_eth = UnifiedAccounts::eth_address(&alice_secret());
         let alice_eth_address: Address = alice_eth.into();
 
@@ -101,7 +101,7 @@ fn test_get_native_address() {
     });
 
     // Case 2 : mapped address
-    ExtBuilder::default().build().execute_with(|| {
+    ExtBuilder.build().execute_with(|| {
         // claiming address
         let alice_eth: Address = UnifiedAccounts::eth_address(&alice_secret()).into();
         let signature = get_evm_signature(&ALICE, &alice_secret());

--- a/precompiles/xcm/src/tests.rs
+++ b/precompiles/xcm/src/tests.rs
@@ -34,7 +34,7 @@ mod xcm_old_interface_test {
     use super::*;
     #[test]
     fn wrong_assets_len_or_fee_index_reverts() {
-        ExtBuilder::default().build().execute_with(|| {
+        ExtBuilder.build().execute_with(|| {
             precompiles()
                 .prepare_test(
                     TestAccount::Alice,
@@ -74,7 +74,7 @@ mod xcm_old_interface_test {
 
     #[test]
     fn sanity_checks_for_parameters() {
-        ExtBuilder::default().build().execute_with(|| {
+        ExtBuilder.build().execute_with(|| {
             // parachain id resolution failure
             precompiles()
                 .prepare_test(
@@ -128,7 +128,7 @@ mod xcm_old_interface_test {
 
     #[test]
     fn assets_withdraw_works() {
-        ExtBuilder::default().build().execute_with(|| {
+        ExtBuilder.build().execute_with(|| {
             // SS58
             precompiles()
                 .prepare_test(
@@ -184,7 +184,7 @@ mod xcm_old_interface_test {
 
     #[test]
     fn remote_transact_works() {
-        ExtBuilder::default().build().execute_with(|| {
+        ExtBuilder.build().execute_with(|| {
             // SS58
             precompiles()
                 .prepare_test(
@@ -206,7 +206,7 @@ mod xcm_old_interface_test {
 
     #[test]
     fn reserve_transfer_assets_works() {
-        ExtBuilder::default().build().execute_with(|| {
+        ExtBuilder.build().execute_with(|| {
             // SS58
             precompiles()
                 .prepare_test(
@@ -283,7 +283,7 @@ mod xcm_old_interface_test {
 
     #[test]
     fn reserve_transfer_currency_works() {
-        ExtBuilder::default().build().execute_with(|| {
+        ExtBuilder.build().execute_with(|| {
             precompiles()
                 .prepare_test(
                     TestAccount::Alice,
@@ -358,7 +358,7 @@ mod xcm_old_interface_test {
 
     #[test]
     fn test_send_clear_origin() {
-        ExtBuilder::default().build().execute_with(|| {
+        ExtBuilder.build().execute_with(|| {
             let dest: Location = Location {
                 parents: 1,
                 interior: AccountId32 {
@@ -396,7 +396,7 @@ mod xcm_new_interface_test {
     fn xtokens_transfer_works() {
         let weight = WeightV2::from(3_000_000_000u64, 1024);
 
-        ExtBuilder::default().build().execute_with(|| {
+        ExtBuilder.build().execute_with(|| {
             let parent_destination = Location {
                 parents: 1,
                 interior: Junctions::from(Junction::AccountId32 {
@@ -489,7 +489,7 @@ mod xcm_new_interface_test {
             }),
         };
 
-        ExtBuilder::default().build().execute_with(|| {
+        ExtBuilder.build().execute_with(|| {
             // sending native token to relay
             precompiles()
                 .prepare_test(
@@ -525,7 +525,7 @@ mod xcm_new_interface_test {
     #[test]
     fn xtokens_transfer_with_fee_works() {
         let weight = WeightV2::from(3_000_000_000u64, 1024);
-        ExtBuilder::default().build().execute_with(|| {
+        ExtBuilder.build().execute_with(|| {
             let parent_destination = Location {
                 parents: 1,
                 interior: Junctions::from(Junction::AccountId32 {
@@ -582,7 +582,7 @@ mod xcm_new_interface_test {
             }),
         };
 
-        ExtBuilder::default().build().execute_with(|| {
+        ExtBuilder.build().execute_with(|| {
             // sending native token to relay
             precompiles()
                 .prepare_test(
@@ -622,7 +622,7 @@ mod xcm_new_interface_test {
     #[test]
     fn transfer_multiasset_works() {
         let weight = WeightV2::from(3_000_000_000u64, 1024);
-        ExtBuilder::default().build().execute_with(|| {
+        ExtBuilder.build().execute_with(|| {
             let relay_token_location = Location {
                 parents: 1,
                 interior: Junctions::Here,
@@ -771,7 +771,7 @@ mod xcm_new_interface_test {
         ]
         .into();
 
-        ExtBuilder::default().build().execute_with(|| {
+        ExtBuilder.build().execute_with(|| {
             precompiles()
                 .prepare_test(
                     TestAccount::Alice,
@@ -837,7 +837,7 @@ mod xcm_new_interface_test {
         ]
         .into();
 
-        ExtBuilder::default().build().execute_with(|| {
+        ExtBuilder.build().execute_with(|| {
             precompiles()
                 .prepare_test(
                     TestAccount::Alice,
@@ -887,7 +887,7 @@ mod xcm_new_interface_test {
         ])
         .unwrap();
 
-        ExtBuilder::default().build().execute_with(|| {
+        ExtBuilder.build().execute_with(|| {
             precompiles()
                 .prepare_test(
                     TestAccount::Alice,
@@ -944,7 +944,7 @@ mod xcm_new_interface_test {
         ]
         .into();
 
-        ExtBuilder::default().build().execute_with(|| {
+        ExtBuilder.build().execute_with(|| {
             precompiles()
                 .prepare_test(
                     TestAccount::Alice,

--- a/tests/xcm-simulator/src/mocks/msg_queue.rs
+++ b/tests/xcm-simulator/src/mocks/msg_queue.rs
@@ -146,7 +146,7 @@ pub mod mock_msg_queue {
                 let _ = XcmpMessageFormat::decode(&mut data_ref)
                     .expect("Simulator encodes with versioned xcm format; qed");
 
-                let mut remaining_fragments = &data_ref[..];
+                let mut remaining_fragments = data_ref;
                 while !remaining_fragments.is_empty() {
                     if let Ok(xcm) =
                         VersionedXcm::<T::RuntimeCall>::decode(&mut remaining_fragments)


### PR DESCRIPTION
**Pull Request Summary**
A small change set to fix the clippy lints.
There is one more warning
```
warning: lint `clippy::clone_double_ref` has been renamed to `suspicious_double_ref_op`
  |
  = help: use the new name `suspicious_double_ref_op`
  = note: requested on the command line with `-A clippy::clone_double_ref`
  = note: `#[warn(renamed_and_removed_lints)]` on by default
```

Mostly coming from upstream I think since I couldn't find it in our repo.

**Check list**
- [ ] added or updated unit tests
- [ ] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [ ] added benchmarks & weights for any modified runtime logics.
