### PR TITLE
feat(dAppStaking): Move actions for bonus rewards

### DIFF
--- a/pallets/dapp-staking/README.md
+++ b/pallets/dapp-staking/README.md
@@ -141,7 +141,7 @@ The protocol keeps track of how much was staked by the user in `voting` and `bui
 
 It is not possible to stake on a dApp that has been unregistered.
 However, if dApp is unregistered after user has staked on it, user will keep earning
-rewards for the staked amount.
+rewards for the staked amount, or can 'move' his stake without impacting his number of allowed _safe move actions_ for the ongoing period.
 
 #### Unstaking Tokens
 
@@ -157,7 +157,24 @@ If unstake would reduce the staked amount below `MinimumStakeAmount`, everything
 
 Once period finishes, all stakes are reset back to zero. This means that no unstake operation is needed after period ends to _unstake_ funds - it's done automatically.
 
-If dApp has been unregistered, a special operation to unstake from unregistered contract must be used.
+During the `Build&Earn` subperiod, if unstaking reduces the voting stake, the bonus status will be updated, and the number of allowed _move actions_ for the ongoing period will be reduced.
+
+If dApp has been unregistered, a special operation to unstake from unregistered contract must be used that preserves bonus elegibility.
+
+#### Moving Stake Between Contracts
+
+The moving stake feature allows users to transfer their staked amount between two smart contracts without undergoing the unstake and stake process separately. This feature ensures that the transferred stake remains aligned with the current staking period (effective in the next era), and any bonus eligibility is preserved as long as the conditions for the bonus reward are not violated (move actions are limited by `MaxBonusSafeMovesPerPeriod`).
+
+Key details about moving stake:
+
+-   The destination contract must be different from the source contract.
+-   The user must ensure that unclaimed rewards are claimed before initiating a stake move.
+-   Only a limited number of move actions (defined by `MaxBonusSafeMovesPerPeriod`) are allowed during a single period to preserve bonus reward eligibility (check "Claiming Bonus Reward" section below).
+-   If the destination contract is newly staked, the user's total staked contracts must not exceed the maximum allowed number of staked contracts.
+-   The destination contract must not be unregistered, but moving stake away from an unregistered contract is allowed without affecting bonus eligibility.
+
+This feature is particularly useful for stakers who wish to rebalance their stake across multiple contracts (including new registrations) or move their stake to better-performing dApps while retaining the potential for rewards and maintaining bonus eligibility.
+
 
 #### Claiming Staker Rewards
 
@@ -175,7 +192,20 @@ Rewards are calculated using a simple formula: `staker_reward_pool * staker_stak
 
 #### Claiming Bonus Reward
 
-If staker staked on a dApp during the voting subperiod, and didn't reduce their staked amount below what was staked at the end of the voting subperiod, this makes them eligible for the bonus reward.
+If a staker has staked on a dApp during the voting subperiod, and the bonus status for the associated staked amount has not been forfeited due to excessive move actions, they remain eligible for the bonus reward.
+
+Only a limited number of _safe move actions_ are allowed during the `build&earn` subperiod to preserve bonus reward eligibility. Move actions refer to either:
+
+-   A 'partial unstake that decreases the voting stake',
+-   A 'stake transfer between two contracts'. (check previous "Moving Stake Between Contracts" section)
+
+The number of authorized safe move actions is defined by `MaxBonusSafeMovesPerPeriod`. For example:
+If 2 safe bonus move actions are allowed for one period, and a user has staked **100** on contract A during the `voting` subperiod and **50** during the `build&earn` subperiod, they can safely:
+
+1. Unstake **70**, reducing the `voting` stake to **80**.
+2. Transfer **50** to contract B.
+
+After these actions, the user will still be eligible for bonus rewards (**20** on contract A and **50** on contract B). However, if an additional move action is performed on contract A, the bonus eligibility will be forfeited.
 
 Bonus rewards need to be claimed per contract, unlike staker rewards.
 

--- a/pallets/dapp-staking/README.md
+++ b/pallets/dapp-staking/README.md
@@ -159,6 +159,8 @@ Once period finishes, all stakes are reset back to zero. This means that no unst
 
 During the `Build&Earn` subperiod, if unstaking reduces the voting stake, the bonus status will be updated, and the number of allowed _move actions_ for the ongoing period will be reduced.
 
+Any forfeited bonus is converted into `Build&Earn` stake, ensuring that voting amounts are not lost but instead reallocated appropriately.
+
 If dApp has been unregistered, a special operation to unstake from unregistered contract must be used that preserves bonus elegibility.
 
 #### Moving Stake Between Contracts
@@ -175,6 +177,12 @@ Key details about moving stake:
 
 This feature is particularly useful for stakers who wish to rebalance their stake across multiple contracts (including new registrations) or move their stake to better-performing dApps while retaining the potential for rewards and maintaining bonus eligibility.
 
+#### Bonus Status Handling in Moves
+
+When moving stake, if the destination contract has no existing bonus eligibility, it inherits the incoming bonus status from the source contract. If both the source and destination have nonzero bonus statuses, they are merged by averaging their values. This prevents unintended bonus gains or losses while ensuring fairness in bonus distribution.
+
+For example, if the configuration allows **2** safe moves, the default bonus status starts at **3**. If the source contract's bonus status decreases from **3** to **1** after an unstake and the move operation, and the destination contract retains the default **3**, the new bonus status is calculated as: **(1 + 3) / 2**, resulting into **2**.
+This ensures a smooth and fair adjustment while keeping stake amounts properly aligned.
 
 #### Claiming Staker Rewards
 

--- a/pallets/dapp-staking/src/benchmarking/mod.rs
+++ b/pallets/dapp-staking/src/benchmarking/mod.rs
@@ -1247,6 +1247,48 @@ mod benchmarks {
         );
     }
 
+    /// TODO: remove this benchmark once BonusStatus update is done
+    #[benchmark]
+    fn update_bonus_step_success() {
+        initial_config::<T>();
+
+        let staker: T::AccountId = whitelisted_caller();
+        let owner: T::AccountId = account("dapp_owner", 0, SEED);
+        let source_contract = T::BenchmarkHelper::get_smart_contract(1);
+        assert_ok!(DappStaking::<T>::register(
+            RawOrigin::Root.into(),
+            owner.clone().into(),
+            source_contract.clone(),
+        ));
+
+        let amount = T::MinimumLockedAmount::get();
+        T::BenchmarkHelper::set_balance(&staker, amount);
+        assert_ok!(DappStaking::<T>::lock(
+            RawOrigin::Signed(staker.clone()).into(),
+            amount,
+        ));
+
+        assert_ok!(DappStaking::<T>::stake(
+            RawOrigin::Signed(staker.clone()).into(),
+            source_contract.clone(),
+            amount
+        ));
+
+        #[block]
+        {
+            assert!(DappStaking::<T>::update_bonus_step(&mut StakerInfo::<T>::iter()).is_ok());
+        }
+    }
+
+    /// TODO: remove this benchmark once BonusStatus update is done
+    #[benchmark]
+    fn update_bonus_step_noop() {
+        #[block]
+        {
+            assert!(DappStaking::<T>::update_bonus_step(&mut StakerInfo::<T>::iter()).is_err());
+        }
+    }
+
     impl_benchmark_test_suite!(
         Pallet,
         crate::benchmarking::tests::new_test_ext(),

--- a/pallets/dapp-staking/src/benchmarking/mod.rs
+++ b/pallets/dapp-staking/src/benchmarking/mod.rs
@@ -875,7 +875,7 @@ mod benchmarks {
         let amount_to_move = T::MinimumLockedAmount::get();
 
         #[extrinsic_call]
-        _(
+        move_stake(
             RawOrigin::Signed(staker.clone()),
             source_contract.clone(),
             destination_contract.clone(),

--- a/pallets/dapp-staking/src/benchmarking/mod.rs
+++ b/pallets/dapp-staking/src/benchmarking/mod.rs
@@ -840,6 +840,60 @@ mod benchmarks {
     }
 
     #[benchmark]
+    fn move_stake() {
+        initial_config::<T>();
+
+        let staker: T::AccountId = whitelisted_caller();
+        let owner: T::AccountId = account("dapp_owner", 0, SEED);
+        let source_contract = T::BenchmarkHelper::get_smart_contract(1);
+        let destination_contract = T::BenchmarkHelper::get_smart_contract(2);
+        assert_ok!(DappStaking::<T>::register(
+            RawOrigin::Root.into(),
+            owner.clone().into(),
+            source_contract.clone(),
+        ));
+        assert_ok!(DappStaking::<T>::register(
+            RawOrigin::Root.into(),
+            owner.clone().into(),
+            destination_contract.clone(),
+        ));
+
+        // To preserve source staking and create destination staking
+        let amount = T::MinimumLockedAmount::get() + T::MinimumLockedAmount::get();
+        T::BenchmarkHelper::set_balance(&staker, amount);
+        assert_ok!(DappStaking::<T>::lock(
+            RawOrigin::Signed(staker.clone()).into(),
+            amount,
+        ));
+
+        assert_ok!(DappStaking::<T>::stake(
+            RawOrigin::Signed(staker.clone()).into(),
+            source_contract.clone(),
+            amount
+        ));
+
+        let amount_to_move = T::MinimumLockedAmount::get();
+
+        #[extrinsic_call]
+        _(
+            RawOrigin::Signed(staker.clone()),
+            source_contract.clone(),
+            destination_contract.clone(),
+            amount_to_move.clone(),
+        );
+
+        assert_last_event::<T>(
+            Event::<T>::StakeMoved {
+                account: staker,
+                source_contract,
+                destination_contract,
+                amount: amount_to_move,
+            }
+            .into(),
+        );
+    }
+
+    #[benchmark]
     fn on_initialize_voting_to_build_and_earn() {
         initial_config::<T>();
 

--- a/pallets/dapp-staking/src/benchmarking/mod.rs
+++ b/pallets/dapp-staking/src/benchmarking/mod.rs
@@ -259,7 +259,7 @@ mod benchmarks {
             amount,
         ));
 
-        // Move over to the build&earn subperiod to ensure 'non-loyal' staking.
+        // Move over to the build&earn subperiod to ensure staking without a bonus status.
         // This is needed so we can achieve staker entry cleanup after claiming unlocked tokens.
         force_advance_to_next_subperiod::<T>();
         assert_eq!(
@@ -782,7 +782,7 @@ mod benchmarks {
     fn cleanup_expired_entries(x: Linear<1, { T::MaxNumberOfStakedContracts::get() }>) {
         initial_config::<T>();
 
-        // Move over to the build&earn subperiod to ensure 'non-loyal' staking.
+        // Move over to the build&earn subperiod to ensure staking without a bonus status.
         force_advance_to_next_subperiod::<T>();
 
         // Prepare staker & lock some amount

--- a/pallets/dapp-staking/src/benchmarking/mod.rs
+++ b/pallets/dapp-staking/src/benchmarking/mod.rs
@@ -25,7 +25,7 @@ use frame_support::{assert_ok, migrations::SteppedMigration, weights::WeightMete
 use frame_system::{Pallet as System, RawOrigin};
 use sp_std::prelude::*;
 
-use ::assert_matches::assert_matches;
+use assert_matches::assert_matches;
 
 mod utils;
 use utils::*;
@@ -840,7 +840,7 @@ mod benchmarks {
     }
 
     #[benchmark]
-    fn move_stake() {
+    fn move_stake_from_registered_source() {
         initial_config::<T>();
 
         let staker: T::AccountId = whitelisted_caller();

--- a/pallets/dapp-staking/src/lib.rs
+++ b/pallets/dapp-staking/src/lib.rs
@@ -1570,7 +1570,7 @@ pub mod pallet {
                         let preserved_bonus_status = staking_info.bonus_status;
                         // This need to be built before 'unstake', otherwise voting amount is converted into B&E amount
                         let unstake_amount_iter: Vec<StakeAmount> =
-                            vec![staking_info.previous_staked, staking_info.staked]
+                            Vec::from([staking_info.previous_staked, staking_info.staked])
                                 .into_iter()
                                 .filter(|stake_amount| !stake_amount.is_empty())
                                 .collect();

--- a/pallets/dapp-staking/src/lib.rs
+++ b/pallets/dapp-staking/src/lib.rs
@@ -2719,11 +2719,12 @@ pub mod pallet {
                 ))
             } else {
                 // Enable maintenance mode on the first run
-                // ActiveProtocolState::<T>::mutate(|state| {
-                //     state.maintenance = true;
-                // });
-                // log::warn!("Maintenance mode enabled.");
-                // consumed_weight.saturating_add(T::DbWeight::get().reads_writes(1, 1));
+                // Likely to be already set in the runtime upgrade migration
+                ActiveProtocolState::<T>::mutate(|state| {
+                    state.maintenance = true;
+                });
+                log::warn!("Maintenance mode enabled.");
+                consumed_weight.saturating_add(T::DbWeight::get().reads_writes(1, 2));
                 StakerInfo::<T>::iter()
             };
 

--- a/pallets/dapp-staking/src/lib.rs
+++ b/pallets/dapp-staking/src/lib.rs
@@ -297,7 +297,7 @@ pub mod pallet {
             era: EraNumber,
             amount: Balance,
         },
-        /// Bonus reward has been paid out to a loyal staker.
+        /// Bonus reward has been paid out to a staker with an eligible bonus status.
         BonusReward {
             account: T::AccountId,
             smart_contract: T::SmartContract,
@@ -1217,8 +1217,8 @@ pub mod pallet {
         /// Cleanup expired stake entries for the contract.
         ///
         /// Entry is considered to be expired if:
-        /// 1. It's from a past period & the account wasn't a loyal staker, meaning there's no claimable bonus reward.
-        /// 2. It's from a period older than the oldest claimable period, regardless whether the account was loyal or not.
+        /// 1. It's from a past period & the account did not maintain an eligible bonus status, meaning there's no claimable bonus reward.
+        /// 2. It's from a period older than the oldest claimable period, regardless of whether the account had an eligible bonus status or not.
         #[pallet::call_index(17)]
         #[pallet::weight(T::WeightInfo::cleanup_expired_entries(
             T::MaxNumberOfStakedContracts::get()
@@ -1529,8 +1529,6 @@ pub mod pallet {
 
             Self::update_ledger(&account, ledger)?;
 
-            // Implementation comment, remove once production code is ready:
-            // We need to know what & how much was unstaked. The code can be made cleaner later, maybe there are redundant parts now.
             // Return the `StakeAmount` that has max total value - that's the one that is equal to the `amount` parameter.
             let unstake_amount = stake_amount_iter
                 .iter()
@@ -2373,7 +2371,7 @@ pub mod pallet {
 
             // Ensure:
             // 1. Period for which rewards are being claimed has ended.
-            // 2. Account has been a loyal staker.
+            // 2. Account has maintained an eligible bonus status.
             // 3. Rewards haven't expired.
             let staked_period = staker_info.period_number();
             ensure!(

--- a/pallets/dapp-staking/src/lib.rs
+++ b/pallets/dapp-staking/src/lib.rs
@@ -655,6 +655,12 @@ pub mod pallet {
             assert!(T::CycleConfiguration::eras_per_voting_subperiod() > 0);
             assert!(T::CycleConfiguration::eras_per_build_and_earn_subperiod() > 0);
             assert!(T::CycleConfiguration::blocks_per_era() > 0);
+
+            /// TODO: remove these checks once BonusStatus update is done
+            assert!(Self::max_call_weight().all_gte(Self::min_call_weight()));
+            assert!(Self::max_call_weight()
+                .all_lte(<T as frame_system::Config>::BlockWeights::get().max_block));
+            assert!(Self::update_weight_margin().all_lte(Self::min_call_weight()));
         }
 
         #[cfg(feature = "try-runtime")]

--- a/pallets/dapp-staking/src/lib.rs
+++ b/pallets/dapp-staking/src/lib.rs
@@ -1340,13 +1340,13 @@ pub mod pallet {
         /// Transfers stake between two smart contracts, ensuring bonus status preservation if eligible.
         /// Emits a `StakeMoved` event.
         #[pallet::call_index(21)]
-        #[pallet::weight(T::WeightInfo::move_stake())]
+        #[pallet::weight(T::WeightInfo::move_stake_unregistered_source().max(T::WeightInfo::move_stake()))]
         pub fn move_stake(
             origin: OriginFor<T>,
             source_contract: T::SmartContract,
             destination_contract: T::SmartContract,
             #[pallet::compact] amount: Balance,
-        ) -> DispatchResult {
+        ) -> DispatchResultWithPostInfo {
             Self::ensure_pallet_enabled()?;
             let account = ensure_signed(origin)?;
 
@@ -1382,7 +1382,12 @@ pub mod pallet {
                 amount: move_amount.total(),
             });
 
-            Ok(())
+            Ok(Some(if is_source_unregistered {
+                T::WeightInfo::move_stake_unregistered_source()
+            } else {
+                T::WeightInfo::move_stake()
+            })
+            .into())
         }
     }
 

--- a/pallets/dapp-staking/src/lib.rs
+++ b/pallets/dapp-staking/src/lib.rs
@@ -1195,7 +1195,7 @@ pub mod pallet {
             Self::ensure_pallet_enabled()?;
             let account = ensure_signed(origin)?;
 
-            let (unstake_amount, _remaining_moves) =
+            let (unstake_amount, _) =
                 Self::inner_unstake_from_unregistered(&account, &smart_contract)?;
 
             Self::deposit_event(Event::<T>::UnstakeFromUnregistered {
@@ -1677,7 +1677,7 @@ pub mod pallet {
             // 4.
             // Update total staked amount for the next era.
             CurrentEraInfo::<T>::mutate(|era_info| {
-                era_info.add_stake_amount(amount, protocol_state.subperiod());
+                era_info.add_stake_amount(amount);
             });
 
             // 5.

--- a/pallets/dapp-staking/src/lib.rs
+++ b/pallets/dapp-staking/src/lib.rs
@@ -1474,7 +1474,7 @@ pub mod pallet {
             // 4.
             // Update total staked amount for the next era.
             CurrentEraInfo::<T>::mutate(|era_info| {
-                era_info.unstake_amount(amount);
+                era_info.unstake_amount(stake_amount_iter.clone());
             });
 
             // 5.
@@ -1558,7 +1558,7 @@ pub mod pallet {
             // This means 'fake' stake total amount has been kept until now, even though contract was unregistered.
             // Although strange, it's been requested to keep it like this from the team.
             CurrentEraInfo::<T>::mutate(|era_info| {
-                era_info.unstake_amount(amount);
+                era_info.unstake_amount(stake_amount_iter.clone());
             });
 
             // Update remaining storage entries

--- a/pallets/dapp-staking/src/migration.rs
+++ b/pallets/dapp-staking/src/migration.rs
@@ -126,7 +126,7 @@ mod v9 {
                 "dapp-staking::migration::v9: wrong storage version"
             );
 
-            let new_default_bonus_status = crate::types::BonusStatusWrapperFor::<T>::default().0;
+            let new_default_bonus_status = *crate::types::BonusStatusWrapperFor::<T>::default();
             for (_, _, staking_info) in StakerInfo::<T>::iter() {
                 assert_eq!(staking_info.bonus_status, new_default_bonus_status);
             }

--- a/pallets/dapp-staking/src/migration.rs
+++ b/pallets/dapp-staking/src/migration.rs
@@ -79,6 +79,7 @@ mod v9 {
             ActiveProtocolState::<T>::mutate(|state| {
                 state.maintenance = true;
             });
+            log::info!("Maintenance mode enabled.");
 
             // In case of try-runtime, we want to execute the whole logic, to ensure it works
             // with on-chain data.

--- a/pallets/dapp-staking/src/migration.rs
+++ b/pallets/dapp-staking/src/migration.rs
@@ -108,31 +108,31 @@ mod v9 {
                 consumed_weight
             }
         }
-    }
 
-    #[cfg(feature = "try-runtime")]
-    fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
-        log::info!(
-            target: LOG_TARGET,
-            "Out of {} already existing stakers are expected to have their bonus updated.",
-            v8::StakerInfo::<T>::iter().count(),
-        );
-        Ok(Vec::new())
-    }
-
-    #[cfg(feature = "try-runtime")]
-    fn post_upgrade(_: Vec<u8>) -> Result<(), TryRuntimeError> {
-        ensure!(
-            Pallet::<T>::on_chain_storage_version() >= 9,
-            "dapp-staking::migration::v9: wrong storage version"
-        );
-
-        let new_default_bonus_status = crate::types::BonusStatusWrapperFor::<T>::default().0;
-        for (_, _, staking_info) in StakerInfo::<T>::iter() {
-            assert_eq!(staking_info.bonus_status, new_default_bonus_status);
+        #[cfg(feature = "try-runtime")]
+        fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+            log::info!(
+                target: LOG_TARGET,
+                "Out of {} already existing stakers are expected to have their bonus updated.",
+                v8::StakerInfo::<T>::iter().count(),
+            );
+            Ok(Vec::new())
         }
 
-        Ok(())
+        #[cfg(feature = "try-runtime")]
+        fn post_upgrade(_: Vec<u8>) -> Result<(), TryRuntimeError> {
+            ensure!(
+                Pallet::<T>::on_chain_storage_version() >= 9,
+                "dapp-staking::migration::v9: wrong storage version"
+            );
+
+            let new_default_bonus_status = crate::types::BonusStatusWrapperFor::<T>::default().0;
+            for (_, _, staking_info) in StakerInfo::<T>::iter() {
+                assert_eq!(staking_info.bonus_status, new_default_bonus_status);
+            }
+
+            Ok(())
+        }
     }
 }
 

--- a/pallets/dapp-staking/src/migration.rs
+++ b/pallets/dapp-staking/src/migration.rs
@@ -59,7 +59,7 @@ pub mod versioned_migrations {
     pub type V8ToV9<T> = frame_support::migrations::VersionedMigration<
         8,
         9,
-        v9::LazyUpdateBonusStatus<T>,
+        v9::ActiveUpdateBonusStatus<T>,
         Pallet<T>,
         <T as frame_system::Config>::DbWeight,
     >;
@@ -70,9 +70,9 @@ mod v9 {
 
     // The loyal staker flag is updated to `u8` with the new MaxBonusSafeMovesPerPeriod from config
     // for all already existing StakerInfo.
-    pub struct LazyUpdateBonusStatus<T>(PhantomData<T>);
+    pub struct ActiveUpdateBonusStatus<T>(PhantomData<T>);
 
-    impl<T: Config> UncheckedOnRuntimeUpgrade for LazyUpdateBonusStatus<T> {
+    impl<T: Config> UncheckedOnRuntimeUpgrade for ActiveUpdateBonusStatus<T> {
         fn on_runtime_upgrade() -> Weight {
             // When upgrade happens, we need to put dApp staking v3 into maintenance mode immediately.
             let mut consumed_weight = T::DbWeight::get().reads_writes(1, 2);

--- a/pallets/dapp-staking/src/migration.rs
+++ b/pallets/dapp-staking/src/migration.rs
@@ -54,6 +54,86 @@ pub mod versioned_migrations {
             Pallet<T>,
             <T as frame_system::Config>::DbWeight,
         >;
+    /// Migration V8 to V9 wrapped in a [`frame_support::migrations::VersionedMigration`], ensuring
+    /// the migration is only performed when on-chain version is 9.
+    pub type V8ToV9<T> = frame_support::migrations::VersionedMigration<
+        8,
+        9,
+        v9::LazyUpdateBonusStatus<T>,
+        Pallet<T>,
+        <T as frame_system::Config>::DbWeight,
+    >;
+}
+
+mod v9 {
+    use super::*;
+
+    // The loyal staker flag is updated to `u8` with the new MaxBonusSafeMovesPerPeriod from config
+    // for all already existing StakerInfo.
+    pub struct LazyUpdateBonusStatus<T>(PhantomData<T>);
+
+    impl<T: Config> UncheckedOnRuntimeUpgrade for LazyUpdateBonusStatus<T> {
+        fn on_runtime_upgrade() -> Weight {
+            // When upgrade happens, we need to put dApp staking v3 into maintenance mode immediately.
+            let mut consumed_weight = T::DbWeight::get().reads_writes(1, 2);
+            ActiveProtocolState::<T>::mutate(|state| {
+                state.maintenance = true;
+            });
+
+            // In case of try-runtime, we want to execute the whole logic, to ensure it works
+            // with on-chain data.
+            if cfg!(feature = "try-runtime") {
+                let mut steps = 0_u32;
+                while ActiveProtocolState::<T>::get().maintenance {
+                    match Pallet::<T>::do_update(crate::Pallet::<T>::max_call_weight()) {
+                        Ok(weight) => {
+                            consumed_weight.saturating_accrue(weight);
+                            steps.saturating_inc();
+                        }
+                        Err(_) => {
+                            panic!("Must never happen since we check whether the update is finished before calling `do_update` by checking maintenance mode.");
+                        }
+                    }
+                }
+
+                log::trace!(
+                    target: LOG_TARGET,
+                    "dApp Staking bonus update finished after {} steps with total weight of {}.",
+                    steps,
+                    consumed_weight,
+                );
+
+                consumed_weight
+            } else {
+                consumed_weight
+            }
+        }
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn pre_upgrade() -> Result<Vec<u8>, TryRuntimeError> {
+        log::info!(
+            target: LOG_TARGET,
+            "Out of {} already existing stakers are expected to have their bonus updated.",
+            v8::StakerInfo::<T>::iter().count(),
+        );
+        Ok(Vec::new())
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn post_upgrade(_: Vec<u8>) -> Result<(), TryRuntimeError> {
+        ensure!(
+            Pallet::<T>::on_chain_storage_version() >= 9,
+            "dapp-staking::migration::v9: wrong storage version"
+        );
+
+        let new_default_bonus_status = crate::types::BonusStatusWrapperFor::<T>::default().0;
+        for (_, _, staking_info) in StakerInfo::<T>::iter() {
+            assert_eq!(staking_info.bonus_status, new_default_bonus_status);
+        }
+
+        Ok(())
+    }
 }
 
 // TierThreshold as percentage of the total issuance
@@ -61,6 +141,31 @@ mod v8 {
     use super::*;
     use crate::migration::v7::TierParameters as TierParametersV7;
     use crate::migration::v7::TiersConfiguration as TiersConfigurationV7;
+
+    /// Information about how much a particular staker staked on a particular smart contract.
+    #[derive(
+        Encode, Decode, MaxEncodedLen, Copy, Clone, Debug, PartialEq, Eq, TypeInfo, Default,
+    )]
+    pub struct SingularStakingInfo {
+        /// Amount staked before, if anything.
+        pub(crate) previous_staked: StakeAmount,
+        /// Staked amount
+        pub(crate) staked: StakeAmount,
+        /// Indicates whether a staker is a loyal staker or not.
+        pub(crate) loyal_staker: bool,
+    }
+
+    /// v8 type for [`crate::StakerInfo`]
+    #[storage_alias]
+    pub type StakerInfo<T: Config> = StorageDoubleMap<
+        Pallet<T>,
+        Blake2_128Concat,
+        <T as frame_system::Config>::AccountId,
+        Blake2_128Concat,
+        <T as Config>::SmartContract,
+        SingularStakingInfo,
+        OptionQuery,
+    >;
 
     pub struct VersionMigrateV7ToV8<T, TierThresholds, ThresholdVariationPercentage>(
         PhantomData<(T, TierThresholds, ThresholdVariationPercentage)>,

--- a/pallets/dapp-staking/src/migration.rs
+++ b/pallets/dapp-staking/src/migration.rs
@@ -137,7 +137,7 @@ mod v9 {
 }
 
 // TierThreshold as percentage of the total issuance
-mod v8 {
+pub mod v8 {
     use super::*;
     use crate::migration::v7::TierParameters as TierParametersV7;
     use crate::migration::v7::TiersConfiguration as TiersConfigurationV7;

--- a/pallets/dapp-staking/src/migration.rs
+++ b/pallets/dapp-staking/src/migration.rs
@@ -116,6 +116,10 @@ mod v9 {
                 "Out of {} already existing stakers are expected to have their bonus updated.",
                 v8::StakerInfo::<T>::iter().count(),
             );
+            assert!(
+                !ActiveProtocolState::<T>::get().maintenance,
+                "Maintenance mode must be disabled before the runtime upgrade."
+            );
             Ok(Vec::new())
         }
 
@@ -125,11 +129,19 @@ mod v9 {
                 Pallet::<T>::on_chain_storage_version() >= 9,
                 "dapp-staking::migration::v9: wrong storage version"
             );
+            assert!(
+                !ActiveProtocolState::<T>::get().maintenance,
+                "Maintenance mode must be disabled after the successful runtime upgrade."
+            );
 
             let new_default_bonus_status = *crate::types::BonusStatusWrapperFor::<T>::default();
             for (_, _, staking_info) in StakerInfo::<T>::iter() {
                 assert_eq!(staking_info.bonus_status, new_default_bonus_status);
             }
+            log::info!(
+                target: LOG_TARGET,
+                "All entries updated to new_default_bonus_status {}", new_default_bonus_status,
+            );
 
             Ok(())
         }

--- a/pallets/dapp-staking/src/test/mock.rs
+++ b/pallets/dapp-staking/src/test/mock.rs
@@ -26,7 +26,9 @@ use frame_support::{
     construct_runtime, derive_impl,
     migrations::MultiStepMigrator,
     ord_parameter_types, parameter_types,
-    traits::{fungible::Mutate as FunMutate, ConstBool, ConstU128, ConstU32, EitherOfDiverse},
+    traits::{
+        fungible::Mutate as FunMutate, ConstBool, ConstU128, ConstU32, ConstU8, EitherOfDiverse,
+    },
     weights::Weight,
 };
 use sp_arithmetic::fixed_point::FixedU128;
@@ -222,6 +224,7 @@ impl pallet_dapp_staking::Config for Test {
     type MinimumStakeAmount = ConstU128<3>;
     type NumberOfTiers = ConstU32<4>;
     type RankingEnabled = ConstBool<true>;
+    type MaxBonusSafeMovesPerPeriod = ConstU8<2>;
     type WeightInfo = weights::SubstrateWeight<Test>;
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = BenchmarkHelper<MockSmartContract, AccountId>;

--- a/pallets/dapp-staking/src/test/testing_utils.rs
+++ b/pallets/dapp-staking/src/test/testing_utils.rs
@@ -550,8 +550,8 @@ pub(crate) fn assert_stake(
             );
             assert_eq!(post_staker_info.period_number(), stake_period);
             assert_eq!(
-                post_staker_info.is_loyal(),
-                pre_staker_info.is_loyal(),
+                post_staker_info.is_bonus_eligible(),
+                pre_staker_info.is_bonus_eligible(),
                 "Staking operation mustn't change loyalty flag."
             );
         }
@@ -570,7 +570,7 @@ pub(crate) fn assert_stake(
             );
             assert_eq!(post_staker_info.period_number(), stake_period);
             assert_eq!(
-                post_staker_info.is_loyal(),
+                post_staker_info.is_bonus_eligible(),
                 stake_subperiod == Subperiod::Voting
             );
         }
@@ -713,7 +713,7 @@ pub(crate) fn assert_unstake(
             "Staked amount must decrease by the 'amount'"
         );
 
-        let is_loyal = pre_staker_info.is_loyal()
+        let is_bonus_eligible = pre_staker_info.is_bonus_eligible()
             && match unstake_subperiod {
                 Subperiod::Voting => !post_staker_info.staked_amount(Subperiod::Voting).is_zero(),
                 Subperiod::BuildAndEarn => {
@@ -723,8 +723,8 @@ pub(crate) fn assert_unstake(
             };
 
         assert_eq!(
-            post_staker_info.is_loyal(),
-            is_loyal,
+            post_staker_info.is_bonus_eligible(),
+            is_bonus_eligible,
             "If 'Voting' stake amount is reduced in B&E period, loyalty flag must be set to false."
         );
     }
@@ -1195,7 +1195,7 @@ pub(crate) fn assert_cleanup_expired_entries(account: AccountId) {
         .iter()
         .for_each(|((inner_account, contract), entry)| {
             if *inner_account == account {
-                if entry.period_number() < current_period && !entry.is_loyal()
+                if entry.period_number() < current_period && !entry.is_bonus_eligible()
                     || entry.period_number() < threshold_period
                 {
                     to_be_deleted.push(contract);

--- a/pallets/dapp-staking/src/test/testing_utils.rs
+++ b/pallets/dapp-staking/src/test/testing_utils.rs
@@ -841,7 +841,7 @@ pub(crate) fn assert_move_stake(
     let unstake_amount_entries_clone = unstake_amount_entries.clone();
     let stake_amount = unstake_amount_entries_clone
         .iter()
-        .max_by(|a, b| a.compare_stake_amounts(b))
+        .max_by(|a, b| a.total().cmp(&b.total()))
         .expect("At least one value exists, otherwise we wouldn't be here.");
     assert_eq!(stake_amount.total(), amount_to_move);
 

--- a/pallets/dapp-staking/src/test/testing_utils.rs
+++ b/pallets/dapp-staking/src/test/testing_utils.rs
@@ -2030,17 +2030,19 @@ fn assert_era_info_current(
     stake_amount_entries: impl IntoIterator<Item = StakeAmount>,
 ) {
     let entries: Vec<StakeAmount> = stake_amount_entries.into_iter().collect();
-    if let Some(first_entry) = entries.first() {
-        let amount = first_entry.total();
-        // It's possible next era has staked more than the current era. This is because 'stake' (or 'move') will always stake for the NEXT era.
-        if pre_era_info.total_staked_amount() < amount {
-            assert!(post_era_info.total_staked_amount().is_zero());
-        } else {
-            assert_eq!(
-                post_era_info.total_staked_amount(),
-                pre_era_info.total_staked_amount() - amount,
-                "Total staked amount for the current era must decrease by 'amount'."
-            );
+    for entry in entries {
+        let (era, amount) = (entry.era, entry.total());
+
+        if era == pre_era_info.current_stake_amount.era {
+            if pre_era_info.total_staked_amount() < amount {
+                assert!(post_era_info.total_staked_amount().is_zero());
+            } else {
+                assert_eq!(
+                    post_era_info.total_staked_amount(),
+                    pre_era_info.total_staked_amount() - amount,
+                    "Total staked amount for the current era must decrease by 'amount'."
+                );
+            }
         }
     }
 }

--- a/pallets/dapp-staking/src/test/testing_utils.rs
+++ b/pallets/dapp-staking/src/test/testing_utils.rs
@@ -828,7 +828,7 @@ pub(crate) fn assert_move_stake(
     // =====================
     // =====================
 
-    let (unstake_amount_entries, bonus_status) = assert_staker_info_and_unstake(
+    let (amount_entries, bonus_status) = assert_staker_info_and_unstake(
         &pre_snapshot,
         &post_snapshot,
         account,
@@ -836,6 +836,20 @@ pub(crate) fn assert_move_stake(
         amount_to_move,
         is_full_move_from_source,
     );
+
+    let pre_staker_info = pre_snapshot
+        .staker_info
+        .get(&(account, source_contract.clone()))
+        .expect("Entry must exist since 'move' is being called.");
+
+    let unstake_amount_entries = if is_source_unregistered {
+        vec![pre_staker_info.previous_staked, pre_staker_info.staked]
+            .into_iter()
+            .filter(|stake_amount| !stake_amount.is_empty())
+            .collect::<Vec<StakeAmount>>()
+    } else {
+        amount_entries
+    };
 
     let unstake_amount_entries_clone = unstake_amount_entries.clone();
     let stake_amount = unstake_amount_entries_clone

--- a/pallets/dapp-staking/src/test/tests.rs
+++ b/pallets/dapp-staking/src/test/tests.rs
@@ -1285,7 +1285,7 @@ fn stake_fails_due_to_too_many_staked_contracts() {
         let account = 1;
         assert_lock(account, 100 as Balance * max_number_of_contracts as Balance);
 
-        // Advance to build&earn subperiod so we ensure 'non-loyal' staking
+        // Advance to the build&earn subperiod to ensure staking without a bonus status.
         advance_to_next_subperiod();
 
         // Register smart contracts up to the max allowed number
@@ -1333,7 +1333,7 @@ fn move_fails_due_to_too_many_staked_contracts() {
         let account = 1;
         assert_lock(account, 100 as Balance * max_number_of_contracts as Balance);
 
-        // Advance to build&earn subperiod so we ensure 'non-loyal' staking
+        // Advance to the build&earn subperiod to ensure staking without a bonus status.
         advance_to_next_subperiod();
 
         let source_contract = MockSmartContract::Wasm(1);

--- a/pallets/dapp-staking/src/test/tests.rs
+++ b/pallets/dapp-staking/src/test/tests.rs
@@ -4029,7 +4029,7 @@ fn move_stake_multiple_conversions_are_ok() {
         let expected_dest_staking_info = SingularStakingInfo {
             previous_staked: StakeAmount {
                 voting: 100,
-                build_and_earn: 150, // TODO: should it not be 0 here?
+                build_and_earn: 0,
                 era: 2,
                 period: 1,
             },

--- a/pallets/dapp-staking/src/test/tests.rs
+++ b/pallets/dapp-staking/src/test/tests.rs
@@ -1269,29 +1269,33 @@ fn stake_fails_due_to_too_many_staked_contracts() {
     })
 }
 
-// #[test]
-// fn move_fails_due_to_too_many_staked_contracts() {
-//     ExtBuilder::default().build_and_execute(|| {
-//         let account = 1;
-//         let excess_destination_contract = setup_max_staked_contracts(account);
-//
-//         // Register & stake the source contract separately
-//         let source_contract = MockSmartContract::Wasm(1);
-//         assert_register(account, &source_contract);
-//         assert_stake(account, &source_contract, 10);
-//
-//         // Max number of staked contract entries has been exceeded.
-//         assert_noop!(
-//             DappStaking::move_stake(
-//                 RuntimeOrigin::signed(account),
-//                 source_contract,
-//                 excess_destination_contract.clone(),
-//                 10
-//             ),
-//             Error::<Test>::TooManyStakedContracts
-//         );
-//     })
-// }
+#[test]
+fn move_fails_due_to_too_many_staked_contracts() {
+    ExtBuilder::default().build_and_execute(|| {
+        let account = 1;
+        let excess_destination_contract = setup_max_staked_contracts(account);
+        let source_contract = MockSmartContract::Wasm(1);
+
+        // Max number of staked contract entries has been exceeded.
+        assert_noop!(
+            DappStaking::move_stake(
+                RuntimeOrigin::signed(account),
+                source_contract,
+                excess_destination_contract.clone(),
+                5 // not full move to preserved contract_stake_count
+            ),
+            Error::<Test>::TooManyStakedContracts
+        );
+
+        // However a full move works because it decreases contract_stake_count before via the inner_unstake
+        assert_ok!(DappStaking::move_stake(
+            RuntimeOrigin::signed(account),
+            source_contract,
+            excess_destination_contract.clone(),
+            10
+        ));
+    })
+}
 
 #[test]
 fn unstake_basic_example_is_ok() {

--- a/pallets/dapp-staking/src/test/tests.rs
+++ b/pallets/dapp-staking/src/test/tests.rs
@@ -3782,6 +3782,22 @@ fn move_stake_from_unregistered_contract_is_ok() {
             &dest_contract,
             1, // the amount is not important for an unregistered contract, everything is moved
         );
+
+        let default_bonus_status = BonusStatusWrapperFor::<Test>::default().0;
+        assert!(StakerInfo::<Test>::get(&account, &source_contract).is_none());
+        let expected_dest_staking_info = SingularStakingInfo {
+            previous_staked: StakeAmount::default(),
+            staked: StakeAmount {
+                voting: partial_stake_1,
+                build_and_earn: partial_stake_2,
+                era: 3,
+                period: 1,
+            },
+            bonus_status: default_bonus_status,
+        };
+        let dest_staking_info = StakerInfo::<Test>::get(&account, &dest_contract)
+            .expect("Should exist after a successful move operation");
+        assert_eq!(dest_staking_info, expected_dest_staking_info);
     })
 }
 

--- a/pallets/dapp-staking/src/test/tests_types.rs
+++ b/pallets/dapp-staking/src/test/tests_types.rs
@@ -517,6 +517,7 @@ fn account_ledger_add_stake_amount_basic_example_with_different_subperiods_works
                 period: period_number,
                 ..StakeAmount::default()
             },
+            0,
             PeriodInfo {
                 number: period_number,
                 subperiod: Subperiod::Voting,
@@ -546,7 +547,7 @@ fn account_ledger_add_stake_amount_basic_example_with_different_subperiods_works
     acc_ledger.add_lock_amount(lock_amount);
 
     assert!(acc_ledger
-        .add_stake_amount(stake_amount_1, period_info_1)
+        .add_stake_amount(stake_amount_1, era_1, period_info_1)
         .is_ok());
 
     assert!(
@@ -591,7 +592,7 @@ fn account_ledger_add_stake_amount_basic_example_with_different_subperiods_works
         period: period_1,
     };
     assert!(acc_ledger
-        .add_stake_amount(stake_amount_2, period_info_2)
+        .add_stake_amount(stake_amount_2, era_2, period_info_2)
         .is_ok());
     assert_eq!(
         acc_ledger.staked_amount(period_1),
@@ -643,7 +644,7 @@ fn account_ledger_add_stake_amount_basic_example_with_same_subperiods_works() {
     acc_ledger.add_lock_amount(lock_amount);
 
     assert!(acc_ledger
-        .add_stake_amount(stake_amount_1, period_info)
+        .add_stake_amount(stake_amount_1, era_1, period_info)
         .is_ok());
 
     assert!(
@@ -677,7 +678,7 @@ fn account_ledger_add_stake_amount_basic_example_with_same_subperiods_works() {
     };
 
     assert!(acc_ledger
-        .add_stake_amount(stake_amount_2, period_info)
+        .add_stake_amount(stake_amount_2, era_1, period_info)
         .is_ok());
     assert_eq!(acc_ledger.staked, snapshot);
     assert_eq!(
@@ -696,7 +697,7 @@ fn account_ledger_add_stake_amount_basic_example_with_same_subperiods_works() {
         period: period_1,
     };
     assert!(acc_ledger
-        .add_stake_amount(stake_amount_3, period_info)
+        .add_stake_amount(stake_amount_3, era_2, period_info)
         .is_ok());
 
     assert_eq!(
@@ -760,7 +761,7 @@ fn account_ledger_add_stake_amount_advanced_example_works() {
     };
     let acc_ledger_snapshot = acc_ledger.clone();
     assert!(acc_ledger
-        .add_stake_amount(stake_amount_2, period_info_1)
+        .add_stake_amount(stake_amount_2, era_1, period_info_1)
         .is_ok());
     assert_eq!(
         acc_ledger.staked_amount(period_1),
@@ -807,7 +808,7 @@ fn account_ledger_add_stake_amount_invalid_era_or_period_fails() {
     };
     acc_ledger.add_lock_amount(lock_amount);
     assert!(acc_ledger
-        .add_stake_amount(stake_amount_1, period_info_1)
+        .add_stake_amount(stake_amount_1, era_1, period_info_1)
         .is_ok());
 
     // Try to add to era after next, it should fail.
@@ -818,7 +819,7 @@ fn account_ledger_add_stake_amount_invalid_era_or_period_fails() {
         period: period_1,
     };
     assert_eq!(
-        acc_ledger.add_stake_amount(stake_amount_2, period_info_1),
+        acc_ledger.add_stake_amount(stake_amount_2, era_1 + 2, period_info_1),
         Err(AccountLedgerError::InvalidEra)
     );
 
@@ -832,6 +833,7 @@ fn account_ledger_add_stake_amount_invalid_era_or_period_fails() {
     assert_eq!(
         acc_ledger.add_stake_amount(
             stake_amount_3,
+            era_1,
             PeriodInfo {
                 number: period_1 + 1,
                 subperiod: Subperiod::Voting,
@@ -858,7 +860,7 @@ fn account_ledger_add_stake_amount_invalid_era_or_period_fails() {
         period: period_1,
     };
     assert_eq!(
-        acc_ledger.add_stake_amount(stake_amount_4, period_info_1),
+        acc_ledger.add_stake_amount(stake_amount_4, era_1 + 1, period_info_1),
         Err(AccountLedgerError::InvalidEra)
     );
 
@@ -871,6 +873,7 @@ fn account_ledger_add_stake_amount_invalid_era_or_period_fails() {
     assert_eq!(
         acc_ledger.add_stake_amount(
             stake_amount_5,
+            era_1,
             PeriodInfo {
                 number: period_1 + 1,
                 subperiod: Subperiod::Voting,
@@ -896,6 +899,7 @@ fn account_ledger_add_stake_amount_too_large_amount_fails() {
     assert_eq!(
         acc_ledger.add_stake_amount(
             stake_amount,
+            1,
             PeriodInfo {
                 number: 1,
                 subperiod: Subperiod::Voting,
@@ -922,7 +926,7 @@ fn account_ledger_add_stake_amount_too_large_amount_fails() {
         period: period_1,
     };
     assert_eq!(
-        acc_ledger.add_stake_amount(stake_amount, period_info_1),
+        acc_ledger.add_stake_amount(stake_amount, era_1, period_info_1),
         Err(AccountLedgerError::UnavailableStakeFunds)
     );
 
@@ -934,7 +938,7 @@ fn account_ledger_add_stake_amount_too_large_amount_fails() {
         period: period_1,
     };
     assert!(acc_ledger
-        .add_stake_amount(stake_amount, period_info_1)
+        .add_stake_amount(stake_amount, era_1, period_info_1)
         .is_ok());
 
     let stake_amount = StakeAmount {
@@ -944,7 +948,7 @@ fn account_ledger_add_stake_amount_too_large_amount_fails() {
         period: period_1,
     };
     assert_eq!(
-        acc_ledger.add_stake_amount(stake_amount, period_info_1),
+        acc_ledger.add_stake_amount(stake_amount, era_1, period_info_1),
         Err(AccountLedgerError::UnavailableStakeFunds)
     );
 }
@@ -975,7 +979,7 @@ fn account_ledger_unstake_amount_basic_scenario_works() {
         period: period_1,
     };
     assert!(acc_ledger
-        .add_stake_amount(stake_amount, period_info_1)
+        .add_stake_amount(stake_amount, era_1, period_info_1)
         .is_ok());
 
     // Only 'current' entry has some values, future is set to None.
@@ -1086,7 +1090,7 @@ fn account_ledger_unstake_amount_advanced_scenario_works() {
         period: period_1,
     };
     assert!(acc_ledger
-        .add_stake_amount(stake_amount, period_info_1)
+        .add_stake_amount(stake_amount, era_2, period_info_1)
         .is_ok());
     assert_eq!(acc_ledger.staked_amount(period_1), amount_2);
     assert_eq!(acc_ledger.staked, StakeAmount::default());
@@ -1121,7 +1125,7 @@ fn account_ledger_unstake_from_invalid_era_fails() {
         period: period_1,
     };
     assert!(acc_ledger
-        .add_stake_amount(stake_amount, period_info_1)
+        .add_stake_amount(stake_amount, era_1, period_info_1)
         .is_ok());
 
     // Try to unstake from the current & next era, it should work.
@@ -1199,7 +1203,7 @@ fn account_ledger_unstake_too_much_fails() {
         period: period_1,
     };
     assert!(acc_ledger
-        .add_stake_amount(stake_amount, period_info_1)
+        .add_stake_amount(stake_amount, era_1, period_info_1)
         .is_ok());
 
     assert_eq!(
@@ -1237,7 +1241,7 @@ fn account_ledger_unlockable_amount_works() {
         period: stake_period,
     };
     assert!(acc_ledger
-        .add_stake_amount(stake_amount, period_info)
+        .add_stake_amount(stake_amount, lock_era, period_info)
         .is_ok());
     assert_eq!(
         acc_ledger.unlockable_amount(stake_period),
@@ -2211,7 +2215,7 @@ fn singular_staking_info_basics_are_ok() {
         era: era_1,
         period: period_number,
     };
-    staking_info.stake(stake_amount_1, 0);
+    staking_info.stake(stake_amount_1, era_1, 0);
     assert_eq!(staking_info.total_staked_amount(), vote_stake_amount_1);
     assert_eq!(
         staking_info.staked_amount(Subperiod::Voting),
@@ -2237,7 +2241,7 @@ fn singular_staking_info_basics_are_ok() {
         period: period_number,
     };
 
-    staking_info.stake(stake_amount_2, 0);
+    staking_info.stake(stake_amount_2, era_2, 0);
     assert_eq!(
         staking_info.total_staked_amount(),
         vote_stake_amount_1 + bep_stake_amount_1
@@ -2277,7 +2281,7 @@ fn singular_staking_info_unstake_during_voting_is_ok() {
         era: era_1,
         period: period_number,
     };
-    staking_info.stake(stake_amount_1, 0);
+    staking_info.stake(stake_amount_1, era_1, 0);
 
     // 1. Unstake some amount during `Voting` period, bonus should remain as expected.
     let unstake_amount_1 = 5;
@@ -2360,7 +2364,7 @@ fn singular_staking_info_unstake_during_bep_is_ok() {
         era: era_1 - 1,
         period: period_number,
     };
-    staking_info.stake(stake_amount_1, 0);
+    staking_info.stake(stake_amount_1, era_1 - 1, 0);
 
     let bep_stake_amount_1 = 23;
     let stake_amount_2 = StakeAmount {
@@ -2369,7 +2373,7 @@ fn singular_staking_info_unstake_during_bep_is_ok() {
         era: era_1,
         period: period_number,
     };
-    staking_info.stake(stake_amount_2, 0);
+    staking_info.stake(stake_amount_2, era_1, 0);
 
     assert_eq!(staking_info.previous_staked.total(), vote_stake_amount_1);
     assert_eq!(staking_info.previous_staked.era, era_1);
@@ -2419,7 +2423,7 @@ fn singular_staking_info_unstake_during_bep_is_ok() {
         era: era_1,
         period: period_number,
     };
-    staking_info.stake(stake_amount, 0);
+    staking_info.stake(stake_amount, era_1, 0);
     let previous_total_stake = staking_info.previous_staked.total();
     let delta = staking_info.staked.total() - staking_info.previous_staked.total();
     let overflow = 1;
@@ -2553,12 +2557,12 @@ fn singular_staking_info_unstake_stake_amount_entries_are_ok() {
         let stake_amount = StakeAmount {
             voting: 0,
             build_and_earn: bep_stake_amount,
-            era: era,
+            era,
             period: period_number,
         };
         let unstake_amount = 3;
         let mut staking_info = SingularStakingInfo::new(period_number, 0);
-        staking_info.stake(stake_amount, 0);
+        staking_info.stake(stake_amount, era, 0);
 
         let expected_stake_amount = StakeAmount {
             voting: 0,
@@ -2579,12 +2583,12 @@ fn singular_staking_info_unstake_stake_amount_entries_are_ok() {
         let stake_amount = StakeAmount {
             voting: 0,
             build_and_earn: bep_stake_amount,
-            era: era,
+            era,
             period: period_number,
         };
         let unstake_amount = 5;
         let mut staking_info = SingularStakingInfo::new(period_number, 0);
-        staking_info.stake(stake_amount, 0);
+        staking_info.stake(stake_amount, era, 0);
 
         let expected_stake_amount_1 = StakeAmount {
             voting: 0,
@@ -2615,11 +2619,11 @@ fn singular_staking_info_unstake_stake_amount_entries_are_ok() {
         let stake_amount = StakeAmount {
             voting: 0,
             build_and_earn: bep_stake_amount,
-            era: era,
+            era,
             period: period_number,
         };
         let mut staking_info = SingularStakingInfo::new(period_number, 0);
-        staking_info.stake(stake_amount, 0);
+        staking_info.stake(stake_amount, era, 0);
 
         let expected_stake_amount_1 = StakeAmount {
             voting: 0,
@@ -2655,7 +2659,7 @@ fn singular_staking_stake_with_bonus_status() {
 
     // Prep - StakeAmount with forfeited bonus and voting stake
     let mut staking_info = SingularStakingInfo::new(0, 0);
-    staking_info.stake(stake_amount, 0);
+    staking_info.stake(stake_amount, 1, 0);
     assert_eq!(
         staking_info.bonus_status, 0,
         "Bonus status should be initialized to 0 before staking"
@@ -2663,7 +2667,7 @@ fn singular_staking_stake_with_bonus_status() {
 
     // Scenario 1 - Stake again but with incoming bonus status
     let incoming_bonus_status = 1;
-    staking_info.stake(stake_amount, incoming_bonus_status);
+    staking_info.stake(stake_amount, 1, incoming_bonus_status);
 
     // Check if the bonus status is updated
     assert_eq!(
@@ -2685,14 +2689,14 @@ fn singular_staking_stake_with_bonus_status() {
     // Scenario 2 - bonus_status is not 0 anymore and new voting amount is staked on same staking_info
     let voting_amount_snapshot = staking_info.staked_amount(Subperiod::Voting);
     let bep_amount_snapshot = staking_info.staked_amount(Subperiod::BuildAndEarn);
-    staking_info.stake(stake_amount, 0);
+    staking_info.stake(stake_amount, 1, 0);
     assert_eq!(
         staking_info.bonus_status, incoming_bonus_status,
         "Bonus status should be initialized to prev incoming_bonus_status"
     );
 
     let incoming_bonus_status_2 = 10;
-    staking_info.stake(stake_amount, incoming_bonus_status_2);
+    staking_info.stake(stake_amount, 1, incoming_bonus_status_2);
 
     // Ensure that the StakeAmount is increased with bonus status remaining the same
     assert_eq!(
@@ -2841,7 +2845,7 @@ fn contract_stake_amount_stake_is_ok() {
         era: era_1,
         period: period_1,
     };
-    contract_stake.stake(amount_1, period_1);
+    contract_stake.stake(amount_1, era_1, period_1);
     assert!(!contract_stake.is_empty());
     assert!(
         contract_stake.staked.is_empty(),
@@ -2870,7 +2874,7 @@ fn contract_stake_amount_stake_is_ok() {
         era: era_1,
         period: period_1,
     };
-    contract_stake.stake(amount_2, period_1);
+    contract_stake.stake(amount_2, era_1, period_1);
     let entry_1_2 = contract_stake.get(stake_era_1, period_1).unwrap();
     assert_eq!(entry_1_2.era, stake_era_1);
     assert_eq!(entry_1_2.total(), amount_1.total() + amount_2.total());
@@ -2895,7 +2899,7 @@ fn contract_stake_amount_stake_is_ok() {
         era: era_2,
         period: period_1,
     };
-    contract_stake.stake(amount_3, period_1);
+    contract_stake.stake(amount_3, era_2, period_1);
     let entry_2_1 = contract_stake
         .get(era_2, period_1)
         .expect("Since stake will change next era, entries should be aligned.");
@@ -2933,7 +2937,7 @@ fn contract_stake_amount_stake_is_ok() {
         period: period_2,
     };
 
-    contract_stake.stake(amount_4, period_2);
+    contract_stake.stake(amount_4, era_3, period_2);
     assert!(
         contract_stake.get(era_2, period_1).is_none(),
         "Old period must be removed."
@@ -2966,7 +2970,7 @@ fn contract_stake_amount_stake_is_ok() {
         era: era_4,
         period: period_2,
     };
-    contract_stake.stake(amount_5, period_2);
+    contract_stake.stake(amount_5, era_4, period_2);
     let entry_4_1 = contract_stake.get(stake_era_3, period_2).unwrap();
     let entry_4_2 = contract_stake.get(stake_era_4, period_2).unwrap();
     assert_eq!(entry_4_1, entry_3_1, "Old entry must remain unchanged.");
@@ -3001,7 +3005,7 @@ fn contract_stake_amount_basic_unstake_is_ok() {
         era: era_1,
         period,
     };
-    contract_stake.stake(stake_amount, period);
+    contract_stake.stake(stake_amount, era_1, period);
     let total_stake_amount = stake_amount.total();
 
     // 1st scenario - unstake some amount from the next era, B&E subperiod
@@ -3165,8 +3169,8 @@ fn contract_stake_amount_advanced_unstake_is_ok() {
         era: era_2,
         period,
     };
-    contract_stake.stake(stake_amount_1, period);
-    contract_stake.stake(stake_amount_2, period);
+    contract_stake.stake(stake_amount_1, era_1, period);
+    contract_stake.stake(stake_amount_2, era_2, period);
     let total_stake_amount = stake_amount_1.total() + stake_amount_2.total();
 
     // Unstake some amount from both staked & staked_future fields

--- a/pallets/dapp-staking/src/test/tests_types.rs
+++ b/pallets/dapp-staking/src/test/tests_types.rs
@@ -2050,7 +2050,7 @@ fn era_info_unstake_works() {
     };
     era_info.unstake_amount(vec![unstake_amount_2_current]);
 
-    // Current era remains unchanged
+    // Current era
     assert_eq!(
         era_info.total_staked_amount(),
         total_staked - unstake_amount_1_current.total() - unstake_amount_2_current.total()
@@ -2061,10 +2061,10 @@ fn era_info_unstake_works() {
     );
     assert!(era_info.staked_amount(Subperiod::BuildAndEarn).is_zero());
 
-    // Next era
+    // Next era remains unchanged
     assert_eq!(
         era_info.total_staked_amount_next_era(),
-        total_staked_next_era - unstake_amount_1_next.total() - unstake_amount_2_current.total()
+        total_staked_next_era - unstake_amount_1_next.total()
     );
     assert_eq!(
         era_info.staked_amount_next_era(Subperiod::Voting),
@@ -2072,7 +2072,7 @@ fn era_info_unstake_works() {
     );
     assert_eq!(
         era_info.staked_amount_next_era(Subperiod::BuildAndEarn),
-        bep_stake_amount_2 - unstake_amount_1_next.build_and_earn - overflow
+        bep_stake_amount_2 - unstake_amount_1_next.build_and_earn
     );
 }
 

--- a/pallets/dapp-staking/src/test/tests_types.rs
+++ b/pallets/dapp-staking/src/test/tests_types.rs
@@ -2543,18 +2543,19 @@ fn singular_staking_info_unstake_during_bep_is_ok() {
 
     // 4th scenario - Bonus forfeited
     // Fully exhaust the bonus by performing another unstake during the B&E subperiod
+    // Voting stake amount should migrate to B&E stake
     let era_3 = era_2 + 2;
     let unstake_3 = 5;
 
     let expected_stake_amount_1 = StakeAmount {
-        voting: unstake_3,
-        build_and_earn: 0,
+        voting: 0,
+        build_and_earn: unstake_3,
         era: era_3,
         period: period_number,
     };
     let expected_stake_amount_2 = StakeAmount {
-        voting: unstake_3,
-        build_and_earn: 0,
+        voting: 0,
+        build_and_earn: unstake_3,
         era: era_3 + 1,
         period: period_number,
     };
@@ -2700,13 +2701,13 @@ fn singular_staking_stake_with_bonus_status() {
     // Ensure that the previous voting stake amount was moved to BuildAndEarn
     assert_eq!(
         staking_info.staked_amount(Subperiod::Voting),
-        voting_amount,
+        voting_amount + voting_amount,
         "Voting amount should increase correctly"
     );
     assert_eq!(
         staking_info.staked_amount(Subperiod::BuildAndEarn),
-        (voting_amount + bep_amount) + bep_amount,
-        "BuildAndEarn amount should have increased including previous voting stake"
+        bep_amount + bep_amount,
+        "BuildAndEarn amount should increase correctly"
     );
 
     // Scenario 2 - bonus_status is not 0 anymore and new voting amount is staked on same staking_info

--- a/pallets/dapp-staking/src/test/tests_types.rs
+++ b/pallets/dapp-staking/src/test/tests_types.rs
@@ -2726,11 +2726,12 @@ fn singular_staking_stake_with_bonus_status() {
     );
 
     let incoming_bonus_status_2 = 10;
+    let expected_merged_bonus_status = (incoming_bonus_status_2 + staking_info.bonus_status) / 2; // (both bonus_status are not 0)
     staking_info.stake(stake_amount, 1, incoming_bonus_status_2);
 
-    // Ensure that the StakeAmount is increased with bonus status remaining the same
+    // Ensure that the StakeAmount is increased with bonus status merged
     assert_eq!(
-        staking_info.bonus_status, incoming_bonus_status,
+        staking_info.bonus_status, expected_merged_bonus_status,
         "Bonus status should remain the same"
     );
     assert_eq!(

--- a/pallets/dapp-staking/src/test/tests_types.rs
+++ b/pallets/dapp-staking/src/test/tests_types.rs
@@ -2380,10 +2380,11 @@ fn singular_staking_info_unstake_during_bep_is_ok() {
 
     // Prep actions
     let era_1 = 3;
-    let vote_stake_amount_1 = 11;
+    let vote_stake_amount_prep = 11;
+    let bep_stake_amount_prep = 1;
     let stake_amount_1 = StakeAmount {
-        voting: vote_stake_amount_1,
-        build_and_earn: 0,
+        voting: vote_stake_amount_prep,
+        build_and_earn: bep_stake_amount_prep,
         era: era_1 - 1,
         period: period_number,
     };
@@ -2398,7 +2399,8 @@ fn singular_staking_info_unstake_during_bep_is_ok() {
     };
     staking_info.stake(stake_amount_2, era_1, 0);
 
-    assert_eq!(staking_info.previous_staked.total(), vote_stake_amount_1);
+    let expected_prep_amount = vote_stake_amount_prep + bep_stake_amount_prep;
+    assert_eq!(staking_info.previous_staked.total(), expected_prep_amount);
     assert_eq!(staking_info.previous_staked.era, era_1);
 
     // 1st scenario - Unstake some of the amount staked during B&E period
@@ -2416,15 +2418,15 @@ fn singular_staking_info_unstake_during_bep_is_ok() {
     );
     assert_eq!(
         staking_info.total_staked_amount(),
-        vote_stake_amount_1 + bep_stake_amount_1 - unstake_1
+        expected_prep_amount + bep_stake_amount_1 - unstake_1
     );
     assert_eq!(
         staking_info.staked_amount(Subperiod::Voting),
-        vote_stake_amount_1
+        vote_stake_amount_prep
     );
     assert_eq!(
         staking_info.staked_amount(Subperiod::BuildAndEarn),
-        bep_stake_amount_1 - unstake_1
+        bep_stake_amount_prep + bep_stake_amount_1 - unstake_1
     );
     assert!(staking_info.is_bonus_eligible());
     assert_eq!(
@@ -2434,7 +2436,7 @@ fn singular_staking_info_unstake_during_bep_is_ok() {
     );
 
     // No changes to the previous staked amount
-    assert_eq!(staking_info.previous_staked.total(), vote_stake_amount_1);
+    assert_eq!(staking_info.previous_staked.total(), expected_prep_amount);
     assert_eq!(staking_info.previous_staked.era, era_1);
 
     // 2nd scenario - Ensure that staked amount is larger than the previous stake amount, and then
@@ -2447,6 +2449,10 @@ fn singular_staking_info_unstake_during_bep_is_ok() {
         period: period_number,
     };
     staking_info.stake(stake_amount, era_1, 0);
+    // This must remain unchanged since we are still staking for era_1 (same as previous stake operation)
+    assert_eq!(staking_info.previous_staked.total(), expected_prep_amount);
+    assert_eq!(staking_info.previous_staked.era, era_1);
+
     let previous_total_stake = staking_info.previous_staked.total();
     let delta = staking_info.staked.total() - staking_info.previous_staked.total();
     let overflow = 1;
@@ -2474,15 +2480,15 @@ fn singular_staking_info_unstake_during_bep_is_ok() {
 
     assert_eq!(
         staking_info.total_staked_amount(),
-        vote_stake_amount_1 + bep_stake_amount_1 + bep_stake_amount_2 - unstake_1 - unstake_2
+        expected_prep_amount + bep_stake_amount_1 + bep_stake_amount_2 - unstake_1 - unstake_2
     );
     assert_eq!(
         staking_info.staked_amount(Subperiod::Voting),
-        vote_stake_amount_1
+        vote_stake_amount_prep
     );
     assert_eq!(
         staking_info.staked_amount(Subperiod::BuildAndEarn),
-        bep_stake_amount_1 + bep_stake_amount_2 - unstake_1 - unstake_2
+        bep_stake_amount_prep + bep_stake_amount_1 + bep_stake_amount_2 - unstake_1 - unstake_2
     );
 
     assert_eq!(
@@ -2525,7 +2531,7 @@ fn singular_staking_info_unstake_during_bep_is_ok() {
     );
     assert_eq!(
         staking_info.staked_amount(Subperiod::Voting),
-        vote_stake_amount_1 - voting_stake_overflow
+        vote_stake_amount_prep - voting_stake_overflow
     );
     assert!(staking_info
         .staked_amount(Subperiod::BuildAndEarn)

--- a/pallets/dapp-staking/src/test/tests_types.rs
+++ b/pallets/dapp-staking/src/test/tests_types.rs
@@ -1945,7 +1945,7 @@ fn era_info_stake_works() {
         voting: vp_stake_amount,
         ..StakeAmount::default()
     };
-    era_info.add_stake_amount(stake_amount, Subperiod::Voting);
+    era_info.add_stake_amount(stake_amount);
     assert_eq!(era_info.total_staked_amount_next_era(), vp_stake_amount);
     assert_eq!(
         era_info.staked_amount_next_era(Subperiod::Voting),
@@ -1962,7 +1962,7 @@ fn era_info_stake_works() {
         build_and_earn: bep_stake_amount,
         ..StakeAmount::default()
     };
-    era_info.add_stake_amount(stake_amount, Subperiod::BuildAndEarn);
+    era_info.add_stake_amount(stake_amount);
     assert_eq!(
         era_info.total_staked_amount_next_era(),
         vp_stake_amount + bep_stake_amount

--- a/pallets/dapp-staking/src/test/tests_types.rs
+++ b/pallets/dapp-staking/src/test/tests_types.rs
@@ -2219,7 +2219,7 @@ fn singular_staking_info_basics_are_ok() {
     type TestBonusStatusWrapper = BonusStatusWrapper<MaxMoves>;
 
     let period_number = 3;
-    let bonus_status = TestBonusStatusWrapper::default().0;
+    let bonus_status = *TestBonusStatusWrapper::default();
     let mut staking_info = SingularStakingInfo::new(period_number, bonus_status);
 
     // Sanity checks
@@ -2292,7 +2292,7 @@ fn singular_staking_info_unstake_during_voting_is_ok() {
     type TestBonusStatusWrapper = BonusStatusWrapper<MaxMoves>;
 
     let period_number = 3;
-    let bonus_status = TestBonusStatusWrapper::default().0;
+    let bonus_status = *TestBonusStatusWrapper::default();
     let mut staking_info = SingularStakingInfo::new(period_number, bonus_status);
 
     // Prep actions
@@ -2368,7 +2368,7 @@ fn singular_staking_info_unstake_during_bep_is_ok() {
     type TestBonusStatusWrapper = BonusStatusWrapper<MaxMoves>;
 
     let period_number = 3;
-    let bonus_status = TestBonusStatusWrapper::default().0;
+    let bonus_status = *TestBonusStatusWrapper::default();
     let mut staking_info = SingularStakingInfo::new(period_number, bonus_status);
 
     // Sanity check
@@ -2674,16 +2674,16 @@ fn singular_staking_info_unstake_stake_amount_entries_are_ok() {
 fn singular_staking_stake_with_bonus_status() {
     let voting_amount = 100;
     let bep_amount = 30;
-    let stake_amount = StakeAmount {
+    let prep_stake_amount = StakeAmount {
         era: 1,
-        voting: voting_amount,
+        voting: 0,
         build_and_earn: bep_amount,
         period: 0,
     };
 
     // Prep - StakeAmount with forfeited bonus and voting stake
     let mut staking_info = SingularStakingInfo::new(0, 0);
-    staking_info.stake(stake_amount, 1, 0);
+    staking_info.stake(prep_stake_amount, 1, 0);
     assert_eq!(
         staking_info.bonus_status, 0,
         "Bonus status should be initialized to 0 before staking"
@@ -2691,6 +2691,12 @@ fn singular_staking_stake_with_bonus_status() {
 
     // Scenario 1 - Stake again but with incoming bonus status
     let incoming_bonus_status = 1;
+    let stake_amount = StakeAmount {
+        era: 1,
+        voting: voting_amount,
+        build_and_earn: bep_amount,
+        period: 0,
+    };
     staking_info.stake(stake_amount, 1, incoming_bonus_status);
 
     // Check if the bonus status is updated
@@ -2701,7 +2707,7 @@ fn singular_staking_stake_with_bonus_status() {
     // Ensure that the previous voting stake amount was moved to BuildAndEarn
     assert_eq!(
         staking_info.staked_amount(Subperiod::Voting),
-        voting_amount + voting_amount,
+        voting_amount,
         "Voting amount should increase correctly"
     );
     assert_eq!(

--- a/pallets/dapp-staking/src/test/tests_types.rs
+++ b/pallets/dapp-staking/src/test/tests_types.rs
@@ -2018,11 +2018,11 @@ fn singular_staking_info_basics_are_ok() {
 
     // Sanity checks
     assert_eq!(staking_info.period_number(), period_number);
-    assert!(staking_info.is_loyal());
+    assert!(staking_info.is_bonus_eligible());
     assert!(staking_info.total_staked_amount().is_zero());
     assert!(staking_info.is_empty());
     assert!(staking_info.era().is_zero());
-    assert!(!SingularStakingInfo::new(period_number, Subperiod::BuildAndEarn).is_loyal());
+    assert!(!SingularStakingInfo::new(period_number, Subperiod::BuildAndEarn).is_bonus_eligible());
 
     // Add some staked amount during `Voting` period
     let era_1 = 7;
@@ -2089,7 +2089,7 @@ fn singular_staking_info_unstake_during_voting_is_ok() {
         staking_info.total_staked_amount(),
         vote_stake_amount_1 - unstake_amount_1
     );
-    assert!(staking_info.is_loyal());
+    assert!(staking_info.is_bonus_eligible());
     assert_eq!(
         staking_info.era(),
         era_1 + 1,
@@ -2109,7 +2109,7 @@ fn singular_staking_info_unstake_during_voting_is_ok() {
     );
     assert!(staking_info.total_staked_amount().is_zero());
     assert!(
-        !staking_info.is_loyal(),
+        !staking_info.is_bonus_eligible(),
         "Loyalty flag should have been removed since it was full unstake."
     );
     assert!(staking_info.era().is_zero());
@@ -2153,7 +2153,7 @@ fn singular_staking_info_unstake_during_bep_is_ok() {
         staking_info.staked_amount(Subperiod::BuildAndEarn),
         bep_stake_amount_1 - unstake_1
     );
-    assert!(staking_info.is_loyal());
+    assert!(staking_info.is_bonus_eligible());
     assert_eq!(
         staking_info.era(),
         era_1 + 1,
@@ -2222,7 +2222,7 @@ fn singular_staking_info_unstake_during_bep_is_ok() {
         .staked_amount(Subperiod::BuildAndEarn)
         .is_zero());
     assert!(
-        !staking_info.is_loyal(),
+        !staking_info.is_bonus_eligible(),
         "Loyalty flag should have been removed due to non-zero voting subperiod unstake"
     );
     assert_eq!(staking_info.era(), era_2);

--- a/pallets/dapp-staking/src/types.rs
+++ b/pallets/dapp-staking/src/types.rs
@@ -588,17 +588,17 @@ where
     /// Additionally, the staked amount must not exceed what's available for staking.
     pub fn add_stake_amount(
         &mut self,
-        amount: Balance,
-        current_era: EraNumber,
+        amount: StakeAmount,
         current_period_info: PeriodInfo,
     ) -> Result<(), AccountLedgerError> {
-        if amount.is_zero() {
+        if amount.total().is_zero() {
             return Ok(());
         }
 
+        let current_era = amount.era;
         self.stake_unstake_argument_check(current_era, &current_period_info)?;
 
-        if self.stakeable_amount(current_period_info.number) < amount {
+        if self.stakeable_amount(current_period_info.number) < amount.total() {
             return Err(AccountLedgerError::UnavailableStakeFunds);
         }
 
@@ -610,14 +610,16 @@ where
                     self.staked = *stake_amount;
                 }
 
-                stake_amount.add(amount, current_period_info.subperiod);
+                stake_amount.add(amount.voting, Subperiod::Voting);
+                stake_amount.add(amount.build_and_earn, Subperiod::BuildAndEarn);
                 stake_amount.era = current_era.saturating_add(1);
             }
             None => {
                 let mut stake_amount = self.staked;
                 stake_amount.era = current_era.saturating_add(1);
                 stake_amount.period = current_period_info.number;
-                stake_amount.add(amount, current_period_info.subperiod);
+                stake_amount.add(amount.voting, Subperiod::Voting);
+                stake_amount.add(amount.build_and_earn, Subperiod::BuildAndEarn);
                 self.staked_future = Some(stake_amount);
             }
         }
@@ -893,6 +895,17 @@ impl StakeAmount {
             self.voting.saturating_reduce(remainder);
         }
     }
+
+    // TODO: improve this later (especially the name), it's a convenience method for now
+    pub fn subtract_type(&self, other: &StakeAmount) -> Self {
+        let mut result = *self;
+        result.voting.saturating_reduce(other.voting);
+        result
+            .build_and_earn
+            .saturating_reduce(other.build_and_earn);
+
+        result
+    }
 }
 
 /// Info about an era, including the rewards, how much is locked, unlocking, etc.
@@ -940,8 +953,11 @@ impl EraInfo {
     }
 
     /// Add the specified `amount` to the appropriate stake amount, based on the `Subperiod`.
-    pub fn add_stake_amount(&mut self, amount: Balance, subperiod: Subperiod) {
-        self.next_stake_amount.add(amount, subperiod);
+    // TODO: get rid of redundant param
+    pub fn add_stake_amount(&mut self, amount: StakeAmount, _subperiod: Subperiod) {
+        self.next_stake_amount.add(amount.voting, Subperiod::Voting);
+        self.next_stake_amount
+            .add(amount.build_and_earn, Subperiod::BuildAndEarn);
     }
 
     /// Subtract the specified `amount` from the appropriate stake amount.
@@ -1002,8 +1018,8 @@ pub struct SingularStakingInfo {
     pub(crate) previous_staked: StakeAmount,
     /// Staked amount
     pub(crate) staked: StakeAmount,
-    /// Indicates whether a staker is a loyal staker or not.
-    pub(crate) loyal_staker: bool,
+    /// Indicates how much time the staker can move their stake, while still being eligible for the bonus.
+    pub(crate) bonus_moves: u8,
 }
 
 impl SingularStakingInfo {
@@ -1013,20 +1029,20 @@ impl SingularStakingInfo {
     ///
     /// `period` - period number for which this entry is relevant.
     /// `subperiod` - subperiod during which this entry is created.
-    pub(crate) fn new(period: PeriodNumber, subperiod: Subperiod) -> Self {
+    pub(crate) fn new(period: PeriodNumber, bonus_moves: u8) -> Self {
         Self {
             previous_staked: Default::default(),
             staked: StakeAmount {
                 period,
                 ..Default::default()
             },
-            // Loyalty staking is only possible if stake is first made during the voting subperiod.
-            loyal_staker: subperiod == Subperiod::Voting,
+            bonus_moves,
         }
     }
 
     /// Stake the specified amount on the contract, for the specified subperiod.
-    pub fn stake(&mut self, amount: Balance, current_era: EraNumber, subperiod: Subperiod) {
+    // TODO: get rid of redundant param
+    pub fn stake(&mut self, amount: StakeAmount, current_era: EraNumber, _subperiod: Subperiod) {
         // Keep the previous stake amount for future reference
         self.previous_staked = self.staked;
         self.previous_staked.era = current_era;
@@ -1035,7 +1051,9 @@ impl SingularStakingInfo {
         }
 
         // Stake is only valid from the next era so we keep it consistent here
-        self.staked.add(amount, subperiod);
+        self.staked.add(amount.voting, Subperiod::Voting);
+        self.staked
+            .add(amount.build_and_earn, Subperiod::BuildAndEarn);
         self.staked.era = current_era.saturating_add(1);
     }
 
@@ -1057,22 +1075,25 @@ impl SingularStakingInfo {
         amount: Balance,
         current_era: EraNumber,
         subperiod: Subperiod,
-    ) -> Vec<(EraNumber, Balance)> {
+    ) -> (Vec<StakeAmount>, u8) {
         let mut result = Vec::new();
         let staked_snapshot = self.staked;
 
         // 1. Modify 'current' staked amount, and update the result.
         self.staked.subtract(amount);
-        let unstaked_amount = staked_snapshot.total().saturating_sub(self.staked.total());
         self.staked.era = self.staked.era.max(current_era);
-        result.push((self.staked.era, unstaked_amount));
 
-        // 2. Update loyal staker flag accordingly.
-        self.loyal_staker = self.loyal_staker
-            && match subperiod {
-                Subperiod::Voting => !self.staked.voting.is_zero(),
-                Subperiod::BuildAndEarn => self.staked.voting == staked_snapshot.voting,
-            };
+        // Implementation comment: Unlike before, we provide full info about the unstaked amount.
+        let mut unstaked_amount = staked_snapshot.subtract_type(&self.staked);
+        unstaked_amount.era = self.staked.era;
+
+        result.push(unstaked_amount);
+
+        // 2. Update bonus eligibility flag accordingly.
+        // In case voting subperiod has passed, and the the 'voting' stake amount was reduced, we need to reduce the bonus eligibility counter.
+        if subperiod != Subperiod::Voting && self.staked.voting < staked_snapshot.voting {
+            self.bonus_moves = self.bonus_moves.saturating_sub(1);
+        }
 
         // 3. Determine what was the previous staked amount.
         // This is done by simply comparing where does the _previous era_ fit in the current context.
@@ -1111,17 +1132,29 @@ impl SingularStakingInfo {
                 .total()
                 .checked_sub(self.previous_staked.total());
             match maybe_stake_delta {
-                Some(stake_delta) if unstaked_amount > stake_delta => {
-                    let overflow_amount = unstaked_amount - stake_delta;
+                Some(stake_delta) if unstaked_amount.total() > stake_delta => {
+                    let overflow_amount = unstaked_amount.total() - stake_delta;
+
+                    let previous_staked_snapshot = self.previous_staked;
                     self.previous_staked.subtract(overflow_amount);
 
-                    result.insert(0, (self.previous_staked.era, overflow_amount));
+                    let temp_unstaked_amount =
+                        previous_staked_snapshot.subtract_type(&self.previous_staked);
+                    assert_eq!(
+                        temp_unstaked_amount.total(),
+                        overflow_amount,
+                        "Sanity check, behavior should remain the same as before."
+                    );
+
+                    result.insert(0, temp_unstaked_amount);
                 }
                 _ => {}
             }
         } else if self.staked.era == current_era {
             // In case the `staked` era was already the current era, it also means we're chipping away from the future era.
-            result.push((self.staked.era.saturating_add(1), unstaked_amount));
+            let mut temp_unstaked_amount = unstaked_amount;
+            temp_unstaked_amount.era = self.staked.era.saturating_add(1);
+            result.push(temp_unstaked_amount);
         }
 
         // 5. Convenience cleanup
@@ -1134,7 +1167,7 @@ impl SingularStakingInfo {
             self.previous_staked = Default::default();
         }
 
-        result
+        (result, self.bonus_moves)
     }
 
     /// Total staked on the contract by the user. Both subperiod stakes are included.
@@ -1148,8 +1181,8 @@ impl SingularStakingInfo {
     }
 
     /// If `true` staker has staked during voting subperiod and has never reduced their sta
-    pub fn is_loyal(&self) -> bool {
-        self.loyal_staker
+    pub fn is_bonus_eligible(&self) -> bool {
+        self.bonus_moves > 0
     }
 
     /// Period for which this entry is relevant.
@@ -1256,13 +1289,14 @@ impl ContractStakeAmount {
     }
 
     /// Stake the specified `amount` on the contract, for the specified `subperiod` and `era`.
-    pub fn stake(&mut self, amount: Balance, period_info: PeriodInfo, current_era: EraNumber) {
+    pub fn stake(&mut self, amount: StakeAmount, period_info: PeriodInfo, current_era: EraNumber) {
         let stake_era = current_era.saturating_add(1);
 
         match self.staked_future.as_mut() {
             // Future entry matches the era, just updated it and return
             Some(stake_amount) if stake_amount.era == stake_era => {
-                stake_amount.add(amount, period_info.subperiod);
+                stake_amount.add(amount.voting, Subperiod::Voting);
+                stake_amount.add(amount.build_and_earn, Subperiod::BuildAndEarn);
                 return;
             }
             // Future entry has an older era, but periods match so overwrite the 'current' entry with it
@@ -1282,7 +1316,8 @@ impl ContractStakeAmount {
             // otherwise just create a dummy new entry
             _ => Default::default(),
         };
-        new_entry.add(amount, period_info.subperiod);
+        new_entry.add(amount.voting, Subperiod::Voting);
+        new_entry.add(amount.build_and_earn, Subperiod::BuildAndEarn);
         new_entry.era = stake_era;
         new_entry.period = period_info.number;
 
@@ -1298,7 +1333,7 @@ impl ContractStakeAmount {
     // Important to account for the ongoing specified `subperiod` and `era` in order to align the entries.
     pub fn unstake(
         &mut self,
-        era_and_amount_pairs: Vec<(EraNumber, Balance)>,
+        era_and_amount_pairs: &Vec<StakeAmount>,
         period_info: PeriodInfo,
         current_era: EraNumber,
     ) {
@@ -1322,7 +1357,8 @@ impl ContractStakeAmount {
         }
 
         // 2. Value updates - only after alignment
-        for (era, amount) in era_and_amount_pairs {
+        for entry in era_and_amount_pairs {
+            let (era, amount) = (entry.era, entry.total());
             if self.staked.era == era {
                 self.staked.subtract(amount);
                 continue;

--- a/pallets/dapp-staking/src/types.rs
+++ b/pallets/dapp-staking/src/types.rs
@@ -1100,10 +1100,12 @@ impl SingularStakingInfo {
         bonus_status: BonusStatus,
     ) {
         // Keep the previous stake amount for future reference
-        self.previous_staked = self.staked;
-        self.previous_staked.era = current_era;
-        if self.previous_staked.total().is_zero() {
-            self.previous_staked = Default::default();
+        if self.previous_staked.era < current_era {
+            self.previous_staked = self.staked;
+            self.previous_staked.era = current_era;
+            if self.previous_staked.total().is_zero() {
+                self.previous_staked = Default::default();
+            }
         }
 
         // This is necessary for move operations, when bonus is transferred to this own staking info

--- a/pallets/dapp-staking/src/types.rs
+++ b/pallets/dapp-staking/src/types.rs
@@ -98,6 +98,33 @@ pub type DAppInfoFor<T> = DAppInfo<<T as frame_system::Config>::AccountId>;
 // Convenience type for `BonusStatusWrapper` usage.
 pub type BonusStatusWrapperFor<T> = BonusStatusWrapper<<T as Config>::MaxBonusSafeMovesPerPeriod>;
 
+/// TODO: remove it once all BonusStatus are updated and the `ActiveBonusUpdateCursor` storage value is cleanup.
+pub type BonusUpdateStateFor<T> =
+    BonusUpdateState<<T as frame_system::Config>::AccountId, <T as Config>::SmartContract>;
+
+pub type BonusUpdateCursorFor<T> = (
+    <T as frame_system::Config>::AccountId,
+    <T as Config>::SmartContract,
+);
+
+pub type BonusUpdateCursor<AccountId, SmartContract> = (AccountId, SmartContract);
+
+#[derive(Encode, Decode, MaxEncodedLen, Clone, Debug, PartialEq, Eq, TypeInfo)]
+pub enum BonusUpdateState<AccountId, SmartContract> {
+    /// No update in progress yet
+    NotInProgress,
+    /// Update in progress for the current cursor
+    InProgress(BonusUpdateCursor<AccountId, SmartContract>),
+    /// All updates have been finished
+    Finished,
+}
+
+impl<AccountId, SmartContract> Default for BonusUpdateState<AccountId, SmartContract> {
+    fn default() -> Self {
+        BonusUpdateState::<AccountId, SmartContract>::NotInProgress
+    }
+}
+
 /// Simple enum representing errors possible when using sparse bounded vector.
 #[derive(Debug, PartialEq, Eq)]
 pub enum AccountLedgerError {

--- a/pallets/dapp-staking/src/types.rs
+++ b/pallets/dapp-staking/src/types.rs
@@ -159,7 +159,7 @@ impl PeriodInfo {
 /// Struct with relevant information for a finished period.
 #[derive(Encode, Decode, MaxEncodedLen, Clone, Copy, Debug, PartialEq, Eq, TypeInfo)]
 pub struct PeriodEndInfo {
-    /// Bonus reward pool allocated for 'loyal' stakers
+    /// Bonus reward pool allocated for eligible stakers with a non-null bonus status
     #[codec(compact)]
     pub(crate) bonus_reward_pool: Balance,
     /// Total amount staked (remaining) from the voting subperiod.

--- a/pallets/dapp-staking/src/types.rs
+++ b/pallets/dapp-staking/src/types.rs
@@ -1048,7 +1048,7 @@ pub struct BonusStatusWrapper<MaxBonusMoves: Get<u8>>(pub BonusStatus, PhantomDa
 impl<MaxBonusMoves: Get<u8>> Default for BonusStatusWrapper<MaxBonusMoves> {
     fn default() -> Self {
         let max = MaxBonusMoves::get();
-        BonusStatusWrapper::<MaxBonusMoves>(max.saturating_add(1), PhantomData::default())
+        BonusStatusWrapper::<MaxBonusMoves>(max.saturating_add(1), PhantomData)
     }
 }
 

--- a/pallets/dapp-staking/src/types.rs
+++ b/pallets/dapp-staking/src/types.rs
@@ -1109,6 +1109,9 @@ impl SingularStakingInfo {
         // This is necessary for move operations, when bonus is transferred to this own staking info
         if self.bonus_status == 0 {
             self.bonus_status = bonus_status;
+        } else if self.bonus_status > 0 && bonus_status > 0 {
+            let merged = (bonus_status + self.bonus_status) / 2;
+            self.bonus_status = merged;
         }
 
         // Stake is only valid from the next era so we keep it consistent here

--- a/pallets/dapp-staking/src/types.rs
+++ b/pallets/dapp-staking/src/types.rs
@@ -979,18 +979,14 @@ impl EraInfo {
     /// - If an entry belongs to the `next_era`, it reduces `next_stake_amount`.
     /// - If the entry is from a past era or invalid, it is ignored.
     pub fn unstake_amount(&mut self, stake_amount_entries: impl IntoIterator<Item = StakeAmount>) {
-        let entries: Vec<StakeAmount> = stake_amount_entries.into_iter().collect();
-        match entries.as_slice() {
-            [single_entry] => {
-                let amount = single_entry.total();
+        for entry in stake_amount_entries {
+            let (era, amount) = (entry.era, entry.total());
+
+            if era == self.current_stake_amount.era {
                 self.current_stake_amount.subtract(amount);
+            } else if era == self.next_stake_amount.era {
                 self.next_stake_amount.subtract(amount);
             }
-            [entry_current, entry_next] => {
-                self.current_stake_amount.subtract(entry_current.total());
-                self.next_stake_amount.subtract(entry_next.total());
-            }
-            _ => {} // Ignore cases with more than 2 entries or empty input - this should never happen
         }
     }
 

--- a/pallets/dapp-staking/src/types.rs
+++ b/pallets/dapp-staking/src/types.rs
@@ -911,7 +911,7 @@ impl StakeAmount {
     }
 
     // Compares `self` and `other` by total amount first or by lowest era in case of tie
-    pub fn compare_stake_amounts(&self, other: &StakeAmount) -> std::cmp::Ordering {
+    pub fn compare_stake_amounts(&self, other: &StakeAmount) -> sp_std::cmp::Ordering {
         let total_self = self.total();
         let total_other = other.total();
 

--- a/pallets/dapp-staking/src/types.rs
+++ b/pallets/dapp-staking/src/types.rs
@@ -1211,11 +1211,6 @@ impl SingularStakingInfo {
                     let mut temp_unstaked_amount =
                         previous_staked_snapshot.saturating_difference(&self.previous_staked);
                     temp_unstaked_amount.era = self.previous_staked.era;
-                    assert_eq!(
-                        temp_unstaked_amount.total(),
-                        overflow_amount,
-                        "Sanity check, behavior should remain the same as before."
-                    );
 
                     if is_bonus_lost && temp_unstaked_amount.voting > 0 {
                         temp_unstaked_amount.convert_bonus_into_regular_stake();

--- a/pallets/dapp-staking/src/weights.rs
+++ b/pallets/dapp-staking/src/weights.rs
@@ -69,6 +69,7 @@ pub trait WeightInfo {
 	fn cleanup_expired_entries(x: u32, ) -> Weight;
 	fn force() -> Weight;
 	fn move_stake() -> Weight;
+	fn move_stake_unregistered_source() -> Weight;
 	fn on_initialize_voting_to_build_and_earn() -> Weight;
 	fn on_initialize_build_and_earn_to_voting() -> Weight;
 	fn on_initialize_build_and_earn_to_build_and_earn() -> Weight;
@@ -409,6 +410,27 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Storage: `Balances::Locks` (r:1 w:0)
 	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
 	fn move_stake() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `536`
+		//  Estimated: `6298`
+		// Minimum execution time: 59_000_000 picoseconds.
+		Weight::from_parts(60_000_000, 6298)
+			.saturating_add(T::DbWeight::get().reads(9_u64))
+			.saturating_add(T::DbWeight::get().writes(6_u64))
+	}
+	/// Storage: `DappStaking::IntegratedDApps` (r:2 w:0)
+	/// Proof: `DappStaking::IntegratedDApps` (`max_values`: Some(65535), `max_size`: Some(116), added: 2096, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::Ledger` (r:1 w:1)
+	/// Proof: `DappStaking::Ledger` (`max_values`: None, `max_size`: Some(310), added: 2785, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::StakerInfo` (r:2 w:2)
+	/// Proof: `DappStaking::StakerInfo` (`max_values`: None, `max_size`: Some(179), added: 2654, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::ContractStake` (r:2 w:2)
+	/// Proof: `DappStaking::ContractStake` (`max_values`: Some(65535), `max_size`: Some(91), added: 2071, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:1)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:0)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	fn move_stake_unregistered_source() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `536`
 		//  Estimated: `6298`
@@ -844,6 +866,27 @@ impl WeightInfo for () {
 	/// Storage: `Balances::Locks` (r:1 w:0)
 	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
 	fn move_stake() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `536`
+		//  Estimated: `6298`
+		// Minimum execution time: 59_000_000 picoseconds.
+		Weight::from_parts(60_000_000, 6298)
+			.saturating_add(RocksDbWeight::get().reads(9_u64))
+			.saturating_add(RocksDbWeight::get().writes(6_u64))
+	}
+	/// Storage: `DappStaking::IntegratedDApps` (r:2 w:0)
+	/// Proof: `DappStaking::IntegratedDApps` (`max_values`: Some(65535), `max_size`: Some(116), added: 2096, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::Ledger` (r:1 w:1)
+	/// Proof: `DappStaking::Ledger` (`max_values`: None, `max_size`: Some(310), added: 2785, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::StakerInfo` (r:2 w:2)
+	/// Proof: `DappStaking::StakerInfo` (`max_values`: None, `max_size`: Some(179), added: 2654, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::ContractStake` (r:2 w:2)
+	/// Proof: `DappStaking::ContractStake` (`max_values`: Some(65535), `max_size`: Some(91), added: 2071, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:1)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:0)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	fn move_stake_unregistered_source() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `536`
 		//  Estimated: `6298`

--- a/pallets/dapp-staking/src/weights.rs
+++ b/pallets/dapp-staking/src/weights.rs
@@ -76,6 +76,9 @@ pub trait WeightInfo {
 	fn dapp_tier_assignment(x: u32, ) -> Weight;
 	fn on_idle_cleanup() -> Weight;
 	fn step() -> Weight;
+	/// TODO: remove both weights once BonusStatus update is done
+	fn update_bonus_step_success() -> Weight;
+	fn update_bonus_step_noop() -> Weight;
 }
 
 /// Weights for pallet_dapp_staking using the Substrate node and recommended hardware.
@@ -420,22 +423,24 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	}
 	/// Storage: `DappStaking::IntegratedDApps` (r:2 w:0)
 	/// Proof: `DappStaking::IntegratedDApps` (`max_values`: Some(65535), `max_size`: Some(116), added: 2096, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::StakerInfo` (r:2 w:2)
+	/// Proof: `DappStaking::StakerInfo` (`max_values`: None, `max_size`: Some(178), added: 2653, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::Ledger` (r:1 w:1)
 	/// Proof: `DappStaking::Ledger` (`max_values`: None, `max_size`: Some(310), added: 2785, mode: `MaxEncodedLen`)
-	/// Storage: `DappStaking::StakerInfo` (r:2 w:2)
-	/// Proof: `DappStaking::StakerInfo` (`max_values`: None, `max_size`: Some(179), added: 2654, mode: `MaxEncodedLen`)
-	/// Storage: `DappStaking::ContractStake` (r:2 w:2)
-	/// Proof: `DappStaking::ContractStake` (`max_values`: Some(65535), `max_size`: Some(91), added: 2071, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::CurrentEraInfo` (r:1 w:1)
+	/// Proof: `DappStaking::CurrentEraInfo` (`max_values`: Some(1), `max_size`: Some(112), added: 607, mode: `MaxEncodedLen`)
 	/// Storage: `Balances::Freezes` (r:1 w:1)
 	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
 	/// Storage: `Balances::Locks` (r:1 w:0)
 	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::ContractStake` (r:1 w:1)
+	/// Proof: `DappStaking::ContractStake` (`max_values`: Some(65535), `max_size`: Some(91), added: 2071, mode: `MaxEncodedLen`)
 	fn move_stake_unregistered_source() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `536`
-		//  Estimated: `6298`
-		// Minimum execution time: 59_000_000 picoseconds.
-		Weight::from_parts(60_000_000, 6298)
+		//  Measured:  `414`
+		//  Estimated: `6296`
+		// Minimum execution time: 62_000_000 picoseconds.
+		Weight::from_parts(64_000_000, 6296)
 			.saturating_add(T::DbWeight::get().reads(9_u64))
 			.saturating_add(T::DbWeight::get().writes(6_u64))
 	}
@@ -532,6 +537,27 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_parts(10_314_000, 6560)
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
+	/// Storage: `DappStaking::StakerInfo` (r:2 w:1)
+	/// Proof: `DappStaking::StakerInfo` (`max_values`: None, `max_size`: Some(178), added: 2653, mode: `MaxEncodedLen`)
+	fn update_bonus_step_success() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `141`
+		//  Estimated: `6296`
+		// Minimum execution time: 9_000_000 picoseconds.
+		Weight::from_parts(10_000_000, 6296)
+			.saturating_add(T::DbWeight::get().reads(2_u64))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
+	/// Storage: `DappStaking::StakerInfo` (r:1 w:0)
+	/// Proof: `DappStaking::StakerInfo` (`max_values`: None, `max_size`: Some(178), added: 2653, mode: `MaxEncodedLen`)
+	fn update_bonus_step_noop() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `19`
+		//  Estimated: `3643`
+		// Minimum execution time: 2_000_000 picoseconds.
+		Weight::from_parts(3_000_000, 3643)
+			.saturating_add(T::DbWeight::get().reads(1_u64))
 	}
 }
 
@@ -876,22 +902,24 @@ impl WeightInfo for () {
 	}
 	/// Storage: `DappStaking::IntegratedDApps` (r:2 w:0)
 	/// Proof: `DappStaking::IntegratedDApps` (`max_values`: Some(65535), `max_size`: Some(116), added: 2096, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::StakerInfo` (r:2 w:2)
+	/// Proof: `DappStaking::StakerInfo` (`max_values`: None, `max_size`: Some(178), added: 2653, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::Ledger` (r:1 w:1)
 	/// Proof: `DappStaking::Ledger` (`max_values`: None, `max_size`: Some(310), added: 2785, mode: `MaxEncodedLen`)
-	/// Storage: `DappStaking::StakerInfo` (r:2 w:2)
-	/// Proof: `DappStaking::StakerInfo` (`max_values`: None, `max_size`: Some(179), added: 2654, mode: `MaxEncodedLen`)
-	/// Storage: `DappStaking::ContractStake` (r:2 w:2)
-	/// Proof: `DappStaking::ContractStake` (`max_values`: Some(65535), `max_size`: Some(91), added: 2071, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::CurrentEraInfo` (r:1 w:1)
+	/// Proof: `DappStaking::CurrentEraInfo` (`max_values`: Some(1), `max_size`: Some(112), added: 607, mode: `MaxEncodedLen`)
 	/// Storage: `Balances::Freezes` (r:1 w:1)
 	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
 	/// Storage: `Balances::Locks` (r:1 w:0)
 	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::ContractStake` (r:1 w:1)
+	/// Proof: `DappStaking::ContractStake` (`max_values`: Some(65535), `max_size`: Some(91), added: 2071, mode: `MaxEncodedLen`)
 	fn move_stake_unregistered_source() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `536`
-		//  Estimated: `6298`
-		// Minimum execution time: 59_000_000 picoseconds.
-		Weight::from_parts(60_000_000, 6298)
+		//  Measured:  `414`
+		//  Estimated: `6296`
+		// Minimum execution time: 62_000_000 picoseconds.
+		Weight::from_parts(64_000_000, 6296)
 			.saturating_add(RocksDbWeight::get().reads(9_u64))
 			.saturating_add(RocksDbWeight::get().writes(6_u64))
 	}
@@ -988,5 +1016,26 @@ impl WeightInfo for () {
 		Weight::from_parts(10_314_000, 6560)
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	/// Storage: `DappStaking::StakerInfo` (r:2 w:1)
+	/// Proof: `DappStaking::StakerInfo` (`max_values`: None, `max_size`: Some(178), added: 2653, mode: `MaxEncodedLen`)
+	fn update_bonus_step_success() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `141`
+		//  Estimated: `6296`
+		// Minimum execution time: 9_000_000 picoseconds.
+		Weight::from_parts(10_000_000, 6296)
+			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	/// Storage: `DappStaking::StakerInfo` (r:1 w:0)
+	/// Proof: `DappStaking::StakerInfo` (`max_values`: None, `max_size`: Some(178), added: 2653, mode: `MaxEncodedLen`)
+	fn update_bonus_step_noop() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `19`
+		//  Estimated: `3643`
+		// Minimum execution time: 2_000_000 picoseconds.
+		Weight::from_parts(3_000_000, 3643)
+			.saturating_add(RocksDbWeight::get().reads(1_u64))
 	}
 }

--- a/pallets/dapp-staking/src/weights.rs
+++ b/pallets/dapp-staking/src/weights.rs
@@ -68,6 +68,7 @@ pub trait WeightInfo {
 	fn unstake_from_unregistered() -> Weight;
 	fn cleanup_expired_entries(x: u32, ) -> Weight;
 	fn force() -> Weight;
+	fn move_stake() -> Weight;
 	fn on_initialize_voting_to_build_and_earn() -> Weight;
 	fn on_initialize_build_and_earn_to_voting() -> Weight;
 	fn on_initialize_build_and_earn_to_build_and_earn() -> Weight;
@@ -394,6 +395,27 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		//  Estimated: `0`
 		// Minimum execution time: 11_543_000 picoseconds.
 		Weight::from_parts(11_735_000, 0)
+	}
+	/// Storage: `DappStaking::IntegratedDApps` (r:2 w:0)
+	/// Proof: `DappStaking::IntegratedDApps` (`max_values`: Some(65535), `max_size`: Some(116), added: 2096, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::Ledger` (r:1 w:1)
+	/// Proof: `DappStaking::Ledger` (`max_values`: None, `max_size`: Some(310), added: 2785, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::StakerInfo` (r:2 w:2)
+	/// Proof: `DappStaking::StakerInfo` (`max_values`: None, `max_size`: Some(179), added: 2654, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::ContractStake` (r:2 w:2)
+	/// Proof: `DappStaking::ContractStake` (`max_values`: Some(65535), `max_size`: Some(91), added: 2071, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:1)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:0)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	fn move_stake() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `536`
+		//  Estimated: `6298`
+		// Minimum execution time: 59_000_000 picoseconds.
+		Weight::from_parts(60_000_000, 6298)
+			.saturating_add(T::DbWeight::get().reads(9_u64))
+			.saturating_add(T::DbWeight::get().writes(6_u64))
 	}
 	/// Storage: DappStaking CurrentEraInfo (r:1 w:1)
 	/// Proof: DappStaking CurrentEraInfo (max_values: Some(1), max_size: Some(112), added: 607, mode: MaxEncodedLen)
@@ -808,6 +830,27 @@ impl WeightInfo for () {
 		//  Estimated: `0`
 		// Minimum execution time: 11_543_000 picoseconds.
 		Weight::from_parts(11_735_000, 0)
+	}
+	/// Storage: `DappStaking::IntegratedDApps` (r:2 w:0)
+	/// Proof: `DappStaking::IntegratedDApps` (`max_values`: Some(65535), `max_size`: Some(116), added: 2096, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::Ledger` (r:1 w:1)
+	/// Proof: `DappStaking::Ledger` (`max_values`: None, `max_size`: Some(310), added: 2785, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::StakerInfo` (r:2 w:2)
+	/// Proof: `DappStaking::StakerInfo` (`max_values`: None, `max_size`: Some(179), added: 2654, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::ContractStake` (r:2 w:2)
+	/// Proof: `DappStaking::ContractStake` (`max_values`: Some(65535), `max_size`: Some(91), added: 2071, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:1)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:0)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	fn move_stake() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `536`
+		//  Estimated: `6298`
+		// Minimum execution time: 59_000_000 picoseconds.
+		Weight::from_parts(60_000_000, 6298)
+			.saturating_add(RocksDbWeight::get().reads(9_u64))
+			.saturating_add(RocksDbWeight::get().writes(6_u64))
 	}
 	/// Storage: DappStaking CurrentEraInfo (r:1 w:1)
 	/// Proof: DappStaking CurrentEraInfo (max_values: Some(1), max_size: Some(112), added: 607, mode: MaxEncodedLen)

--- a/pallets/dapp-staking/src/weights.rs
+++ b/pallets/dapp-staking/src/weights.rs
@@ -68,7 +68,7 @@ pub trait WeightInfo {
 	fn unstake_from_unregistered() -> Weight;
 	fn cleanup_expired_entries(x: u32, ) -> Weight;
 	fn force() -> Weight;
-	fn move_stake() -> Weight;
+	fn move_stake_from_registered_source() -> Weight;
 	fn move_stake_unregistered_source() -> Weight;
 	fn on_initialize_voting_to_build_and_earn() -> Weight;
 	fn on_initialize_build_and_earn_to_voting() -> Weight;
@@ -412,7 +412,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
 	/// Storage: `Balances::Locks` (r:1 w:0)
 	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
-	fn move_stake() -> Weight {
+	fn move_stake_from_registered_source() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `536`
 		//  Estimated: `6298`
@@ -891,7 +891,7 @@ impl WeightInfo for () {
 	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
 	/// Storage: `Balances::Locks` (r:1 w:0)
 	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
-	fn move_stake() -> Weight {
+	fn move_stake_from_registered_source() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `536`
 		//  Estimated: `6298`

--- a/pallets/inflation/src/lib.rs
+++ b/pallets/inflation/src/lib.rs
@@ -494,7 +494,7 @@ pub struct InflationConfiguration {
     /// This is provided to the stakers according to formula: 'pool * min(1, total_staked / ideal_staked)'.
     #[codec(compact)]
     pub adjustable_staker_reward_pool_per_era: Balance,
-    /// Bonus reward pool per period, for loyal stakers.
+    /// Bonus reward pool per period, for eligible stakers.
     #[codec(compact)]
     pub bonus_reward_pool_per_period: Balance,
     /// The ideal staking rate, in respect to total issuance.

--- a/precompiles/dapp-staking/DappsStakingV3.sol
+++ b/precompiles/dapp-staking/DappsStakingV3.sol
@@ -71,6 +71,13 @@ interface DAppStaking {
     /// @param amount: The amount of tokens to be unstaked.
     function unstake(SmartContract calldata smart_contract, uint128 amount) external returns (bool);
 
+    /// @notice Move the given amount of tokens from the specified source contract to the specified destination contract.
+    ///         The amount specified must be precise, otherwise the call will fail.
+    /// @param source_contract: The source smart contract to be moved from.
+    /// @param destination_contract: The destination smart contract to be moved on.
+    /// @param amount: The amount of tokens to be moved.
+    function move_stake(SmartContract calldata source_contract, SmartContract calldata destination_contract, uint128 amount) external returns (bool);
+
     /// @notice Claims one or more pending staker rewards.
     function claim_staker_rewards() external returns (bool);
 

--- a/precompiles/dapp-staking/src/lib.rs
+++ b/precompiles/dapp-staking/src/lib.rs
@@ -766,6 +766,28 @@ where
         Ok(true)
     }
 
+    #[precompile::public("move_stake((uint8,bytes),(uint8,bytes),uint128)")]
+    fn move_stake(
+        handle: &mut impl PrecompileHandle,
+        source_contract: SmartContractV2,
+        destination_contract: SmartContractV2,
+        amount: Balance,
+    ) -> EvmResult<bool> {
+        let source_contract = Self::decode_smart_contract(source_contract)?;
+        let destination_contract = Self::decode_smart_contract(destination_contract)?;
+
+        // Prepare call & dispatch it
+        let origin = R::AddressMapping::into_account_id(handle.context().caller);
+        let move_call = pallet_dapp_staking::Call::<R>::move_stake {
+            source_contract,
+            destination_contract,
+            amount,
+        };
+        RuntimeHelper::<R>::try_dispatch(handle, Some(origin).into(), move_call)?;
+
+        Ok(true)
+    }
+
     // Utility functions
 
     /// Helper method to decode smart contract struct for v2 calls

--- a/precompiles/dapp-staking/src/lib.rs
+++ b/precompiles/dapp-staking/src/lib.rs
@@ -688,7 +688,7 @@ where
         Ok(true)
     }
 
-    /// Attempts to claim bonus reward for being a loyal staker of the given dApp.
+    /// Attempts to claim a bonus reward for maintaining an eligible bonus status with the given dApp.
     #[precompile::public("claim_bonus_reward((uint8,bytes))")]
     fn claim_bonus_reward(
         handle: &mut impl PrecompileHandle,

--- a/precompiles/dapp-staking/src/test/mock.rs
+++ b/precompiles/dapp-staking/src/test/mock.rs
@@ -35,7 +35,7 @@ use sp_arithmetic::{fixed_point::FixedU128, Permill};
 use sp_core::H160;
 use sp_io::TestExternalities;
 use sp_runtime::{
-    traits::{ConstU32, IdentityLookup},
+    traits::{ConstU32, ConstU8, IdentityLookup},
     BuildStorage, Perbill,
 };
 extern crate alloc;
@@ -247,6 +247,7 @@ impl pallet_dapp_staking::Config for Test {
     type MinimumStakeAmount = ConstU128<3>;
     type NumberOfTiers = ConstU32<4>;
     type RankingEnabled = ConstBool<true>;
+    type MaxBonusSafeMovesPerPeriod = ConstU8<0>;
     type WeightInfo = pallet_dapp_staking::weights::SubstrateWeight<Test>;
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = BenchmarkHelper<MockSmartContract, AccountId>;

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -1590,7 +1590,7 @@ pub type Executive = frame_executive::Executive<
 pub type Migrations = (Unreleased, Permanent);
 
 /// Unreleased migrations. Add new ones here:
-pub type Unreleased = ();
+pub type Unreleased = pallet_dapp_staking::migration::versioned_migrations::V8ToV9<Runtime>;
 
 /// Migrations/checks that do not need to be versioned and can run on every upgrade.
 pub type Permanent = (pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,);

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -29,7 +29,7 @@ use frame_support::{
     genesis_builder_helper, parameter_types,
     traits::{
         fungible::{Balanced, Credit, HoldConsideration},
-        AsEnsureOriginWithArg, ConstBool, ConstU128, ConstU32, ConstU64, Contains,
+        AsEnsureOriginWithArg, ConstBool, ConstU128, ConstU32, ConstU64, ConstU8, Contains,
         EqualPrivilegeOnly, FindAuthor, Get, Imbalance, InstanceFilter, LinearStoragePrice,
         Nothing, OnFinalize, OnUnbalanced, Randomness, WithdrawReasons,
     },
@@ -460,6 +460,7 @@ impl pallet_dapp_staking::Config for Runtime {
     type MinimumStakeAmount = MinimumStakingAmount;
     type NumberOfTiers = ConstU32<4>;
     type RankingEnabled = ConstBool<true>;
+    type MaxBonusSafeMovesPerPeriod = ConstU8<0>;
     type WeightInfo = weights::pallet_dapp_staking::SubstrateWeight<Runtime>;
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = DAppStakingBenchmarkHelper<SmartContract<AccountId>, AccountId>;

--- a/runtime/astar/src/weights/pallet_dapp_staking.rs
+++ b/runtime/astar/src/weights/pallet_dapp_staking.rs
@@ -378,7 +378,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `DappStaking::StakerInfo` (`max_values`: None, `max_size`: Some(179), added: 2654, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::ContractStake` (r:2 w:2)
 	/// Proof: `DappStaking::ContractStake` (`max_values`: Some(65535), `max_size`: Some(91), added: 2071, mode: `MaxEncodedLen`)
-	fn move_stake() -> Weight {
+	fn move_stake_from_registered_source() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `373`
 		//  Estimated: `6298`

--- a/runtime/astar/src/weights/pallet_dapp_staking.rs
+++ b/runtime/astar/src/weights/pallet_dapp_staking.rs
@@ -40,6 +40,8 @@
 // --output=./benchmark-results/astar-dev/dapp_staking_weights.rs
 // --template=./scripts/templates/weight-template.hbs
 
+// TODO: Dummy values for move_stake: do proper benchmark using gha
+
 #![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(unused_parens)]
 #![allow(unused_imports)]
@@ -369,6 +371,21 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Minimum execution time: 8_769_000 picoseconds.
 		Weight::from_parts(8_948_000, 1486)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
+	}
+	/// Storage: `DappStaking::IntegratedDApps` (r:2 w:0)
+	/// Proof: `DappStaking::IntegratedDApps` (`max_values`: Some(65535), `max_size`: Some(116), added: 2096, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::StakerInfo` (r:2 w:2)
+	/// Proof: `DappStaking::StakerInfo` (`max_values`: None, `max_size`: Some(179), added: 2654, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::ContractStake` (r:2 w:2)
+	/// Proof: `DappStaking::ContractStake` (`max_values`: Some(65535), `max_size`: Some(91), added: 2071, mode: `MaxEncodedLen`)
+	fn move_stake() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `373`
+		//  Estimated: `6298`
+		// Minimum execution time: 38_000_000 picoseconds.
+		Weight::from_parts(38_000_000, 6298)
+			.saturating_add(T::DbWeight::get().reads(6_u64))
+			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
 	/// Storage: `DappStaking::CurrentEraInfo` (r:1 w:1)
 	/// Proof: `DappStaking::CurrentEraInfo` (`max_values`: Some(1), `max_size`: Some(112), added: 607, mode: `MaxEncodedLen`)

--- a/runtime/astar/src/weights/pallet_dapp_staking.rs
+++ b/runtime/astar/src/weights/pallet_dapp_staking.rs
@@ -387,6 +387,27 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(6_u64))
 			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
+	/// Storage: `DappStaking::IntegratedDApps` (r:2 w:0)
+	/// Proof: `DappStaking::IntegratedDApps` (`max_values`: Some(65535), `max_size`: Some(116), added: 2096, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::Ledger` (r:1 w:1)
+	/// Proof: `DappStaking::Ledger` (`max_values`: None, `max_size`: Some(310), added: 2785, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::StakerInfo` (r:2 w:2)
+	/// Proof: `DappStaking::StakerInfo` (`max_values`: None, `max_size`: Some(179), added: 2654, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::ContractStake` (r:2 w:2)
+	/// Proof: `DappStaking::ContractStake` (`max_values`: Some(65535), `max_size`: Some(91), added: 2071, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:1)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:0)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	fn move_stake_unregistered_source() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `536`
+		//  Estimated: `6298`
+		// Minimum execution time: 59_000_000 picoseconds.
+		Weight::from_parts(60_000_000, 6298)
+			.saturating_add(RocksDbWeight::get().reads(9_u64))
+			.saturating_add(RocksDbWeight::get().writes(6_u64))
+	}
 	/// Storage: `DappStaking::CurrentEraInfo` (r:1 w:1)
 	/// Proof: `DappStaking::CurrentEraInfo` (`max_values`: Some(1), `max_size`: Some(112), added: 607, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::EraRewards` (r:1 w:1)
@@ -487,6 +508,28 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Storage: `DappStaking::Ledger` (r:2 w:1)
 	/// Proof: `DappStaking::Ledger` (`max_values`: None, `max_size`: Some(310), added: 2785, mode: `MaxEncodedLen`)
 	fn step() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `76`
+		//  Estimated: `6560`
+		// Minimum execution time: 10_060_000 picoseconds.
+		Weight::from_parts(10_314_000, 6560)
+			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	/// Storage: `DappStaking::Ledger` (r:2 w:1)
+	/// Proof: `DappStaking::Ledger` (`max_values`: None, `max_size`: Some(310), added: 2785, mode: `MaxEncodedLen`)
+	fn update_bonus_step_success() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `76`
+		//  Estimated: `6560`
+		// Minimum execution time: 10_060_000 picoseconds.
+		Weight::from_parts(10_314_000, 6560)
+			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	/// Storage: `DappStaking::Ledger` (r:2 w:1)
+	/// Proof: `DappStaking::Ledger` (`max_values`: None, `max_size`: Some(310), added: 2785, mode: `MaxEncodedLen`)
+	fn update_bonus_step_noop() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `76`
 		//  Estimated: `6560`

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -28,9 +28,9 @@ use frame_support::{
     construct_runtime, genesis_builder_helper, parameter_types,
     traits::{
         fungible::{Balanced, Credit, HoldConsideration},
-        AsEnsureOriginWithArg, ConstU128, ConstU32, ConstU64, Contains, EqualPrivilegeOnly,
-        FindAuthor, Get, InsideBoth, InstanceFilter, LinearStoragePrice, Nothing, OnFinalize,
-        WithdrawReasons,
+        AsEnsureOriginWithArg, ConstU128, ConstU32, ConstU64, ConstU8, Contains,
+        EqualPrivilegeOnly, FindAuthor, Get, InsideBoth, InstanceFilter, LinearStoragePrice,
+        Nothing, OnFinalize, WithdrawReasons,
     },
     weights::{
         constants::{ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_REF_TIME_PER_SECOND},
@@ -485,6 +485,7 @@ impl pallet_dapp_staking::Config for Runtime {
     type MinimumStakeAmount = ConstU128<AST>;
     type NumberOfTiers = ConstU32<4>;
     type RankingEnabled = ConstBool<true>;
+    type MaxBonusSafeMovesPerPeriod = ConstU8<0>;
     type WeightInfo = pallet_dapp_staking::weights::SubstrateWeight<Runtime>;
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = BenchmarkHelper<SmartContract<AccountId>, AccountId>;

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -29,7 +29,7 @@ use frame_support::{
     genesis_builder_helper, parameter_types,
     traits::{
         fungible::{Balanced, Credit, HoldConsideration},
-        AsEnsureOriginWithArg, ConstBool, ConstU128, ConstU32, ConstU64, Contains,
+        AsEnsureOriginWithArg, ConstBool, ConstU128, ConstU32, ConstU64, ConstU8, Contains,
         EqualPrivilegeOnly, FindAuthor, Get, Imbalance, InsideBoth, InstanceFilter,
         LinearStoragePrice, Nothing, OnFinalize, OnUnbalanced, WithdrawReasons,
     },
@@ -492,6 +492,7 @@ impl pallet_dapp_staking::Config for Runtime {
     type MinimumStakeAmount = MinimumStakingAmount;
     type NumberOfTiers = ConstU32<4>;
     type RankingEnabled = ConstBool<true>;
+    type MaxBonusSafeMovesPerPeriod = ConstU8<0>;
     type WeightInfo = weights::pallet_dapp_staking::SubstrateWeight<Runtime>;
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = DAppStakingBenchmarkHelper<SmartContract<AccountId>, AccountId>;

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -1687,7 +1687,7 @@ pub type Executive = frame_executive::Executive<
 pub type Migrations = (Unreleased, Permanent);
 
 /// Unreleased migrations. Add new ones here:
-pub type Unreleased = ();
+pub type Unreleased = pallet_dapp_staking::migration::versioned_migrations::V8ToV9<Runtime>;
 
 /// Migrations/checks that do not need to be versioned and can run on every upgrade.
 pub type Permanent = (pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,);

--- a/runtime/shibuya/src/weights/pallet_dapp_staking.rs
+++ b/runtime/shibuya/src/weights/pallet_dapp_staking.rs
@@ -378,7 +378,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `DappStaking::StakerInfo` (`max_values`: None, `max_size`: Some(179), added: 2654, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::ContractStake` (r:2 w:2)
 	/// Proof: `DappStaking::ContractStake` (`max_values`: Some(65535), `max_size`: Some(91), added: 2071, mode: `MaxEncodedLen`)
-	fn move_stake() -> Weight {
+	fn move_stake_from_registered_source() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `373`
 		//  Estimated: `6298`

--- a/runtime/shibuya/src/weights/pallet_dapp_staking.rs
+++ b/runtime/shibuya/src/weights/pallet_dapp_staking.rs
@@ -40,6 +40,8 @@
 // --output=./benchmark-results/shibuya-dev/dapp_staking_weights.rs
 // --template=./scripts/templates/weight-template.hbs
 
+// TODO: Dummy values for move_stake: do proper benchmark using gha
+
 #![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(unused_parens)]
 #![allow(unused_imports)]
@@ -369,6 +371,21 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Minimum execution time: 8_432_000 picoseconds.
 		Weight::from_parts(8_696_000, 1486)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
+	}
+	/// Storage: `DappStaking::IntegratedDApps` (r:2 w:0)
+	/// Proof: `DappStaking::IntegratedDApps` (`max_values`: Some(65535), `max_size`: Some(116), added: 2096, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::StakerInfo` (r:2 w:2)
+	/// Proof: `DappStaking::StakerInfo` (`max_values`: None, `max_size`: Some(179), added: 2654, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::ContractStake` (r:2 w:2)
+	/// Proof: `DappStaking::ContractStake` (`max_values`: Some(65535), `max_size`: Some(91), added: 2071, mode: `MaxEncodedLen`)
+	fn move_stake() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `373`
+		//  Estimated: `6298`
+		// Minimum execution time: 38_000_000 picoseconds.
+		Weight::from_parts(38_000_000, 6298)
+			.saturating_add(T::DbWeight::get().reads(6_u64))
+			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
 	/// Storage: `DappStaking::CurrentEraInfo` (r:1 w:1)
 	/// Proof: `DappStaking::CurrentEraInfo` (`max_values`: Some(1), `max_size`: Some(112), added: 607, mode: `MaxEncodedLen`)

--- a/runtime/shibuya/src/weights/pallet_dapp_staking.rs
+++ b/runtime/shibuya/src/weights/pallet_dapp_staking.rs
@@ -387,6 +387,27 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(6_u64))
 			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
+	/// Storage: `DappStaking::IntegratedDApps` (r:2 w:0)
+	/// Proof: `DappStaking::IntegratedDApps` (`max_values`: Some(65535), `max_size`: Some(116), added: 2096, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::Ledger` (r:1 w:1)
+	/// Proof: `DappStaking::Ledger` (`max_values`: None, `max_size`: Some(310), added: 2785, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::StakerInfo` (r:2 w:2)
+	/// Proof: `DappStaking::StakerInfo` (`max_values`: None, `max_size`: Some(179), added: 2654, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::ContractStake` (r:2 w:2)
+	/// Proof: `DappStaking::ContractStake` (`max_values`: Some(65535), `max_size`: Some(91), added: 2071, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:1)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:0)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	fn move_stake_unregistered_source() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `536`
+		//  Estimated: `6298`
+		// Minimum execution time: 59_000_000 picoseconds.
+		Weight::from_parts(60_000_000, 6298)
+			.saturating_add(RocksDbWeight::get().reads(9_u64))
+			.saturating_add(RocksDbWeight::get().writes(6_u64))
+	}
 	/// Storage: `DappStaking::CurrentEraInfo` (r:1 w:1)
 	/// Proof: `DappStaking::CurrentEraInfo` (`max_values`: Some(1), `max_size`: Some(112), added: 607, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::EraRewards` (r:1 w:1)
@@ -487,6 +508,28 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Storage: `DappStaking::Ledger` (r:2 w:1)
 	/// Proof: `DappStaking::Ledger` (`max_values`: None, `max_size`: Some(310), added: 2785, mode: `MaxEncodedLen`)
 	fn step() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `76`
+		//  Estimated: `6560`
+		// Minimum execution time: 10_060_000 picoseconds.
+		Weight::from_parts(10_314_000, 6560)
+			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	/// Storage: `DappStaking::Ledger` (r:2 w:1)
+	/// Proof: `DappStaking::Ledger` (`max_values`: None, `max_size`: Some(310), added: 2785, mode: `MaxEncodedLen`)
+	fn update_bonus_step_success() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `76`
+		//  Estimated: `6560`
+		// Minimum execution time: 10_060_000 picoseconds.
+		Weight::from_parts(10_314_000, 6560)
+			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	/// Storage: `DappStaking::Ledger` (r:2 w:1)
+	/// Proof: `DappStaking::Ledger` (`max_values`: None, `max_size`: Some(310), added: 2785, mode: `MaxEncodedLen`)
+	fn update_bonus_step_noop() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `76`
 		//  Estimated: `6560`

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -29,8 +29,8 @@ use frame_support::{
     genesis_builder_helper, parameter_types,
     traits::{
         fungible::{Balanced, Credit},
-        AsEnsureOriginWithArg, ConstBool, ConstU32, ConstU64, Contains, FindAuthor, Get, Imbalance,
-        InstanceFilter, Nothing, OnFinalize, OnUnbalanced, WithdrawReasons,
+        AsEnsureOriginWithArg, ConstBool, ConstU32, ConstU64, ConstU8, Contains, FindAuthor, Get,
+        Imbalance, InstanceFilter, Nothing, OnFinalize, OnUnbalanced, WithdrawReasons,
     },
     weights::{
         constants::{
@@ -450,6 +450,7 @@ impl pallet_dapp_staking::Config for Runtime {
     type MinimumStakeAmount = MinimumStakingAmount;
     type NumberOfTiers = ConstU32<4>;
     type RankingEnabled = ConstBool<true>;
+    type MaxBonusSafeMovesPerPeriod = ConstU8<0>;
     type WeightInfo = weights::pallet_dapp_staking::SubstrateWeight<Runtime>;
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = DAppStakingBenchmarkHelper<SmartContract<AccountId>, AccountId>;

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -1294,7 +1294,7 @@ pub type Executive = frame_executive::Executive<
 pub type Migrations = (Unreleased, Permanent);
 
 /// Unreleased migrations. Add new ones here:
-pub type Unreleased = ();
+pub type Unreleased = pallet_dapp_staking::migration::versioned_migrations::V8ToV9<Runtime>;
 
 /// Migrations/checks that do not need to be versioned and can run on every upgrade.
 pub type Permanent = (pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,);

--- a/runtime/shiden/src/weights/pallet_dapp_staking.rs
+++ b/runtime/shiden/src/weights/pallet_dapp_staking.rs
@@ -378,7 +378,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `DappStaking::StakerInfo` (`max_values`: None, `max_size`: Some(179), added: 2654, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::ContractStake` (r:2 w:2)
 	/// Proof: `DappStaking::ContractStake` (`max_values`: Some(65535), `max_size`: Some(91), added: 2071, mode: `MaxEncodedLen`)
-	fn move_stake() -> Weight {
+	fn move_stake_from_registered_source() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `373`
 		//  Estimated: `6298`

--- a/runtime/shiden/src/weights/pallet_dapp_staking.rs
+++ b/runtime/shiden/src/weights/pallet_dapp_staking.rs
@@ -40,6 +40,8 @@
 // --output=./benchmark-results/shiden-dev/dapp_staking_weights.rs
 // --template=./scripts/templates/weight-template.hbs
 
+// TODO: Dummy values for move_stake: do proper benchmark using gha
+
 #![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(unused_parens)]
 #![allow(unused_imports)]
@@ -369,6 +371,21 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		// Minimum execution time: 8_530_000 picoseconds.
 		Weight::from_parts(8_785_000, 1486)
 			.saturating_add(T::DbWeight::get().reads(1_u64))
+	}
+	/// Storage: `DappStaking::IntegratedDApps` (r:2 w:0)
+	/// Proof: `DappStaking::IntegratedDApps` (`max_values`: Some(65535), `max_size`: Some(116), added: 2096, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::StakerInfo` (r:2 w:2)
+	/// Proof: `DappStaking::StakerInfo` (`max_values`: None, `max_size`: Some(179), added: 2654, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::ContractStake` (r:2 w:2)
+	/// Proof: `DappStaking::ContractStake` (`max_values`: Some(65535), `max_size`: Some(91), added: 2071, mode: `MaxEncodedLen`)
+	fn move_stake() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `373`
+		//  Estimated: `6298`
+		// Minimum execution time: 38_000_000 picoseconds.
+		Weight::from_parts(38_000_000, 6298)
+			.saturating_add(T::DbWeight::get().reads(6_u64))
+			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
 	/// Storage: `DappStaking::CurrentEraInfo` (r:1 w:1)
 	/// Proof: `DappStaking::CurrentEraInfo` (`max_values`: Some(1), `max_size`: Some(112), added: 607, mode: `MaxEncodedLen`)

--- a/runtime/shiden/src/weights/pallet_dapp_staking.rs
+++ b/runtime/shiden/src/weights/pallet_dapp_staking.rs
@@ -387,6 +387,27 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(6_u64))
 			.saturating_add(T::DbWeight::get().writes(4_u64))
 	}
+	/// Storage: `DappStaking::IntegratedDApps` (r:2 w:0)
+	/// Proof: `DappStaking::IntegratedDApps` (`max_values`: Some(65535), `max_size`: Some(116), added: 2096, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::Ledger` (r:1 w:1)
+	/// Proof: `DappStaking::Ledger` (`max_values`: None, `max_size`: Some(310), added: 2785, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::StakerInfo` (r:2 w:2)
+	/// Proof: `DappStaking::StakerInfo` (`max_values`: None, `max_size`: Some(179), added: 2654, mode: `MaxEncodedLen`)
+	/// Storage: `DappStaking::ContractStake` (r:2 w:2)
+	/// Proof: `DappStaking::ContractStake` (`max_values`: Some(65535), `max_size`: Some(91), added: 2071, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Freezes` (r:1 w:1)
+	/// Proof: `Balances::Freezes` (`max_values`: None, `max_size`: Some(67), added: 2542, mode: `MaxEncodedLen`)
+	/// Storage: `Balances::Locks` (r:1 w:0)
+	/// Proof: `Balances::Locks` (`max_values`: None, `max_size`: Some(1299), added: 3774, mode: `MaxEncodedLen`)
+	fn move_stake_unregistered_source() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `536`
+		//  Estimated: `6298`
+		// Minimum execution time: 59_000_000 picoseconds.
+		Weight::from_parts(60_000_000, 6298)
+			.saturating_add(RocksDbWeight::get().reads(9_u64))
+			.saturating_add(RocksDbWeight::get().writes(6_u64))
+	}
 	/// Storage: `DappStaking::CurrentEraInfo` (r:1 w:1)
 	/// Proof: `DappStaking::CurrentEraInfo` (`max_values`: Some(1), `max_size`: Some(112), added: 607, mode: `MaxEncodedLen`)
 	/// Storage: `DappStaking::EraRewards` (r:1 w:1)
@@ -495,4 +516,27 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
+	/// Storage: `DappStaking::Ledger` (r:2 w:1)
+	/// Proof: `DappStaking::Ledger` (`max_values`: None, `max_size`: Some(310), added: 2785, mode: `MaxEncodedLen`)
+	fn update_bonus_step_success() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `76`
+		//  Estimated: `6560`
+		// Minimum execution time: 10_060_000 picoseconds.
+		Weight::from_parts(10_314_000, 6560)
+			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	/// Storage: `DappStaking::Ledger` (r:2 w:1)
+	/// Proof: `DappStaking::Ledger` (`max_values`: None, `max_size`: Some(310), added: 2785, mode: `MaxEncodedLen`)
+	fn update_bonus_step_noop() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `76`
+		//  Estimated: `6560`
+		// Minimum execution time: 10_060_000 picoseconds.
+		Weight::from_parts(10_314_000, 6560)
+			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+
 }

--- a/tests/xcm-simulator/src/mocks/parachain.rs
+++ b/tests/xcm-simulator/src/mocks/parachain.rs
@@ -23,8 +23,8 @@ use frame_support::{
     dispatch::DispatchClass,
     parameter_types,
     traits::{
-        AsEnsureOriginWithArg, ConstBool, ConstU128, ConstU32, ConstU64, Contains, Everything,
-        InstanceFilter, Nothing,
+        AsEnsureOriginWithArg, ConstBool, ConstU128, ConstU32, ConstU64, ConstU8, Contains,
+        Everything, InstanceFilter, Nothing,
     },
     weights::{
         constants::{BlockExecutionWeight, ExtrinsicBaseWeight, WEIGHT_REF_TIME_PER_SECOND},
@@ -675,6 +675,7 @@ impl pallet_dapp_staking::Config for Runtime {
     type MinimumStakeAmount = ConstU128<3>;
     type NumberOfTiers = ConstU32<4>;
     type RankingEnabled = ConstBool<true>;
+    type MaxBonusSafeMovesPerPeriod = ConstU8<0>;
     type WeightInfo = ();
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = BenchmarkHelper<MockSmartContract, AccountId>;


### PR DESCRIPTION
**Pull Request Summary**

Closes #1379 

This PR introduces enhancements to the bonus reward eligibility mechanism and implements robust handling for stake movement, particularly during the `build&earn` subperiod.

The approach aims to first adapt existing pallet to easily support `move` functionality.
Pallet has a lot of tests covering stake & unstake functioality, and in case `MAX_BONUS_MOVES = 1`, every legacy test **must** work same as before.

### Changes
* logic from `stake`, `unstake` and `unstake_from_unregistered` is moved to separate functions, with minimal modifications
* it's important for `unstake` to return more comprehensive information of what was unstaked
* _types_ are modified to return necessary information for the higher level functionality
* test files are adapted to ensure that high level (extrinsic) tests are passing
* `move` extrinsic, using `inner_unstake` and `inner_stake` functions (or `unstake_from_unregistered`) as the building blocks

### Bonus Reward Eligibility

The previously used `loyal_staker` flag is replaced with a `bonus_status` `u8` type.
The number of allowed move actions is defined by a config parameter (`MaxBonusSafeMovesPerPeriod`); bonus is forfeited if _move actions_ exceed this value.

### Move action

A _move action_ is defined as either:
- Partial unstaking that reduces the 'voting stake'.
- Transfers of 'voting stake' between contracts.

If a _move action_ is performed during the `build&earn` subperiod, the `bonus_status` attached to the relevant singular staking info is reduced until it is forfeited.

### Stake Movement Enhancements

A new `move_stake` extrinsic is implemented. It is similar to an 'unstake' followed by a 'stake'. Existing safeguards are extended additional checks to:
- Ensure the source and destination contracts are different.
- Validate the amount to be moved.

When moving stake from unregistered contracts, the bonus status is always preserved.

### Migration

This PR introduces the `update_bonus` extrinsic, which updates `loyal_staker` flags from the previous 0 move actions limit to the new value set by `MaxBonusSafeMovesPerPeriod`. The change will take effect in a future runtime upgrade when the config parameters are updated.

**Check list**
- [x] added or updated unit tests
- [ ] updated Astar official documentation
- [X] update dAppStaking precompile
- [X] added benchmarks & weights for any modified runtime logics.
- [ ] add E2E tests
- [ ] prepare follow-up issue for Astar Portal frontend & forum post
