### PR TITLE
docs: Fix grammatical error in time display

### DIFF
--- a/scripts/sync-smoke.sh
+++ b/scripts/sync-smoke.sh
@@ -11,7 +11,7 @@ chain="$@"
 trap "kill $CHAIN_PID" EXIT
 
 echo "Waiting for RPC to be ready"
-attempts=12 # 1 minutes
+attempts=12 # 1 minute
 until nc -z localhost 9944; do
   attempts=$((attempts - 1))
   if [ $attempts -eq 0 ]; then


### PR DESCRIPTION
**Description**  

I noticed a grammatical issue where "1 minutes" was displayed instead of "1 minute."
This PR corrects the error to ensure proper singular/plural usage.  

**Check list**
- [x] added or updated unit tests
- [x] updated Astar official documentation
- [x] added OnRuntimeUpgrade hook for precompile revert code registration
- [x] added benchmarks & weights for any modified runtime logics.
