### PR TITLE
Runtime-1000 release prep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "astar-runtime"
-version = "5.44.0"
+version = "5.45.0"
 dependencies = [
  "array-bytes",
  "astar-primitives",
@@ -14309,7 +14309,7 @@ dependencies = [
 
 [[package]]
 name = "shibuya-runtime"
-version = "5.44.0"
+version = "5.45.0"
 dependencies = [
  "array-bytes",
  "astar-primitives",
@@ -14431,7 +14431,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "5.44.0"
+version = "5.45.0"
 dependencies = [
  "array-bytes",
  "astar-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6481,7 +6481,7 @@ dependencies = [
 
 [[package]]
 name = "local-runtime"
-version = "5.44.0"
+version = "5.45.0"
 dependencies = [
  "array-bytes",
  "astar-primitives",

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-runtime"
-version = "5.44.0"
+version = "5.45.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -175,7 +175,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("astar"),
     impl_name: create_runtime_str!("astar"),
     authoring_version: 1,
-    spec_version: 95,
+    spec_version: 1000,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,

--- a/runtime/local/Cargo.toml
+++ b/runtime/local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local-runtime"
-version = "5.44.0"
+version = "5.45.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "5.44.0"
+version = "5.45.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -207,7 +207,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shibuya"),
     impl_name: create_runtime_str!("shibuya"),
     authoring_version: 1,
-    spec_version: 137,
+    spec_version: 1000,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "5.44.0"
+version = "5.45.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -177,7 +177,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("shiden"),
     impl_name: create_runtime_str!("shiden"),
     authoring_version: 1,
-    spec_version: 134,
+    spec_version: 1000,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,


### PR DESCRIPTION
### Summary

Prepare for the first runtime release.
Spec versions are bumped according to the new versioning schema.

Crates are bumped as well, but this might need to be revised later on since it might make things more confusing due to the overlap with the client version.