### PR TITLE
docs: Fix typo: "dependecy" -> "dependency"

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Defining _features_ in the root `Cargo.toml` is additive with the features defin
 1. Check if the dependency is already defined in the root `Cargo.toml`
     1. if **yes**, nothing to do, just take note of the enabled features
     2. if **no**, add it (make sure to use `default-features = false` if dependency is used in _no_std_ context)
-2. Add `new_dependecy = { workspace = true }` to the required crate
+2. Add `new_dependency = { workspace = true }` to the required crate
 3. In case dependency is defined with `default-features = false` but you need it in _std_ context, add `features = ["std"]` to the required crate.
 
 ## Further Reading


### PR DESCRIPTION
**Pull Request Summary**

I noticed a small typo in the documentation where "dependecy" was used instead of the correct spelling "dependency."
I've fixed it to improve accuracy and readability.

**Check list**
- [ ] added or updated unit tests
- [x] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [ ] added benchmarks & weights for any modified runtime logics.
