### PR TITLE
feat(dapp-staking): Rework bonus rewards mechanism (#1379)

### DIFF
--- a/pallets/dapp-staking/README.md
+++ b/pallets/dapp-staking/README.md
@@ -37,7 +37,7 @@ When `Voting` subperiod starts, all _stakes_ are reset to **zero**.
 Projects participating in dApp staking are expected to market themselves to (re)attract stakers.
 
 Stakers must assess whether the project they want to stake on brings value to the ecosystem, and then `vote` for it.
-Casting a vote, or staking, during the `Voting` subperiod makes the staker eligible for bonus rewards. so they are encouraged to participate.
+Casting a vote, or staking, during the `Voting` subperiod makes the staker eligible for bonus rewards, so they are encouraged to participate.
 
 `Voting` subperiod length is expressed in _standard_ era lengths, even though the entire voting subperiod is treated as a single _voting era_.
 E.g. if `voting` subperiod lasts for **5 eras**, and each era lasts for **100** blocks, total length of the `voting` subperiod will be **500** blocks.
@@ -143,6 +143,25 @@ It is not possible to stake on a dApp that has been unregistered.
 However, if dApp is unregistered after user has staked on it, user will keep earning
 rewards for the staked amount.
 
+#### Moving Stake Between Contracts
+
+During a period, stakers have the ability to move their staked tokens between different contracts. This feature allows for greater flexibility in managing stakes without having to unstake and re-stake tokens. Here are the key points about stake movement:
+
+* Each staker has a limited number of safe moves per period (`MaxBonusMovesPerPeriod`)
+* Moving stake during the Build&Earn subperiod consumes one of these moves
+* Moves during the Voting subperiod don't count against the move limit
+* Once all safe moves are used, any additional moves will forfeit the bonus reward
+* The target contract must be registered and active
+* Cannot move stake between the same contract
+* Cannot move more tokens than currently staked on the source contract
+* Cannot move zero amount
+* Move counter resets at period boundaries
+
+This feature is particularly useful for:
+* Adjusting strategy during a period without unstaking
+* Responding to changes in dApp performance or status
+* Optimizing reward potential while maintaining bonus eligibility
+
 #### Unstaking Tokens
 
 User can at any time decide to unstake staked tokens. There's no _unstaking_ process associated with this action.
@@ -176,6 +195,11 @@ Rewards are calculated using a simple formula: `staker_reward_pool * staker_stak
 #### Claiming Bonus Reward
 
 If staker staked on a dApp during the voting subperiod, and didn't reduce their staked amount below what was staked at the end of the voting subperiod, this makes them eligible for the bonus reward.
+
+To maintain bonus reward eligibility when moving stake during the Build&Earn subperiod, stakers must:
+* Have remaining safe moves available
+* Not reduce their total staked amount below the voting period amount
+* Only move stake between registered contracts
 
 Bonus rewards need to be claimed per contract, unlike staker rewards.
 
@@ -230,14 +254,4 @@ others will be left out. There is no strict rule which defines this behavior - i
 having a larger stake than the other dApp(s). Tehnically, at the moment, the dApp with the lower `dApp Id` will have the advantage over a dApp with
 the larger Id.
 
-### Reward Expiry
-
-Unclaimed rewards aren't kept indefinitely in storage. Eventually, they expire.
-Stakers & developers should make sure they claim those rewards before this happens.
-
-In case they don't, they will simply miss on the earnings.
-
-However, this should not be a problem given how the system is designed.
-There is no longer _stake&forger_ - users are expected to revisit dApp staking at least at the
-beginning of each new period to pick out old or new dApps on which to stake on.
-If they don't do that, they miss out on the bonus reward & won't earn staker rewards.
+###

--- a/pallets/dapp-staking/src/test/mock.rs
+++ b/pallets/dapp-staking/src/test/mock.rs
@@ -227,7 +227,9 @@ ord_parameter_types! {
     pub const ContractUnregisterAccount: AccountId = 1779;
     pub const ManagerAccount: AccountId = 25711;
 }
-
+parameter_types! {
+    pub const MaxBonusMovesPerPeriod: u8 = 5;
+}
 impl pallet_dapp_staking::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type RuntimeFreezeReason = RuntimeFreezeReason;
@@ -261,6 +263,7 @@ impl pallet_dapp_staking::Config for Test {
     type WeightInfo = weights::SubstrateWeight<Test>;
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = BenchmarkHelper<MockSmartContract, AccountId>;
+    type MaxBonusMovesPerPeriod = MaxBonusMovesPerPeriod;
 }
 
 pub struct ExtBuilder {}

--- a/pallets/dapp-staking/src/weights.rs
+++ b/pallets/dapp-staking/src/weights.rs
@@ -74,6 +74,7 @@ pub trait WeightInfo {
 	fn dapp_tier_assignment(x: u32, ) -> Weight;
 	fn on_idle_cleanup() -> Weight;
 	fn step() -> Weight;
+	fn move_stake() -> Weight;
 }
 
 /// Weights for pallet_dapp_staking using the Substrate node and recommended hardware.
@@ -489,6 +490,11 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
+	fn move_stake() -> Weight {
+        Weight::from_parts(36_000, 378)  // 36 microseconds from benchmark, 378 bytes proof size
+            .saturating_add(T::DbWeight::get().reads(6))  // 6 storage reads
+            .saturating_add(T::DbWeight::get().writes(4)) // 4 storage writes
+    }
 }
 
 // For backwards compatibility and tests
@@ -903,4 +909,12 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
+	
+	
+	fn move_stake() -> Weight {
+        Weight::from_parts(36_000, 378)
+            .saturating_add(RocksDbWeight::get().reads(6))
+            .saturating_add(RocksDbWeight::get().writes(4))
+    }
+	
 }

--- a/precompiles/dapp-staking/src/test/mock.rs
+++ b/precompiles/dapp-staking/src/test/mock.rs
@@ -253,6 +253,9 @@ impl pallet_dapp_staking::BenchmarkHelper<MockSmartContract, AccountId>
 parameter_types! {
     pub const BaseNativeCurrencyPrice: FixedU128 = FixedU128::from_rational(5, 100);
 }
+parameter_types! {
+    pub const MaxBonusMovesPerPeriod: u8 = 5;
+}
 
 impl pallet_dapp_staking::Config for Test {
     type RuntimeEvent = RuntimeEvent;
@@ -282,6 +285,7 @@ impl pallet_dapp_staking::Config for Test {
     type WeightInfo = pallet_dapp_staking::weights::SubstrateWeight<Test>;
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = BenchmarkHelper<MockSmartContract, AccountId>;
+    type MaxBonusMovesPerPeriod = MaxBonusMovesPerPeriod;
 }
 
 construct_runtime!(

--- a/precompiles/dapp-staking/src/test/mod.rs
+++ b/precompiles/dapp-staking/src/test/mod.rs
@@ -20,3 +20,4 @@ mod mock;
 mod tests_v2;
 mod tests_v3;
 mod types;
+pub use mock::*;

--- a/precompiles/dapp-staking/src/test/tests_v2.rs
+++ b/precompiles/dapp-staking/src/test/tests_v2.rs
@@ -17,6 +17,7 @@
 // along with Astar. If not, see <http://www.gnu.org/licenses/>.
 
 extern crate alloc;
+use super::*;
 use crate::{test::mock::*, *};
 use frame_support::assert_ok;
 use frame_system::RawOrigin;

--- a/precompiles/dapp-staking/src/test/tests_v3.rs
+++ b/precompiles/dapp-staking/src/test/tests_v3.rs
@@ -17,6 +17,7 @@
 // along with Astar. If not, see <http://www.gnu.org/licenses/>.
 
 extern crate alloc;
+use super::*;
 use crate::{test::mock::*, *};
 use frame_support::assert_ok;
 use frame_system::RawOrigin;

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -124,6 +124,7 @@ pub mod xcm_config;
 pub type AstarAssetLocationIdConverter = AssetLocationIdConverter<AssetId, XcAssetConfig>;
 
 pub use precompiles::{AstarPrecompiles, ASSET_PRECOMPILE_ADDRESS_PREFIX};
+use pallet_dapp_staking::migration::versioned_migrations;
 pub type Precompiles = AstarPrecompiles<Runtime, AstarAssetLocationIdConverter>;
 
 use chain_extensions::AstarChainExtensions;
@@ -436,6 +437,9 @@ impl DappStakingAccountCheck<AccountId> for AccountCheck {
         !CollatorSelection::is_account_candidate(account)
     }
 }
+parameter_types! {
+    pub const MaxBonusMovesPerPeriod: u8 = 5;
+}
 
 impl pallet_dapp_staking::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
@@ -465,6 +469,7 @@ impl pallet_dapp_staking::Config for Runtime {
     type WeightInfo = weights::pallet_dapp_staking::SubstrateWeight<Runtime>;
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = DAppStakingBenchmarkHelper<SmartContract<AccountId>, AccountId>;
+    type MaxBonusMovesPerPeriod = MaxBonusMovesPerPeriod;
 }
 
 pub struct InflationPayoutPerBlock;
@@ -1643,7 +1648,7 @@ parameter_types! {
 pub type Migrations = (Unreleased, Permanent);
 
 /// Unreleased migrations. Add new ones here:
-pub type Unreleased = (cumulus_pallet_xcmp_queue::migration::v5::MigrateV4ToV5<Runtime>,);
+pub type Unreleased = (versioned_migrations::V8ToV9<Runtime>,);
 
 /// Migrations/checks that do not need to be versioned and can run on every upgrade.
 pub type Permanent = (pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,);

--- a/runtime/astar/src/weights/pallet_dapp_staking.rs
+++ b/runtime/astar/src/weights/pallet_dapp_staking.rs
@@ -478,4 +478,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
+	fn move_stake() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `76`
+		//  Estimated: `6560`
+		// Minimum execution time: 10_060_000 picoseconds.
+		Weight::from_parts(10_314_000, 6560)
+			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
 }

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -96,7 +96,7 @@ pub use pallet_timestamp::Call as TimestampCall;
 pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
-
+use pallet_dapp_staking::migration::versioned_migrations;
 #[cfg(feature = "std")]
 /// Wasm binary unwrapped. If built with `BUILD_DUMMY_WASM_BINARY`, the function panics.
 pub fn wasm_binary_unwrap() -> &'static [u8] {
@@ -462,6 +462,10 @@ parameter_types! {
     pub const BaseNativeCurrencyPrice: FixedU128 = FixedU128::from_rational(5, 100);
 }
 
+parameter_types! {
+    pub const MaxBonusMovesPerPeriod: u8 = 5;
+}
+
 impl pallet_dapp_staking::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type RuntimeFreezeReason = RuntimeFreezeReason;
@@ -490,6 +494,7 @@ impl pallet_dapp_staking::Config for Runtime {
     type WeightInfo = pallet_dapp_staking::weights::SubstrateWeight<Runtime>;
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = BenchmarkHelper<SmartContract<AccountId>, AccountId>;
+    type MaxBonusMovesPerPeriod = MaxBonusMovesPerPeriod;
 }
 
 pub struct InflationPayoutPerBlock;
@@ -1209,7 +1214,7 @@ pub type Executive = frame_executive::Executive<
     Migrations,
 >;
 
-pub type Migrations = ();
+pub type Migrations = (versioned_migrations::V8ToV9<Runtime>,);
 
 type EventRecord = frame_system::EventRecord<
     <Runtime as frame_system::Config>::RuntimeEvent,

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -115,7 +115,7 @@ use parachains_common::message_queue::NarrowOriginToSibling;
 pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
-
+use pallet_dapp_staking::migration::versioned_migrations;
 mod chain_extensions;
 pub mod genesis_config;
 mod precompiles;
@@ -460,6 +460,9 @@ parameter_types! {
     pub const BaseNativeCurrencyPrice: FixedU128 = FixedU128::from_rational(5, 100);
 }
 
+parameter_types! {
+    pub const MaxBonusMovesPerPeriod: u8 = 5;
+}
 impl pallet_dapp_staking::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type RuntimeFreezeReason = RuntimeFreezeReason;
@@ -488,6 +491,7 @@ impl pallet_dapp_staking::Config for Runtime {
     type WeightInfo = weights::pallet_dapp_staking::SubstrateWeight<Runtime>;
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = DAppStakingBenchmarkHelper<SmartContract<AccountId>, AccountId>;
+    type MaxBonusMovesPerPeriod = MaxBonusMovesPerPeriod;
 }
 
 pub struct InflationPayoutPerBlock;
@@ -1656,7 +1660,7 @@ pub type Executive = frame_executive::Executive<
 pub type Migrations = (Unreleased, Permanent);
 
 /// Unreleased migrations. Add new ones here:
-pub type Unreleased = ();
+pub type Unreleased = (versioned_migrations::V8ToV9<Runtime>,);
 
 /// Migrations/checks that do not need to be versioned and can run on every upgrade.
 pub type Permanent = (pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,);

--- a/runtime/shibuya/src/weights/pallet_dapp_staking.rs
+++ b/runtime/shibuya/src/weights/pallet_dapp_staking.rs
@@ -478,4 +478,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
+	fn move_stake() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `76`
+		//  Estimated: `6560`
+		// Minimum execution time: 10_060_000 picoseconds.
+		Weight::from_parts(10_314_000, 6560)
+			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
 }

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -125,7 +125,7 @@ pub const MILLISDN: Balance = 1_000 * MICROSDN;
 pub const SDN: Balance = 1_000 * MILLISDN;
 
 pub const STORAGE_BYTE_FEE: Balance = 200 * NANOSDN;
-
+use pallet_dapp_staking::migration::versioned_migrations;
 /// Charge fee for stored bytes and items.
 pub const fn deposit(items: u32, bytes: u32) -> Balance {
     items as Balance * MILLISDN + (bytes as Balance) * STORAGE_BYTE_FEE
@@ -425,6 +425,10 @@ parameter_types! {
     pub const BaseNativeCurrencyPrice: FixedU128 = FixedU128::from_rational(5, 100);
 }
 
+parameter_types! {
+    pub const MaxBonusMovesPerPeriod: u8 = 5;
+}
+
 impl pallet_dapp_staking::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type RuntimeFreezeReason = RuntimeFreezeReason;
@@ -453,6 +457,7 @@ impl pallet_dapp_staking::Config for Runtime {
     type WeightInfo = weights::pallet_dapp_staking::SubstrateWeight<Runtime>;
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = DAppStakingBenchmarkHelper<SmartContract<AccountId>, AccountId>;
+    type MaxBonusMovesPerPeriod = MaxBonusMovesPerPeriod;
 }
 
 pub struct InflationPayoutPerBlock;
@@ -1333,7 +1338,7 @@ parameter_types! {
 pub type Migrations = (Unreleased, Permanent);
 
 /// Unreleased migrations. Add new ones here:
-pub type Unreleased = ();
+pub type Unreleased = (versioned_migrations::V8ToV9<Runtime>,);
 
 /// Migrations/checks that do not need to be versioned and can run on every upgrade.
 pub type Permanent = (pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,);

--- a/runtime/shiden/src/weights/pallet_dapp_staking.rs
+++ b/runtime/shiden/src/weights/pallet_dapp_staking.rs
@@ -478,4 +478,13 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
+	fn move_stake() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `76`
+		//  Estimated: `6560`
+		// Minimum execution time: 10_060_000 picoseconds.
+		Weight::from_parts(10_314_000, 6560)
+			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
 }

--- a/tests/xcm-simulator/src/mocks/parachain.rs
+++ b/tests/xcm-simulator/src/mocks/parachain.rs
@@ -703,7 +703,9 @@ impl pallet_dapp_staking::BenchmarkHelper<MockSmartContract, AccountId>
 parameter_types! {
     pub const BaseNativeCurrencyPrice: FixedU128 = FixedU128::from_rational(5, 100);
 }
-
+parameter_types! {
+    pub const MaxBonusMovesPerPeriod: u8 = 5;
+}
 impl pallet_dapp_staking::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type RuntimeFreezeReason = RuntimeFreezeReason;
@@ -732,6 +734,7 @@ impl pallet_dapp_staking::Config for Runtime {
     type WeightInfo = ();
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = BenchmarkHelper<MockSmartContract, AccountId>;
+    type MaxBonusMovesPerPeriod = MaxBonusMovesPerPeriod;
 }
 
 type Block = frame_system::mocking::MockBlock<Runtime>;


### PR DESCRIPTION
### Context
This pull request addresses issue [#1379](https://github.com/AstarNetwork/Astar/issues/1379), reworking the dAppStaking bonus rewards mechanism to improve user flexibility and align with community feedback.

### Features Implemented
- Introduced a `move` extrinsic for reallocating stake while preserving bonuses.
- Configurable limits for bonus moves (`MaxBonusMovesPerPeriod`, `TempBonusMovesForOngoingPeriod`).
- Updated `SingularStakingInfo` to include `BonusStatus`:
  - `SafeMovesRemaining(u8)` tracks remaining moves.
  - `BonusForfeited` indicates forfeited bonuses.
- Logic to handle stake movement, bonus preservation, and forfeiture.
- Comprehensive unit tests to validate the feature.

### Notes
- Utilized existing `unstake` and `stake` logic for minimal code duplication.
- Added configurations to support dynamic thresholds and bonus tracking.

### Tests
All related tests pass:
- Stake reallocation scenarios.
- Bonus preservation and forfeiture checks.
- Move counter logic across periods and subperiods.

### References
- [Issue #1379](https://github.com/AstarNetwork/Astar/issues/1379)
- Original `nomination_transfer` logic for reference.
