### PR TITLE
1364-integrate-tx-pause-safe-mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,11 +23,11 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "gimli 0.31.0",
+ "gimli 0.31.1",
 ]
 
 [[package]]
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -146,43 +146,43 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.87"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
+checksum = "74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13"
 
 [[package]]
 name = "approx"
@@ -204,7 +204,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -344,9 +344,9 @@ checksum = "5d5dde061bd34119e902bbb2d9b90c5692635cf59fb91d582c2b68043f1b8293"
 
 [[package]]
 name = "arrayref"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -415,7 +415,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "synstructure 0.13.1",
 ]
 
@@ -438,7 +438,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "astar-collator"
-version = "5.45.0"
+version = "5.44.0"
 dependencies = [
  "astar-primitives",
  "astar-runtime",
@@ -499,7 +499,7 @@ dependencies = [
  "frame-system",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
- "futures 0.3.30",
+ "futures 0.3.31",
  "jsonrpsee",
  "local-runtime",
  "log",
@@ -785,7 +785,7 @@ dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand 2.1.1",
- "futures-lite 2.3.0",
+ "futures-lite 2.4.0",
  "slab",
 ]
 
@@ -831,10 +831,10 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.3.0",
+ "futures-lite 2.4.0",
  "parking",
  "polling 3.7.3",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -884,7 +884,7 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "windows-sys 0.48.0",
 ]
 
@@ -900,7 +900,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -914,13 +914,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -929,7 +929,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "pharos",
  "rustc_version 0.4.1",
 ]
@@ -989,14 +989,14 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
@@ -1004,11 +1004,11 @@ version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
- "addr2line 0.24.1",
+ "addr2line 0.24.2",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.36.4",
+ "object 0.36.5",
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
@@ -1067,7 +1067,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "hash-db",
  "log",
@@ -1094,22 +1094,22 @@ dependencies = [
  "lazy_static",
  "lazycell",
  "peeking_take_while",
- "prettyplease 0.2.22",
+ "prettyplease 0.2.25",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "bip39"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
+checksum = "33415e24172c1b7d6066f6d999545375ab8e1d95421d6784bdfff9496f292387"
 dependencies = [
- "bitcoin_hashes 0.11.0",
+ "bitcoin_hashes",
 ]
 
 [[package]]
@@ -1117,12 +1117,6 @@ name = "bitcoin-internals"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90064b8dee6815a6470d60bad07bbbaee885c0e12d04177138fa3291a01b7bc4"
 
 [[package]]
 name = "bitcoin_hashes"
@@ -1252,15 +1246,15 @@ dependencies = [
  "async-channel 2.3.1",
  "async-task",
  "futures-io",
- "futures-lite 2.3.0",
+ "futures-lite 2.4.0",
  "piper",
 ]
 
 [[package]]
 name = "bounded-collections"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32385ecb91a31bddaf908e8dcf4a15aef1bcd3913cc03ebfad02ff6d568abc1"
+checksum = "db436177db0d505b1507f03aca56a41442ae6efdf8b6eaa855d73e52c5b078dc"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -1280,7 +1274,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.14.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1311,7 +1305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
 dependencies = [
  "memchr",
- "regex-automata 0.4.7",
+ "regex-automata 0.4.8",
  "serde",
 ]
 
@@ -1344,9 +1338,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
 
 [[package]]
 name = "byteorder"
@@ -1356,9 +1350,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 dependencies = [
  "serde",
 ]
@@ -1438,9 +1432,9 @@ checksum = "fd6c0e7b807d60291f42f33f58480c0bfafe28ed08286446f45e463728cf9c1c"
 
 [[package]]
 name = "cc"
-version = "1.1.18"
+version = "1.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
+checksum = "67b9470d453346108f93a59222a9a1a5724db32d0a4727b7ab7ace4b4d822dc9"
 dependencies = [
  "jobserver",
  "libc",
@@ -1590,9 +1584,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1600,9 +1594,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1613,14 +1607,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1704,9 +1698,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "combine"
@@ -1759,9 +1753,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8a24a26d37e1ffd45343323dc9fe6654ceea44c12f2fcb3d7ac29e610bc6"
+checksum = "0121754e84117e65f9d90648ee6aa4882a6e63110307ab73967a4c5e7e69e586"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2090,7 +2084,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -2107,12 +2101,12 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
  "cumulus-primitives-core",
- "futures 0.3.30",
+ "futures 0.3.31",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "polkadot-node-primitives",
@@ -2130,7 +2124,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.17.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -2140,7 +2134,7 @@ dependencies = [
  "cumulus-primitives-aura",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
- "futures 0.3.30",
+ "futures 0.3.31",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "polkadot-node-primitives",
@@ -2175,14 +2169,14 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "dyn-clone",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "parity-scale-codec",
  "polkadot-primitives",
@@ -2205,7 +2199,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2220,13 +2214,13 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
- "futures 0.3.30",
+ "futures 0.3.31",
  "parking_lot 0.12.3",
  "sc-consensus",
  "sp-api",
@@ -2243,11 +2237,11 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -2269,7 +2263,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.11.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2291,12 +2285,12 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -2317,7 +2311,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -2329,7 +2323,7 @@ dependencies = [
  "cumulus-relay-chain-inprocess-interface",
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-minimal-node",
- "futures 0.3.30",
+ "futures 0.3.31",
  "polkadot-primitives",
  "sc-client-api",
  "sc-consensus",
@@ -2354,7 +2348,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -2371,7 +2365,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.16.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2407,18 +2401,18 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2433,7 +2427,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.16.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -2458,7 +2452,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2471,7 +2465,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2487,7 +2481,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2503,7 +2497,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2513,7 +2507,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.16.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2532,12 +2526,12 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "polkadot-cli",
  "polkadot-service",
@@ -2556,11 +2550,11 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
- "futures 0.3.30",
+ "futures 0.3.31",
  "jsonrpsee-core",
  "parity-scale-codec",
  "polkadot-overseer",
@@ -2575,14 +2569,14 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "array-bytes",
  "async-trait",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-rpc-interface",
- "futures 0.3.30",
+ "futures 0.3.31",
  "polkadot-core-primitives",
  "polkadot-network-bridge",
  "polkadot-node-network-protocol",
@@ -2610,13 +2604,13 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "either",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "jsonrpsee",
  "parity-scale-codec",
@@ -2649,7 +2643,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -2683,7 +2677,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2701,9 +2695,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.128"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ccead7d199d584d139148b04b4a368d1ec7556a1d9ea2548febb1b9d49f9a4"
+checksum = "cbdc8cca144dce1c4981b5c9ab748761619979e515c3d53b5df385c677d1d007"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -2713,9 +2707,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.128"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77953e99f01508f89f55c494bfa867171ef3a6c8cea03d26975368f2121a5c1"
+checksum = "c5764c3142ab44fcf857101d12c0ddf09c34499900557c764f5ad0597159d1fc"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -2723,24 +2717,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.128"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65777e06cc48f0cb0152024c77d6cf9e4bdb4408e7b48bea993d42fa0f5b02b6"
+checksum = "d422aff542b4fa28c2ce8e5cc202d42dbf24702345c1fba3087b2d3f8a1b90ff"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.128"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98532a60dedaebc4848cb2cba5023337cc9ea3af16a5b062633fabfd9f18fb60"
+checksum = "a1719100f31492cd6adeeab9a0f46cdbc846e615fdb66d7b398aa46ec7fdd06f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2857,7 +2851,7 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2870,7 +2864,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.77",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2959,23 +2973,23 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "docify"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2f138ad521dc4a2ced1a4576148a6a610b4c5923933b062a263130a6802ce"
+checksum = "a772b62b1837c8f060432ddcc10b17aae1453ef17617a99bc07789252d2a5896"
 dependencies = [
  "docify_macros",
 ]
 
 [[package]]
 name = "docify_macros"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a081e51fb188742f5a7a1164ad752121abcb22874b21e2c3b0dd040c515fdad"
+checksum = "60e6be249b0a462a14784a99b19bf35a667bb5e09de611738bb7362fa4c95ff7"
 dependencies = [
  "common-path",
  "derive-syn-parse",
@@ -2983,7 +2997,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.77",
+ "syn 2.0.87",
  "termcolor",
  "toml 0.8.19",
  "walkdir",
@@ -3129,9 +3143,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
@@ -3175,7 +3189,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3195,7 +3209,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3206,7 +3220,7 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3401,13 +3415,13 @@ dependencies = [
  "dunce",
  "ethers-core",
  "eyre",
- "prettyplease 0.2.22",
+ "prettyplease 0.2.25",
  "proc-macro2",
  "quote",
  "regex",
  "serde",
  "serde_json",
- "syn 2.0.77",
+ "syn 2.0.87",
  "toml 0.8.19",
  "walkdir",
 ]
@@ -3425,7 +3439,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3451,7 +3465,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.26.3",
- "syn 2.0.77",
+ "syn 2.0.87",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -3655,7 +3669,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e43f2f1833d64e33f15592464d6fdd70f349dda7b1a53088eb83cd94014008c5"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
 ]
 
 [[package]]
@@ -3667,10 +3681,10 @@ dependencies = [
  "blake2 0.10.6",
  "file-guard",
  "fs-err",
- "prettyplease 0.2.22",
+ "prettyplease 0.2.25",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3733,11 +3747,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb42427514b063d97ce21d5199f36c0c307d981434a6be32582bc79fe5bd2303"
 dependencies = [
  "expander",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3798,7 +3812,7 @@ dependencies = [
  "fc-storage",
  "fp-consensus",
  "fp-rpc",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "log",
  "parking_lot 0.12.3",
@@ -3825,7 +3839,7 @@ dependencies = [
  "fp-evm",
  "fp-rpc",
  "fp-storage",
- "futures 0.3.30",
+ "futures 0.3.31",
  "hex",
  "jsonrpsee",
  "libsecp256k1",
@@ -3961,7 +3975,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36530797b9bf31cd4ff126dcfee8170f86b00cfdcea3269d73133cc0415945c3"
 dependencies = [
  "either",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "log",
  "num-traits",
@@ -4027,7 +4041,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4154,7 +4168,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -4178,7 +4192,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "42.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -4228,18 +4242,18 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "14.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "frame-election-provider-support"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -4255,7 +4269,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -4285,7 +4299,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.5.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "array-bytes",
  "docify",
@@ -4300,7 +4314,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "37.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -4341,7 +4355,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "30.0.4"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4354,35 +4368,35 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "frame-system"
 version = "37.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "cfg-if",
  "docify",
@@ -4402,7 +4416,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4416,7 +4430,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -4426,7 +4440,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4459,7 +4473,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f9df8a11882c4e3335eb2d18a0137c505d9ca927470b0cac9c6f0ae07d28f7"
 dependencies = [
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "windows-sys 0.48.0",
 ]
 
@@ -4477,9 +4491,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4502,9 +4516,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -4512,15 +4526,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -4530,9 +4544,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -4551,9 +4565,9 @@ dependencies = [
 
 [[package]]
 name = "futures-lite"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+checksum = "3f1fa2f9765705486b33fd2acf1577f8ec449c2ba1f318ae5447697b7c08d210"
 dependencies = [
  "fastrand 2.1.1",
  "futures-core",
@@ -4574,13 +4588,13 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4595,15 +4609,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-timer"
@@ -4617,9 +4631,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures 0.1.31",
  "futures-channel",
@@ -4727,9 +4741,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
@@ -4757,7 +4771,7 @@ checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
 dependencies = [
  "cfg-if",
  "dashmap",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "no-std-compat",
  "nonzero_ext",
@@ -4792,7 +4806,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -4811,7 +4825,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -5073,9 +5087,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -5091,9 +5105,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
+version = "0.14.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -5115,9 +5129,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -5141,7 +5155,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "log",
  "rustls 0.21.12",
  "rustls-native-certs 0.6.3",
@@ -5151,15 +5165,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "pin-project-lite",
  "tokio",
  "tower-service",
@@ -5167,9 +5181,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -5186,6 +5200,124 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5211,12 +5343,23 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -5238,7 +5381,7 @@ dependencies = [
  "async-io 2.3.4",
  "core-foundation",
  "fnv",
- "futures 0.3.30",
+ "futures 0.3.31",
  "if-addrs",
  "ipnet",
  "log",
@@ -5257,9 +5400,9 @@ dependencies = [
  "async-trait",
  "attohttpc",
  "bytes",
- "futures 0.3.30",
+ "futures 0.3.31",
  "http 0.2.12",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "log",
  "rand",
  "tokio",
@@ -5343,12 +5486,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
 ]
 
 [[package]]
@@ -5483,9 +5626,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is-terminal"
@@ -5500,9 +5643,9 @@ dependencies = [
 
 [[package]]
 name = "is_executable"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba3d8548b8b04dafdf2f4cc6f5e379db766d0a6d9aac233ad4c9a92ea892233"
+checksum = "d4a1b5bad6f9072935961dfbf1cced2f3d129963d091b6f69f007fe04e758ae2"
 dependencies = [
  "winapi",
 ]
@@ -5577,9 +5720,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -5610,7 +5753,7 @@ dependencies = [
  "http 1.1.0",
  "jsonrpsee-core",
  "pin-project",
- "rustls 0.23.13",
+ "rustls 0.23.16",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto 0.8.0",
@@ -5660,7 +5803,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5674,7 +5817,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -5733,9 +5876,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -5822,9 +5965,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libloading"
@@ -5838,9 +5981,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libp2p"
@@ -5850,7 +5993,7 @@ checksum = "e94495eb319a85b70a68b85e2389a95bb3555c71c49025b78c691a854a7e6464"
 dependencies = [
  "bytes",
  "either",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "getrandom",
  "instant",
@@ -5911,13 +6054,13 @@ checksum = "dd44289ab25e4c9230d9246c475a22241e301b23e8f4061d3bdef304a1a99713"
 dependencies = [
  "either",
  "fnv",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "instant",
  "libp2p-identity",
  "log",
  "multiaddr 0.18.2",
- "multihash 0.19.1",
+ "multihash 0.19.2",
  "multistream-select",
  "once_cell",
  "parking_lot 0.12.3",
@@ -5938,7 +6081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6a18db73084b4da2871438f6239fef35190b05023de7656e877c18a00541a3b"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "libp2p-core",
  "libp2p-identity",
  "log",
@@ -5955,7 +6098,7 @@ checksum = "45a96638a0a176bec0a4bcaebc1afa8cf909b114477209d7456ade52c61cd9cd"
 dependencies = [
  "asynchronous-codec",
  "either",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-bounded",
  "futures-timer",
  "libp2p-core",
@@ -5979,7 +6122,7 @@ dependencies = [
  "bs58 0.5.1",
  "ed25519-dalek",
  "hkdf",
- "multihash 0.19.1",
+ "multihash 0.19.2",
  "quick-protobuf",
  "rand",
  "sha2 0.10.8",
@@ -5999,7 +6142,7 @@ dependencies = [
  "bytes",
  "either",
  "fnv",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "instant",
  "libp2p-core",
@@ -6024,7 +6167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a2567c305232f5ef54185e9604579a894fd0674819402bb0ac0246da82f52a"
 dependencies = [
  "data-encoding",
- "futures 0.3.30",
+ "futures 0.3.31",
  "if-watch",
  "libp2p-core",
  "libp2p-identity",
@@ -6063,12 +6206,12 @@ checksum = "d2eeec39ad3ad0677551907dd304b2f13f17208ccebe333bef194076cd2e8921"
 dependencies = [
  "bytes",
  "curve25519-dalek",
- "futures 0.3.30",
+ "futures 0.3.31",
  "libp2p-core",
  "libp2p-identity",
  "log",
  "multiaddr 0.18.2",
- "multihash 0.19.1",
+ "multihash 0.19.2",
  "once_cell",
  "quick-protobuf",
  "rand",
@@ -6087,7 +6230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e702d75cd0827dfa15f8fd92d15b9932abe38d10d21f47c50438c71dd1b5dae3"
 dependencies = [
  "either",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "instant",
  "libp2p-core",
@@ -6105,7 +6248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "130d451d83f21b81eb7b35b360bc7972aeafb15177784adc56528db082e6b927"
 dependencies = [
  "bytes",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "if-watch",
  "libp2p-core",
@@ -6129,7 +6272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8e3b4d67870478db72bac87bfc260ee6641d0734e0e3e275798f089c3fecfd4"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "instant",
  "libp2p-core",
  "libp2p-identity",
@@ -6148,7 +6291,7 @@ checksum = "580189e0074af847df90e75ef54f3f30059aedda37ea5a1659e8b9fca05c0141"
 dependencies = [
  "either",
  "fnv",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "instant",
  "libp2p-core",
@@ -6173,7 +6316,7 @@ dependencies = [
  "proc-macro-warning 0.4.2",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6182,7 +6325,7 @@ version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b558dd40d1bcd1aaaed9de898e9ec6a436019ecc2420dd0016e712fbb61c5508"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "if-watch",
  "libc",
@@ -6199,7 +6342,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8218d1d5482b122ccae396bbf38abdcb283ecc96fa54760e1dfd251f0546ac61"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-rustls",
  "libp2p-core",
  "libp2p-identity",
@@ -6218,7 +6361,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82775a47b34f10f787ad3e2a22e2c1541e6ebef4fe9f28f3ac553921554c94c1"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "igd-next",
  "libp2p-core",
@@ -6234,7 +6377,7 @@ version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e5d8e3a9e07da0ef5b55a9f26c009c8fb3c725d492d8bb4b431715786eea79c"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "js-sys",
  "libp2p-core",
  "send_wrapper 0.6.0",
@@ -6249,7 +6392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "004ee9c4a4631435169aee6aad2f62e3984dc031c43b6d29731e8e82a016c538"
 dependencies = [
  "either",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-rustls",
  "libp2p-core",
  "libp2p-identity",
@@ -6269,7 +6412,7 @@ version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eedcb62824c4300efb9cfd4e2a6edaf3ca097b9e68b36dabe45a44469fd6a85"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "libp2p-core",
  "log",
  "thiserror",
@@ -6284,7 +6427,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall 0.5.7",
 ]
 
 [[package]]
@@ -6387,9 +6530,9 @@ dependencies = [
 
 [[package]]
 name = "linregress"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de04dcecc58d366391f9920245b85ffa684558a5ef6e7736e754347c3aea9c2"
+checksum = "a9eda9dcf4f2a99787827661f312ac3219292549c2ee992bf9a6248ffb066bf7"
 dependencies = [
  "nalgebra",
 ]
@@ -6425,6 +6568,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+
+[[package]]
 name = "litep2p"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6435,10 +6584,10 @@ dependencies = [
  "bytes",
  "cid 0.10.1",
  "ed25519-dalek",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "hex-literal",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "libc",
  "mockall 0.12.1",
  "multiaddr 0.17.1",
@@ -6609,19 +6758,18 @@ dependencies = [
 
 [[package]]
 name = "lz4"
-version = "1.26.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958b4caa893816eea05507c20cfe47574a43d9a697138a7872990bba8a0ece68"
+checksum = "4d1febb2b4a79ddd1980eede06a8f7902197960aa0383ffcfdd62fe723036725"
 dependencies = [
- "libc",
  "lz4-sys",
 ]
 
 [[package]]
 name = "lz4-sys"
-version = "1.10.0"
+version = "1.11.1+lz4-1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109de74d5d2353660401699a4174a4ff23fcc649caf553df71933c7fb45ad868"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
 dependencies = [
  "cc",
  "libc",
@@ -6645,7 +6793,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6659,7 +6807,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6670,7 +6818,7 @@ checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6681,7 +6829,7 @@ checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6727,7 +6875,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix 0.38.37",
+ "rustix 0.38.38",
 ]
 
 [[package]]
@@ -6741,9 +6889,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
 dependencies = [
  "libc",
 ]
@@ -6798,7 +6946,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69672161530e8aeca1d1400fbf3f1a1747ff60ea604265a4e906c2442df20532"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "rand",
  "thrift",
 ]
@@ -6864,9 +7012,9 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "parity-scale-codec",
  "sc-client-api",
@@ -6883,7 +7031,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -6946,7 +7094,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7002,7 +7150,7 @@ dependencies = [
  "ethereum",
  "ethereum-types",
  "fc-rpc-core",
- "futures 0.3.30",
+ "futures 0.3.31",
  "jsonrpsee",
  "moonbeam-client-evm-tracing",
  "moonbeam-rpc-core-types",
@@ -7016,7 +7164,7 @@ name = "moonbeam-rpc-core-trace"
 version = "0.6.0"
 dependencies = [
  "ethereum-types",
- "futures 0.3.30",
+ "futures 0.3.31",
  "jsonrpsee",
  "moonbeam-client-evm-tracing",
  "moonbeam-rpc-core-types",
@@ -7058,7 +7206,7 @@ dependencies = [
  "fc-rpc-core",
  "fc-storage",
  "fp-rpc",
- "futures 0.3.30",
+ "futures 0.3.31",
  "hex-literal",
  "jsonrpsee",
  "moonbeam-client-evm-tracing",
@@ -7117,7 +7265,7 @@ dependencies = [
  "fc-rpc-core",
  "fc-storage",
  "fp-rpc",
- "futures 0.3.30",
+ "futures 0.3.31",
  "jsonrpsee",
  "log",
  "moonbeam-client-evm-tracing",
@@ -7199,7 +7347,7 @@ dependencies = [
  "data-encoding",
  "libp2p-identity",
  "multibase",
- "multihash 0.19.1",
+ "multihash 0.19.2",
  "percent-encoding",
  "serde",
  "static_assertions",
@@ -7254,12 +7402,12 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076d548d76a0e2a0d4ab471d0b1c36c577786dfc4471242035d97a12a735c492"
+checksum = "cc41f430805af9d1cf4adae4ed2149c759b877b01d909a1f40256188d09345d2"
 dependencies = [
  "core2",
- "unsigned-varint 0.7.2",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -7295,7 +7443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
 dependencies = [
  "bytes",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "pin-project",
  "smallvec",
@@ -7304,29 +7452,17 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.32.6"
+version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
+checksum = "26aecdf64b707efd1310e3544d709c5c0ac61c13756046aaaba41be5c4f66a3b"
 dependencies = [
  "approx",
  "matrixmultiply",
- "nalgebra-macros",
  "num-complex",
  "num-rational",
  "num-traits",
  "simba",
  "typenum",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.77",
 ]
 
 [[package]]
@@ -7389,7 +7525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65b4b14489ab424703c092062176d52ba55485a89c076b4f9db05092b7223aa6"
 dependencies = [
  "bytes",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "netlink-packet-core",
  "netlink-sys",
@@ -7404,7 +7540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416060d346fbaf1f23f9512963e3e878f1a78e707cb699ba9215761754244307"
 dependencies = [
  "bytes",
- "futures 0.3.30",
+ "futures 0.3.31",
  "libc",
  "log",
  "tokio",
@@ -7554,7 +7690,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7657,7 +7793,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7683,9 +7819,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
@@ -7710,9 +7846,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opaque-debug"
@@ -7753,9 +7889,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -7774,7 +7910,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7785,18 +7921,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.3.2+3.3.2"
+version = "300.4.0+3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a211a18d945ef7e648cc6e0058f4c548ee46aab922ea203e0d30e966ea23647b"
+checksum = "a709e02f2b4aca747929cca5ed248880847c650233cf8b8cdc48f40aaf4898a6"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
@@ -7819,7 +7955,7 @@ checksum = "41f6bbacc8c189a3f2e45e0fd0436e5d97f194db888e721bdbc3973e7dbed4c2"
 dependencies = [
  "async-trait",
  "dyn-clonable",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "orchestra-proc-macro",
  "pin-project",
@@ -7835,7 +7971,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7b1d40dd8f367db3c65bec8d3dd47d4a604ee8874480738f93191bddab4e0e0"
 dependencies = [
  "expander",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "itertools 0.11.0",
  "petgraph",
  "proc-macro-crate 3.2.0",
@@ -7951,7 +8087,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-asset-conversion"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7969,7 +8105,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7983,7 +8119,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8000,7 +8136,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8016,7 +8152,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8032,7 +8168,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8047,7 +8183,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8060,7 +8196,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8083,7 +8219,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "aquamarine",
  "docify",
@@ -8104,7 +8240,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8119,7 +8255,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8138,7 +8274,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -8162,7 +8298,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8179,7 +8315,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8239,7 +8375,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8283,7 +8419,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8302,7 +8438,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8338,7 +8474,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "bitflags 1.3.2",
  "environmental",
@@ -8371,17 +8507,17 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "23.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "pallet-contracts-uapi"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -8393,7 +8529,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8432,7 +8568,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8445,7 +8581,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8482,7 +8618,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8504,7 +8640,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8517,7 +8653,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8617,7 +8753,7 @@ dependencies = [
 name = "pallet-evm-precompile-assets-erc20"
 version = "0.5.2"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.18",
  "fp-evm",
  "frame-support",
  "frame-system",
@@ -8663,7 +8799,7 @@ version = "0.1.0"
 dependencies = [
  "assert_matches",
  "astar-primitives",
- "derive_more",
+ "derive_more 0.99.18",
  "fp-evm",
  "frame-support",
  "frame-system",
@@ -8764,7 +8900,7 @@ dependencies = [
 name = "pallet-evm-precompile-sr25519"
 version = "1.2.1"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.18",
  "fp-evm",
  "frame-support",
  "frame-system",
@@ -8789,7 +8925,7 @@ name = "pallet-evm-precompile-substrate-ecdsa"
 version = "1.2.2"
 dependencies = [
  "assert_matches",
- "derive_more",
+ "derive_more 0.99.18",
  "fp-evm",
  "frame-support",
  "frame-system",
@@ -8814,7 +8950,7 @@ name = "pallet-evm-precompile-unified-accounts"
 version = "0.1.0"
 dependencies = [
  "astar-primitives",
- "derive_more",
+ "derive_more 0.99.18",
  "ethers",
  "fp-evm",
  "frame-support",
@@ -8844,7 +8980,7 @@ version = "0.11.0"
 dependencies = [
  "assert_matches",
  "astar-primitives",
- "derive_more",
+ "derive_more 0.99.18",
  "fp-evm",
  "frame-support",
  "frame-system",
@@ -8877,7 +9013,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8895,7 +9031,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8917,7 +9053,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -8933,7 +9069,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8952,7 +9088,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8987,7 +9123,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9000,7 +9136,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9016,7 +9152,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9035,7 +9171,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "7.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9052,7 +9188,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9069,7 +9205,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9084,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9099,7 +9235,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9117,7 +9253,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9137,7 +9273,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "32.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -9147,7 +9283,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9163,7 +9299,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9186,7 +9322,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9203,7 +9339,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9241,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9255,7 +9391,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9273,7 +9409,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9287,7 +9423,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -9305,7 +9441,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9317,9 +9453,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-safe-mode"
+version = "18.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
+dependencies = [
+ "docify",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "pallet-proxy",
+ "pallet-utility",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-scheduler"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9336,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9357,7 +9511,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9373,7 +9527,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9390,7 +9544,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9412,18 +9566,18 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -9432,7 +9586,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9442,7 +9596,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9478,7 +9632,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9493,7 +9647,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "36.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9512,7 +9666,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9530,7 +9684,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9545,7 +9699,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -9561,7 +9715,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -9592,7 +9746,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "36.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9604,6 +9758,23 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pallet-tx-pause"
+version = "18.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
+dependencies = [
+ "docify",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "pallet-proxy",
+ "pallet-utility",
+ "parity-scale-codec",
+ "scale-info",
  "sp-runtime",
 ]
 
@@ -9635,7 +9806,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "37.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9650,7 +9821,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9664,7 +9835,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9698,7 +9869,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "16.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -9721,7 +9892,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9739,7 +9910,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -9772,7 +9943,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
- "bitcoin_hashes 0.13.0",
+ "bitcoin_hashes",
  "rand",
  "rand_core",
  "serde",
@@ -9882,7 +10053,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall 0.5.7",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -9953,9 +10124,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.12"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c73c26c01b8c87956cea613c907c9d6ecffd8d18a2a5908e5de0adfaa185cea"
+checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
  "thiserror",
@@ -9964,9 +10135,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.12"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664d22978e2815783adbdd2c588b455b1bd625299ce36b2a99881ac9627e6d8d"
+checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -9974,22 +10145,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.12"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d5487022d5d33f4c30d91c22afa240ce2a644e87fe08caad974d4eab6badbe"
+checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.12"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0091754bbd0ea592c4deb3a122ce8ecbb0753b738aa82bc055fcc2eccc8d8174"
+checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
 dependencies = [
  "once_cell",
  "pest",
@@ -10003,7 +10174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
 ]
 
 [[package]]
@@ -10012,35 +10183,35 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "rustc_version 0.4.1",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -10071,17 +10242,17 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "polkadot-approval-distribution"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "bitvec",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "itertools 0.11.0",
  "polkadot-node-jaeger",
@@ -10098,10 +10269,10 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "always-assert",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
@@ -10114,11 +10285,11 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "17.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.18",
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-network-protocol",
@@ -10138,11 +10309,11 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-network-protocol",
@@ -10171,12 +10342,12 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "cfg-if",
  "clap",
  "frame-benchmarking-cli",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "polkadot-node-metrics",
  "polkadot-node-primitives",
@@ -10199,11 +10370,11 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "bitvec",
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
@@ -10221,7 +10392,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10232,13 +10403,13 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "17.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.18",
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-network-protocol",
@@ -10257,7 +10428,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -10271,9 +10442,9 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
@@ -10293,13 +10464,13 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "always-assert",
  "async-trait",
  "bytes",
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "polkadot-node-metrics",
@@ -10316,9 +10487,9 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-primitives",
@@ -10334,11 +10505,11 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "bitvec",
- "derive_more",
- "futures 0.3.30",
+ "derive_more 0.99.18",
+ "futures 0.3.31",
  "futures-timer",
  "itertools 0.11.0",
  "kvdb",
@@ -10367,10 +10538,10 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "bitvec",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "kvdb",
  "parity-scale-codec",
@@ -10389,11 +10560,11 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "bitvec",
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "polkadot-erasure-coding",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
@@ -10409,9 +10580,9 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
@@ -10424,10 +10595,10 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "17.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "parity-scale-codec",
  "polkadot-node-core-pvf",
@@ -10447,9 +10618,9 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "polkadot-node-metrics",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-types",
@@ -10461,9 +10632,9 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "kvdb",
  "parity-scale-codec",
@@ -10478,10 +10649,10 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "kvdb",
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -10497,10 +10668,10 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "polkadot-node-subsystem",
  "polkadot-overseer",
@@ -10514,10 +10685,10 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "16.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
@@ -10528,11 +10699,11 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "bitvec",
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
@@ -10546,13 +10717,13 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "always-assert",
  "array-bytes",
  "blake3",
  "cfg-if",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "parity-scale-codec",
  "pin-project",
@@ -10575,9 +10746,9 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
@@ -10591,10 +10762,10 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "cpu-time",
- "futures 0.3.30",
+ "futures 0.3.31",
  "landlock",
  "libc",
  "nix 0.28.0",
@@ -10617,9 +10788,9 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "polkadot-node-metrics",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-types",
@@ -10632,7 +10803,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "lazy_static",
  "log",
@@ -10651,10 +10822,10 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "bs58 0.5.1",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "log",
  "parity-scale-codec",
@@ -10670,14 +10841,14 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
  "bitvec",
- "derive_more",
+ "derive_more 0.99.18",
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "hex",
  "parity-scale-codec",
  "polkadot-node-jaeger",
@@ -10696,11 +10867,11 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "bitvec",
  "bounded-vec",
- "futures 0.3.30",
+ "futures 0.3.31",
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
@@ -10719,7 +10890,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -10729,13 +10900,13 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "17.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
  "bitvec",
- "derive_more",
+ "derive_more 0.99.18",
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "orchestra",
  "polkadot-node-jaeger",
  "polkadot-node-network-protocol",
@@ -10759,12 +10930,12 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "17.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
- "derive_more",
+ "derive_more 0.99.18",
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-channel",
  "itertools 0.11.0",
  "kvdb",
@@ -10795,10 +10966,10 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "orchestra",
  "parking_lot 0.12.3",
@@ -10817,10 +10988,10 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "bounded-collections",
- "derive_more",
+ "derive_more 0.99.18",
  "parity-scale-codec",
  "polkadot-core-primitives",
  "scale-info",
@@ -10833,7 +11004,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -10859,7 +11030,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -10894,7 +11065,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "16.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -10944,7 +11115,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "bs58 0.5.1",
  "frame-benchmarking",
@@ -10956,11 +11127,11 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "16.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
- "derive_more",
+ "derive_more 0.99.18",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -11003,7 +11174,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "17.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -11011,7 +11182,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
- "futures 0.3.30",
+ "futures 0.3.31",
  "hex-literal",
  "is_executable",
  "kvdb",
@@ -11121,14 +11292,14 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "arrayvec 0.7.6",
  "bitvec",
  "fatality",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "parity-scale-codec",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
@@ -11144,7 +11315,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -11201,7 +11372,7 @@ dependencies = [
  "polkavm-common",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -11211,7 +11382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
  "polkavm-derive-impl",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -11261,7 +11432,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -11291,9 +11462,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "powerfmt"
@@ -11315,7 +11486,7 @@ name = "precompile-utils"
 version = "0.1.0"
 source = "git+https://github.com/AstarNetwork/frontier?branch=stable2407#68d63a3cfab5293eacf551ab84c75057a5772830"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.18",
  "environmental",
  "evm",
  "fp-evm",
@@ -11346,7 +11517,7 @@ source = "git+https://github.com/AstarNetwork/frontier?branch=stable2407#68d63a3
 dependencies = [
  "case",
  "num_enum 0.7.3",
- "prettyplease 0.2.22",
+ "prettyplease 0.2.25",
  "proc-macro2",
  "quote",
  "sp-crypto-hashing",
@@ -11405,12 +11576,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.22"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -11435,8 +11606,8 @@ checksum = "a172e6cc603231f2cf004232eabcecccc0da53ba576ab286ef7baa0cfc7927ad"
 dependencies = [
  "coarsetime",
  "crossbeam-queue",
- "derive_more",
- "futures 0.3.30",
+ "derive_more 0.99.18",
+ "futures 0.3.31",
  "futures-timer",
  "nanorand",
  "thiserror",
@@ -11494,7 +11665,7 @@ checksum = "3d1eaa7fa0aa1929ffdf7eeb6eac234dde6268914a14ad44d23521ab6a9b258e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -11505,14 +11676,14 @@ checksum = "834da187cfe638ae8abb0203f0b33e5ccdb02a28e7199f2f47b3e2754f50edca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -11551,7 +11722,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -11566,7 +11737,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "unarray",
 ]
 
@@ -11625,11 +11796,11 @@ dependencies = [
  "multimap 0.10.0",
  "once_cell",
  "petgraph",
- "prettyplease 0.2.22",
+ "prettyplease 0.2.25",
  "prost 0.12.6",
  "prost-types 0.12.6",
  "regex",
- "syn 2.0.77",
+ "syn 2.0.87",
  "tempfile",
 ]
 
@@ -11656,7 +11827,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -11901,9 +12072,9 @@ dependencies = [
 
 [[package]]
 name = "raw-cpuid"
-version = "11.1.0"
+version = "11.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb9ee317cfe3fbd54b36a511efc1edd42e216903c9cd575e686dd68a2ba90d8d"
+checksum = "1ab240315c661615f2ee9f0f2cd32d5a7343a84d5ebcccb99d46e6637565e7b0"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -11957,9 +12128,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -11981,7 +12152,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87413ebb313323d431e85d0afc5a68222aaed972843537cbfe5f061cf1b4bcab"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.18",
  "fs-err",
  "static_init",
  "thiserror",
@@ -12004,7 +12175,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -12034,14 +12205,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -12055,13 +12226,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -12072,9 +12243,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -12090,7 +12261,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "ipnet",
  "js-sys",
  "log",
@@ -12206,7 +12377,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -12306,7 +12477,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -12342,7 +12513,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "322c53fd76a18698f1c27381d58091de3a043d356aa5bd0d510608b565f469a0"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "netlink-packet-route",
  "netlink-proto",
@@ -12436,9 +12607,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -12472,9 +12643,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.13"
+version = "0.23.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
 dependencies = [
  "log",
  "once_cell",
@@ -12504,7 +12675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.1.3",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -12521,19 +12692,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "base64 0.22.1",
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-platform-verifier"
@@ -12546,7 +12716,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.13",
+ "rustls 0.23.16",
  "rustls-native-certs 0.7.3",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.102.8",
@@ -12585,9 +12755,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "ruzstd"
@@ -12606,7 +12776,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "pin-project",
  "static_assertions",
 ]
@@ -12656,7 +12826,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "log",
  "sp-core",
@@ -12667,16 +12837,16 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "ip_network",
  "libp2p",
  "linked_hash_set",
  "log",
- "multihash 0.19.1",
+ "multihash 0.19.2",
  "parity-scale-codec",
  "prost 0.12.6",
  "prost-build 0.12.6",
@@ -12697,9 +12867,9 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "log",
  "parity-scale-codec",
@@ -12719,7 +12889,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.42.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -12734,12 +12904,12 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "array-bytes",
  "docify",
  "log",
- "memmap2 0.9.4",
+ "memmap2 0.9.5",
  "parity-scale-codec",
  "sc-chain-spec-derive",
  "sc-client-api",
@@ -12761,24 +12931,24 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "sc-cli"
 version = "0.46.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "array-bytes",
  "chrono",
  "clap",
  "fdlimit",
- "futures 0.3.30",
+ "futures 0.3.31",
  "itertools 0.11.0",
  "libp2p-identity",
  "log",
@@ -12813,10 +12983,10 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "fnv",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -12840,7 +13010,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -12866,10 +13036,10 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "mockall 0.11.4",
  "parking_lot 0.12.3",
@@ -12890,10 +13060,10 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "parity-scale-codec",
  "sc-block-builder",
@@ -12919,11 +13089,11 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
  "fork-tree",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "num-bigint",
  "num-rational",
@@ -12955,9 +13125,9 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "jsonrpsee",
  "sc-consensus-babe",
  "sc-consensus-epochs",
@@ -12977,13 +13147,13 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
  "async-trait",
  "fnv",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -13013,9 +13183,9 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
@@ -13033,7 +13203,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -13046,7 +13216,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.29.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -13054,7 +13224,7 @@ dependencies = [
  "dyn-clone",
  "finality-grandpa",
  "fork-tree",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "log",
  "parity-scale-codec",
@@ -13090,10 +13260,10 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "finality-grandpa",
- "futures 0.3.30",
+ "futures 0.3.31",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
@@ -13110,11 +13280,11 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "assert_matches",
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "jsonrpsee",
  "log",
@@ -13145,10 +13315,10 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "log",
  "parity-scale-codec",
@@ -13168,7 +13338,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -13191,7 +13361,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -13204,7 +13374,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "log",
  "polkavm",
@@ -13215,7 +13385,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -13233,10 +13403,10 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "ansi_term",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "log",
  "sc-client-api",
@@ -13250,7 +13420,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "33.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -13264,13 +13434,13 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.14.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.6",
  "blake2 0.10.6",
  "bytes",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "log",
  "mixnet",
@@ -13293,7 +13463,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -13303,7 +13473,7 @@ dependencies = [
  "cid 0.9.0",
  "either",
  "fnv",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "ip_network",
  "libp2p",
@@ -13344,11 +13514,11 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
- "futures 0.3.30",
+ "futures 0.3.31",
  "libp2p-identity",
  "parity-scale-codec",
  "prost-build 0.12.6",
@@ -13362,10 +13532,10 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "ahash",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "log",
  "sc-network",
@@ -13381,11 +13551,11 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "parity-scale-codec",
  "prost 0.12.6",
@@ -13402,13 +13572,13 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
  "async-trait",
  "fork-tree",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "libp2p",
  "log",
@@ -13439,10 +13609,10 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "array-bytes",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "parity-scale-codec",
  "sc-network",
@@ -13458,7 +13628,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.12.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "bs58 0.5.1",
  "ed25519-dalek",
@@ -13466,7 +13636,7 @@ dependencies = [
  "litep2p",
  "log",
  "multiaddr 0.18.2",
- "multihash 0.19.1",
+ "multihash 0.19.2",
  "rand",
  "thiserror",
  "zeroize",
@@ -13475,14 +13645,14 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "array-bytes",
  "bytes",
  "fnv",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "hyper-rustls",
  "log",
  "num_cpus",
@@ -13509,7 +13679,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -13518,9 +13688,9 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
@@ -13550,7 +13720,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13570,14 +13740,14 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "16.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "forwarded-header-value",
- "futures 0.3.30",
+ "futures 0.3.31",
  "governor",
  "http 1.1.0",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "ip_network",
  "jsonrpsee",
  "log",
@@ -13592,10 +13762,10 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "array-bytes",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-util",
  "hex",
  "jsonrpsee",
@@ -13624,12 +13794,12 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
  "directories",
  "exit-future",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "jsonrpsee",
  "log",
@@ -13688,7 +13858,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.36.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -13699,7 +13869,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.22.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "clap",
  "fs4",
@@ -13712,7 +13882,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.44.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13731,10 +13901,10 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
- "derive_more",
- "futures 0.3.30",
+ "derive_more 0.99.18",
+ "futures 0.3.31",
  "libc",
  "log",
  "rand",
@@ -13752,10 +13922,10 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "chrono",
- "futures 0.3.30",
+ "futures 0.3.31",
  "libp2p",
  "log",
  "parking_lot 0.12.3",
@@ -13772,7 +13942,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -13802,21 +13972,21 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "sc-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "linked-hash-map",
  "log",
@@ -13840,10 +14010,10 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "parity-scale-codec",
  "serde",
@@ -13856,10 +14026,10 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-channel 1.9.0",
- "futures 0.3.30",
+ "futures 0.3.31",
  "futures-timer",
  "lazy_static",
  "log",
@@ -13884,7 +14054,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e98f3262c250d90e700bb802eb704e1f841e03331c2eb815e46516c4edbf5b27"
 dependencies = [
- "derive_more",
+ "derive_more 0.99.18",
  "parity-scale-codec",
  "scale-bits",
  "scale-type-resolver",
@@ -13893,13 +14063,13 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.11.3"
+version = "2.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca070c12893629e2cc820a9761bedf6ce1dcddc9852984d1dc734b8bd9bd024"
+checksum = "1aa7ffc1c0ef49b0452c6e2986abf2b07743320641ffd5fc63d552458e3b779b"
 dependencies = [
  "bitvec",
  "cfg-if",
- "derive_more",
+ "derive_more 1.0.0",
  "parity-scale-codec",
  "scale-info-derive",
  "serde",
@@ -13907,14 +14077,14 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.11.3"
+version = "2.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d35494501194174bda522a32605929eefc9ecf7e0a326c26db1fdd85881eb62"
+checksum = "46385cc24172cf615450267463f937c10072516359b3ff1cb24228a4a08bf951"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -13925,9 +14095,9 @@ checksum = "f0cded6518aa0bd6c1be2b88ac81bf7044992f0f154bfbabd5ad34f43512abcb"
 
 [[package]]
 name = "schannel"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -14094,9 +14264,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -14149,9 +14319,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
 dependencies = [
  "serde_derive",
 ]
@@ -14167,20 +14337,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",
@@ -14190,9 +14360,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -14383,6 +14553,7 @@ dependencies = [
  "pallet-preimage",
  "pallet-price-aggregator",
  "pallet-proxy",
+ "pallet-safe-mode",
  "pallet-scheduler",
  "pallet-session",
  "pallet-sudo",
@@ -14390,6 +14561,7 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "pallet-treasury 36.0.1",
+ "pallet-tx-pause",
  "pallet-unified-accounts",
  "pallet-utility",
  "pallet-vesting",
@@ -14567,9 +14739,9 @@ dependencies = [
 
 [[package]]
 name = "simba"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
+checksum = "b3a386a501cd104797982c15ae17aafe8b9261315b5d07e3ec803f2ea26be0fa"
 dependencies = [
  "approx",
  "num-complex",
@@ -14661,7 +14833,7 @@ dependencies = [
 [[package]]
 name = "slot-range-helper"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -14716,7 +14888,7 @@ dependencies = [
  "bs58 0.5.1",
  "chacha20",
  "crossbeam-queue",
- "derive_more",
+ "derive_more 0.99.18",
  "ed25519-zebra",
  "either",
  "event-listener 2.5.3",
@@ -14765,7 +14937,7 @@ dependencies = [
  "async-lock 2.8.0",
  "base64 0.21.7",
  "blake2-rfc",
- "derive_more",
+ "derive_more 0.99.18",
  "either",
  "event-listener 2.5.3",
  "fnv",
@@ -14842,7 +15014,7 @@ checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
 dependencies = [
  "base64 0.13.1",
  "bytes",
- "futures 0.3.30",
+ "futures 0.3.31",
  "httparse",
  "log",
  "rand",
@@ -14857,7 +15029,7 @@ checksum = "37468c595637c10857701c990f93a40ce0e357cedb0953d1c26c8d8027f9bb53"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures 0.3.30",
+ "futures 0.3.31",
  "http 1.1.0",
  "httparse",
  "log",
@@ -14868,7 +15040,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "docify",
  "hash-db",
@@ -14890,7 +15062,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -14898,13 +15070,13 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "sp-application-crypto"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14916,7 +15088,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -14930,7 +15102,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -14942,7 +15114,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -14952,9 +15124,9 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "37.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "schnellru",
@@ -14971,10 +15143,10 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "sp-core",
  "sp-inherents",
@@ -14986,7 +15158,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15002,7 +15174,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15020,7 +15192,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -15040,7 +15212,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -15057,7 +15229,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15068,7 +15240,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -15077,7 +15249,7 @@ dependencies = [
  "bs58 0.5.1",
  "dyn-clonable",
  "ed25519-zebra",
- "futures 0.3.30",
+ "futures 0.3.31",
  "hash-db",
  "hash256-std-hasher",
  "impl-serde",
@@ -15114,7 +15286,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -15127,17 +15299,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -15146,17 +15318,17 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "sp-externalities"
 version = "0.29.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -15166,7 +15338,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15178,7 +15350,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -15191,7 +15363,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "bytes",
  "docify",
@@ -15217,7 +15389,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -15227,7 +15399,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -15238,7 +15410,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -15247,7 +15419,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -15257,7 +15429,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15268,7 +15440,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -15285,7 +15457,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15298,7 +15470,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -15308,7 +15480,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -15318,7 +15490,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "32.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -15328,7 +15500,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "39.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "docify",
  "either",
@@ -15354,7 +15526,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -15373,20 +15545,20 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "Inflector",
  "expander",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "sp-session"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -15400,7 +15572,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -15413,7 +15585,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "hash-db",
  "log",
@@ -15433,7 +15605,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -15457,12 +15629,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 
 [[package]]
 name = "sp-storage"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -15474,7 +15646,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15486,7 +15658,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -15497,7 +15669,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -15506,7 +15678,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -15520,7 +15692,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "ahash",
  "hash-db",
@@ -15543,7 +15715,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -15560,18 +15732,18 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -15583,7 +15755,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -15627,9 +15799,9 @@ dependencies = [
 
 [[package]]
 name = "ss58-registry"
-version = "1.50.0"
+version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43fce22ed1df64d04b262351c8f9d5c6da4f76f79f25ad15529792f893fad25d"
+checksum = "19409f13998e55816d1c728395af0b52ec066206341d939e22e7766df9b494b8"
 dependencies = [
  "Inflector",
  "num-format",
@@ -15649,7 +15821,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "staging-parachain-info"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -15662,7 +15834,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "14.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -15680,7 +15852,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "16.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -15701,7 +15873,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -15827,13 +15999,13 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2 0.12.2",
@@ -15858,16 +16030,16 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "38.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
- "futures 0.3.30",
+ "futures 0.3.31",
  "jsonrpsee",
  "log",
  "parity-scale-codec",
@@ -15883,10 +16055,10 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "log",
  "prometheus",
@@ -15897,7 +16069,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -15914,7 +16086,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "array-bytes",
  "build-helper",
@@ -15970,9 +16142,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -16005,7 +16177,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -16043,14 +16215,14 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand 2.1.1",
  "once_cell",
- "rustix 0.38.37",
+ "rustix 0.38.38",
  "windows-sys 0.59.0",
 ]
 
@@ -16065,12 +16237,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+checksum = "4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef"
 dependencies = [
- "rustix 0.38.37",
- "windows-sys 0.48.0",
+ "rustix 0.38.38",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -16081,9 +16253,9 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "3b3c6efbfc763e64eb85c11c25320f0737cb7364c4b6336db90aa9ebe27a0bbd"
 dependencies = [
  "thiserror-impl",
 ]
@@ -16105,18 +16277,18 @@ checksum = "e4c60d69f36615a077cc7663b9cb8e42275722d23e58a7fa3d2c7f2915d09d04"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "b607164372e89797d78b8e23a6d67d5d1038c1c65efd52e1389ef8b77caba2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -16219,6 +16391,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16235,9 +16417,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",
@@ -16259,7 +16441,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -16278,7 +16460,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.13",
+ "rustls 0.23.16",
  "rustls-pki-types",
  "tokio",
 ]
@@ -16356,11 +16538,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -16430,7 +16612,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -16456,7 +16638,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -16467,13 +16649,13 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "expander",
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -16651,9 +16833,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uint"
@@ -16675,9 +16857,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
@@ -16696,21 +16878,21 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unified-accounts-chain-extension-types"
@@ -16769,12 +16951,12 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
 dependencies = [
  "form_urlencoded",
- "idna 0.5.0",
+ "idna 1.0.3",
  "percent-encoding",
 ]
 
@@ -16783,6 +16965,18 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -16847,9 +17041,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "w3f-bls"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5da5fa2c6afa2c9158eaa7cd9aee249765eb32b5fb0c63ad8b9e79336a47ec"
+checksum = "70a3028804c8bbae2a97a15b71ffc0e308c4b01a520994aafa77d56e94e19024"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -16911,9 +17105,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -16922,24 +17116,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -16949,9 +17143,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -16959,22 +17153,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wasm-instrument"
@@ -17031,7 +17225,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "js-sys",
  "parking_lot 0.11.2",
  "pin-utils",
@@ -17327,9 +17521,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -17363,7 +17557,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -17469,7 +17663,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -17491,7 +17685,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.37",
+ "rustix 0.38.38",
 ]
 
 [[package]]
@@ -17800,9 +17994,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
@@ -17818,13 +18012,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
 name = "ws_stream_wasm"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7999f5f4217fe3818726b66257a4475f71e74ffd190776ad053fa159e50737f5"
 dependencies = [
  "async_io_stream",
- "futures 0.3.30",
+ "futures 0.3.31",
  "js-sys",
  "log",
  "pharos",
@@ -17894,18 +18100,18 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "10.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -17919,7 +18125,7 @@ dependencies = [
 [[package]]
 name = "xcm-simulator"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fc627930d54785acaaa30fe003190244221ca36a"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2407#fff69c3c96346ed91cf127ec313793682e4d9868"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -18020,7 +18226,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed0164ae619f2dc144909a9f082187ebb5893693d8c0196e8085283ccd4b776"
 dependencies = [
- "futures 0.3.30",
+ "futures 0.3.31",
  "log",
  "nohash-hasher",
  "parking_lot 0.12.3",
@@ -18036,6 +18242,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time",
+]
+
+[[package]]
+name = "yoke"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
@@ -18056,7 +18286,28 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
@@ -18076,7 +18327,29 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,6 +184,8 @@ pallet-message-queue = { git = "https://github.com/paritytech/polkadot-sdk", bra
 pallet-membership = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
 pallet-collective = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
 pallet-democracy = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+pallet-tx-pause = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
+pallet-safe-mode = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2407", default-features = false }
 
 # EVM & Ethereum
 # (wasm)

--- a/bin/collator/Cargo.toml
+++ b/bin/collator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-collator"
-version = "5.45.0"
+version = "5.44.0"
 description = "Astar collator implementation in Rust."
 build = "build.rs"
 default-run = "astar-collator"

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -79,7 +79,8 @@ pallet-treasury = { workspace = true }
 pallet-utility = { workspace = true }
 pallet-vesting = { workspace = true }
 vesting-mbm = { workspace = true }
-
+pallet-tx-pause = { workspace = true, default-features = false }
+pallet-safe-mode = { workspace = true, default-features = false }
 # cumulus dependencies
 cumulus-pallet-aura-ext = { workspace = true }
 cumulus-pallet-parachain-system = { workspace = true }
@@ -153,6 +154,8 @@ substrate-wasm-builder = { workspace = true, optional = true }
 [features]
 default = ["std"]
 std = [
+	"pallet-tx-pause/std",
+	"pallet-safe-mode/std",
 	"parity-scale-codec/std",
 	"serde_json/std",
 	"fp-rpc/std",

--- a/runtime/shibuya/src/genesis_config.rs
+++ b/runtime/shibuya/src/genesis_config.rs
@@ -196,6 +196,8 @@ pub fn default_config(para_id: u32) -> serde_json::Value {
         democracy: Default::default(),
         treasury: Default::default(),
         community_treasury: Default::default(),
+        tx_pause: Default::default(),
+        safe_mode: Default::default(),
     };
 
     serde_json::to_value(&config).expect("Could not build genesis config.")

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -1194,7 +1194,13 @@ parameter_types! {
 impl pallet_migrations::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     #[cfg(not(feature = "runtime-benchmarks"))]
-    type Migrations = ();
+    type Migrations = (
+        pallet_dapp_staking::migration::LazyMigration<
+            Runtime,
+            pallet_dapp_staking::weights::SubstrateWeight<Runtime>,
+        >,
+        vesting_mbm::LazyMigration<Runtime, vesting_mbm::weights::SubstrateWeight<Runtime>>,
+    );
     // Benchmarks need mocked migrations to guarantee that they succeed.
     #[cfg(feature = "runtime-benchmarks")]
     type Migrations = pallet_migrations::mock_helpers::MockedMigrations;
@@ -1333,7 +1339,11 @@ parameter_types! {
 pub type Migrations = (Unreleased, Permanent);
 
 /// Unreleased migrations. Add new ones here:
-pub type Unreleased = ();
+pub type Unreleased = (
+    cumulus_pallet_xcmp_queue::migration::v5::MigrateV4ToV5<Runtime>,
+    pallet_dapp_staking::migration::AdjustEraMigration<Runtime>,
+    pallet_inflation::migration::AdjustBlockRewardMigration<Runtime>,
+);
 
 /// Migrations/checks that do not need to be versioned and can run on every upgrade.
 pub type Permanent = (pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,);


### PR DESCRIPTION
Date:   Thu Nov 7 08:10:27 2024 -0500

    Integrate SafeMode pallet into Shibuya runtime
    - Added pallet_tx_pause to runtime configuration.
    - Added `pallet_safe_mode` to runtime configuration.
    - Updated genesis configuration to include `safe_mode`.
    - Configured `SafeModeWhitelistedCalls` to define calls that bypass SafeMode restrictions.
    - Added parameter types for SafeMode configuration, including enter and extend durations, deposit amounts, and release delay.
    - Updated `construct_runtime!` macro to include SafeMode pallet at index

**Pull Request Summary**


**Check list**
- [ ] added or updated unit tests
- [ ] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [ ] added benchmarks & weights for any modified runtime logics.
