### PR TITLE
fix: unused imports removed

### DIFF
--- a/tests/integration/src/setup.rs
+++ b/tests/integration/src/setup.rs
@@ -21,14 +21,11 @@
 pub use frame_support::{
     assert_noop, assert_ok,
     traits::{OnFinalize, OnIdle, OnInitialize},
-    weights::{
-        constants::ExtrinsicBaseWeight, Weight, WeightToFee as WeightToFeeT,
-        WeightToFeeCoefficient, WeightToFeeCoefficients, WeightToFeePolynomial,
-    },
+    weights::{Weight, WeightToFee as WeightToFeeT},
 };
 use parity_scale_codec::Encode;
 pub use sp_core::{sr25519, Get, H160};
-pub use sp_runtime::{AccountId32, Digest, DigestItem, MultiAddress, Perbill};
+pub use sp_runtime::{AccountId32, Digest, DigestItem, MultiAddress};
 
 use cumulus_primitives_core::{relay_chain::HeadData, PersistedValidationData};
 use cumulus_primitives_parachain_inherent::ParachainInherentData;


### PR DESCRIPTION
`WeightToFee` redundant mock was removed in https://github.com/AstarNetwork/Astar/pull/1388/commits/633982fada9f42a98e00500abc1c8600200f16c6.
This PR removes unused imports to fix warnings when performing integration tests.