### PR TITLE
Tier param setting call

### DIFF
--- a/pallets/dapp-staking/src/benchmarking/utils.rs
+++ b/pallets/dapp-staking/src/benchmarking/utils.rs
@@ -18,7 +18,7 @@
 
 use super::{Pallet as DappStaking, *};
 
-use astar_primitives::Balance;
+use astar_primitives::{dapp_staking::STANDARD_TIER_SLOTS_ARGS, Balance};
 
 use frame_system::Pallet as System;
 
@@ -194,6 +194,7 @@ pub(super) fn init_tier_settings<T: Config>() {
             },
         ])
         .unwrap(),
+        slot_number_args: STANDARD_TIER_SLOTS_ARGS,
     };
 
     let total_issuance = 1000 * MIN_TIER_THRESHOLD;

--- a/pallets/dapp-staking/src/test/mock.rs
+++ b/pallets/dapp-staking/src/test/mock.rs
@@ -35,7 +35,9 @@ use sp_runtime::{BuildStorage, Permill};
 use sp_std::cell::RefCell;
 
 use astar_primitives::{
-    dapp_staking::{Observer as DappStakingObserver, SmartContract, StandardTierSlots},
+    dapp_staking::{
+        Observer as DappStakingObserver, SmartContract, StandardTierSlots, STANDARD_TIER_SLOTS_ARGS,
+    },
     Balance, BlockNumber,
 };
 use frame_system::{EnsureRoot, EnsureSignedBy};
@@ -324,6 +326,7 @@ impl ExtBuilder {
                     },
                 ])
                 .unwrap(),
+                slot_number_args: STANDARD_TIER_SLOTS_ARGS,
             };
 
             let total_issuance = <Test as Config>::Currency::total_issuance();

--- a/pallets/dapp-staking/src/test/tests.rs
+++ b/pallets/dapp-staking/src/test/tests.rs
@@ -21,7 +21,7 @@ use crate::{
     pallet::Config, ActiveProtocolState, ContractStake, DAppId, DAppTierRewardsFor, DAppTiers,
     EraRewards, Error, Event, ForcingType, GenesisConfig, IntegratedDApps, Ledger, NextDAppId,
     Perbill, PeriodNumber, Permill, Safeguard, StakerInfo, StaticTierParams, Subperiod, TierConfig,
-    TierThreshold,
+    TierParameters, TierThreshold,
 };
 
 use frame_support::{
@@ -3125,7 +3125,11 @@ fn base_number_of_slots_is_respected() {
         // 0. Get expected number of slots for the base price
         let total_issuance = <Test as Config>::Currency::total_issuance();
         let base_native_price = <Test as Config>::BaseNativeCurrencyPrice::get();
-        let base_number_of_slots = <Test as Config>::TierSlots::number_of_slots(base_native_price);
+        let tier_params = StaticTierParams::<Test>::get();
+        let base_number_of_slots = <Test as Config>::TierSlots::number_of_slots(
+            base_native_price,
+            tier_params.slot_number_args,
+        );
 
         // 1. Make sure base native price is set initially and calculate the new config. Store the thresholds for later comparison.
         NATIVE_PRICE.with(|v| *v.borrow_mut() = base_native_price);
@@ -3152,7 +3156,10 @@ fn base_number_of_slots_is_respected() {
         );
         assert_eq!(
             TierConfig::<Test>::get().total_number_of_slots(),
-            <Test as Config>::TierSlots::number_of_slots(higher_price),
+            <Test as Config>::TierSlots::number_of_slots(
+                higher_price,
+                tier_params.slot_number_args
+            ),
         );
 
         for (amount, static_tier_threshold) in TierConfig::<Test>::get()
@@ -3200,7 +3207,7 @@ fn base_number_of_slots_is_respected() {
         );
         assert_eq!(
             TierConfig::<Test>::get().total_number_of_slots(),
-            <Test as Config>::TierSlots::number_of_slots(lower_price),
+            <Test as Config>::TierSlots::number_of_slots(lower_price, tier_params.slot_number_args),
         );
 
         // 5. Bring it back to the base price, and expect number of slots to be the same as the base number of slots,
@@ -3485,5 +3492,57 @@ fn claim_bonus_reward_for_works() {
             Balances::free_balance(&claimer_account),
             "Claimer balance must not change since reward is deposited to the staker."
         );
+    })
+}
+
+#[test]
+fn set_static_tier_params_incorrect_origin_fails() {
+    ExtBuilder::default().build_and_execute(|| {
+        let tier_params = StaticTierParams::<Test>::get();
+        assert_noop!(
+            DappStaking::set_static_tier_params(RuntimeOrigin::signed(1), tier_params),
+            BadOrigin
+        );
+    })
+}
+
+#[test]
+fn set_static_tier_params_invalid_params_fails() {
+    ExtBuilder::default().build_and_execute(|| {
+        // Base value is assumed to be correct
+        let tier_params = StaticTierParams::<Test>::get();
+        assert!(tier_params.is_valid(), "Sanity check");
+        type NumberOfTiers = <Test as Config>::NumberOfTiers;
+
+        let invalid_tier_params = TierParameters::<NumberOfTiers> {
+            reward_portion: tier_params.reward_portion[1..].to_vec().try_into().unwrap(),
+            ..tier_params.clone()
+        };
+        assert!(!invalid_tier_params.is_valid(), "Sanity check");
+
+        assert_noop!(
+            DappStaking::set_static_tier_params(RuntimeOrigin::root(), invalid_tier_params),
+            Error::<Test>::InvalidTierParams
+        );
+    })
+}
+
+#[test]
+fn set_static_tier_params_works() {
+    ExtBuilder::default().build_and_execute(|| {
+        let mut tier_params = StaticTierParams::<Test>::get();
+
+        // An example of complete invalidation of the first tier - still valid params.
+        tier_params.reward_portion[0] = Permill::zero();
+        tier_params.slot_distribution[0] = Permill::zero();
+        tier_params.tier_thresholds[0] = TierThreshold::FixedPercentage {
+            required_percentage: Perbill::one(),
+        };
+
+        assert_ok!(DappStaking::set_static_tier_params(
+            RuntimeOrigin::root(),
+            tier_params.clone()
+        ));
+        assert_eq!(StaticTierParams::<Test>::get(), tier_params);
     })
 }

--- a/pallets/dapp-staking/src/test/tests_types.rs
+++ b/pallets/dapp-staking/src/test/tests_types.rs
@@ -2828,6 +2828,7 @@ fn tier_params_check_is_ok() {
             },
         ])
         .unwrap(),
+        slot_number_args: (100, 50),
     };
     assert!(params.is_valid());
 
@@ -2913,6 +2914,7 @@ fn tier_configuration_basic_tests() {
             },
         ])
         .unwrap(),
+        slot_number_args: (100, 50),
     };
     assert!(params.is_valid(), "Example params must be valid!");
 

--- a/pallets/dapp-staking/src/types.rs
+++ b/pallets/dapp-staking/src/types.rs
@@ -1535,7 +1535,7 @@ impl TierThreshold {
     CloneNoBound,
     TypeInfo,
 )]
-#[scale_info(skip_type_params(NT))]
+#[scale_info(skip_type_params(NT, SN))]
 pub struct TierParameters<NT: Get<u32>> {
     /// Reward distribution per tier, in percentage.
     /// First entry refers to the first tier, and so on.
@@ -1550,6 +1550,10 @@ pub struct TierParameters<NT: Get<u32>> {
     /// Requirements for entry into each tier.
     /// First entry refers to the first tier, and so on.
     pub(crate) tier_thresholds: BoundedVec<TierThreshold, NT>,
+    /// Arguments for the linear equation used to calculate the number of slots.
+    /// This can be made more generic in the future in case more complex equations are required.
+    /// But for now this simple tuple serves the purpose.
+    pub(crate) slot_number_args: (u64, u64),
 }
 
 impl<NT: Get<u32>> TierParameters<NT> {
@@ -1641,8 +1645,8 @@ impl<NT: Get<u32>, T: TierSlotsFunc, P: Get<FixedU128>> TiersConfiguration<NT, T
         total_issuance: Balance,
     ) -> Self {
         // It must always be at least 1 slot.
-        let base_number_of_slots = T::number_of_slots(P::get()).max(1);
-        let new_number_of_slots = T::number_of_slots(native_price).max(1);
+        let base_number_of_slots = T::number_of_slots(P::get(), params.slot_number_args).max(1);
+        let new_number_of_slots = T::number_of_slots(native_price, params.slot_number_args).max(1);
 
         // Calculate how much each tier gets slots.
         let new_slots_per_tier: Vec<u16> = params

--- a/pallets/dapp-staking/src/weights.rs
+++ b/pallets/dapp-staking/src/weights.rs
@@ -74,6 +74,7 @@ pub trait WeightInfo {
 	fn dapp_tier_assignment(x: u32, ) -> Weight;
 	fn on_idle_cleanup() -> Weight;
 	fn step() -> Weight;
+	fn set_static_tier_params() -> Weight;
 }
 
 /// Weights for pallet_dapp_staking using the Substrate node and recommended hardware.
@@ -489,6 +490,9 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(2_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}
+	fn set_static_tier_params() -> Weight {
+		T::DbWeight::get().reads_writes(1,1)
+	}
 }
 
 // For backwards compatibility and tests
@@ -902,5 +906,8 @@ impl WeightInfo for () {
 		Weight::from_parts(10_314_000, 6560)
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
+	fn set_static_tier_params() -> Weight {
+		RocksDbWeight::get().reads_writes(1,1)
 	}
 }

--- a/precompiles/dapp-staking/src/test/mock.rs
+++ b/precompiles/dapp-staking/src/test/mock.rs
@@ -43,8 +43,8 @@ extern crate alloc;
 use astar_primitives::{
     dapp_staking::{
         CycleConfiguration, EraNumber, PeriodNumber, SmartContract, StakingRewardHandler,
-        StandardTierSlots,
-    },
+        StandardTierSlots, STANDARD_TIER_SLOTS_ARGS,
+    }, 
     oracle::PriceProvider,
     AccountId, Balance, BlockNumber,
 };
@@ -297,6 +297,7 @@ impl ExternalityBuilder {
                         required_percentage: Perbill::from_percent(1),
                     },
                 ],
+                slot_number_args: STANDARD_TIER_SLOTS_ARGS,
                 slots_per_tier: vec![10, 20, 30, 40],
                 safeguard: None,
                 _config: PhantomData,

--- a/primitives/src/dapp_staking.rs
+++ b/primitives/src/dapp_staking.rs
@@ -186,17 +186,27 @@ impl<AccountId> AccountCheck<AccountId> for () {
 /// Trait for calculating the total number of tier slots for the given price.
 pub trait TierSlots {
     /// Returns the total number of tier slots for the given price.
-    fn number_of_slots(price: CurrencyAmount) -> u16;
+    ///
+    /// # Arguments
+    /// * `price` - price (e.g. moving average over some time period) of the native currency.
+    /// * `args` - arguments, `a` & `b`, for the linear equation `number_of_slots = a * price + b`.
+    ///
+    /// Returns the total number of tier slots.
+    fn number_of_slots(price: CurrencyAmount, args: (u64, u64)) -> u16;
 }
 
 /// Standard tier slots implementation, as proposed in the Tokenomics 2.0 document.
 pub struct StandardTierSlots;
 impl TierSlots for StandardTierSlots {
-    fn number_of_slots(price: CurrencyAmount) -> u16 {
-        let result: u64 = price.saturating_mul_int(1000_u64).saturating_add(50);
+    fn number_of_slots(price: CurrencyAmount, args: (u64, u64)) -> u16 {
+        let result: u64 = price.saturating_mul_int(args.0).saturating_add(args.1);
         result.unique_saturated_into()
     }
 }
+
+/// Standard tier slots arguments.
+/// Initially decided for Astar, during the Tokenomics 2.0 work.
+pub const STANDARD_TIER_SLOTS_ARGS: (u64, u64) = (1000, 50);
 
 /// RankedTier is wrapper around u8 to hold both tier and rank. u8 has 2 bytes (8bits) and they're using in this order `0xrank_tier`.
 /// First 4 bits are used to hold rank and second 4 bits are used to hold tier.

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -1589,10 +1589,15 @@ pub type Executive = frame_executive::Executive<
 pub type Migrations = (Unreleased, Permanent);
 
 /// Unreleased migrations. Add new ones here:
-pub type Unreleased = ();
+pub type Unreleased =
+    (pallet_dapp_staking::migration::versioned_migrations::V8ToV9<Runtime, TierSlotsArgs>,);
 
 /// Migrations/checks that do not need to be versioned and can run on every upgrade.
 pub type Permanent = (pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,);
+
+parameter_types! {
+    pub const TierSlotsArgs: (u64, u64) = (1000, 50);
+}
 
 type EventRecord = frame_system::EventRecord<
     <Runtime as frame_system::Config>::RuntimeEvent,

--- a/runtime/astar/src/weights/pallet_dapp_staking.rs
+++ b/runtime/astar/src/weights/pallet_dapp_staking.rs
@@ -478,4 +478,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
+	fn set_static_tier_params() -> Weight {
+		T::DbWeight::get().reads_writes(1,1)
+	}
 }

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -1686,10 +1686,15 @@ pub type Executive = frame_executive::Executive<
 pub type Migrations = (Unreleased, Permanent);
 
 /// Unreleased migrations. Add new ones here:
-pub type Unreleased = ();
+pub type Unreleased =
+    (pallet_dapp_staking::migration::versioned_migrations::V8ToV9<Runtime, TierSlotsArgs>,);
 
 /// Migrations/checks that do not need to be versioned and can run on every upgrade.
 pub type Permanent = (pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,);
+
+parameter_types! {
+    pub const TierSlotsArgs: (u64, u64) = (1000, 50);
+}
 
 type EventRecord = frame_system::EventRecord<
     <Runtime as frame_system::Config>::RuntimeEvent,

--- a/runtime/shibuya/src/weights/pallet_dapp_staking.rs
+++ b/runtime/shibuya/src/weights/pallet_dapp_staking.rs
@@ -478,4 +478,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
+	fn set_static_tier_params() -> Weight {
+		T::DbWeight::get().reads_writes(1,1)
+	}
 }

--- a/runtime/shiden/src/weights/pallet_dapp_staking.rs
+++ b/runtime/shiden/src/weights/pallet_dapp_staking.rs
@@ -478,4 +478,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(RocksDbWeight::get().reads(2_u64))
 			.saturating_add(RocksDbWeight::get().writes(1_u64))
 	}
+	fn set_static_tier_params() -> Weight {
+		T::DbWeight::get().reads_writes(1,1)
+	}
 }


### PR DESCRIPTION
**Pull Request Summary**

Adds `set_static_tier_params` extrinsic to modify tier related dApp staking parameters dynamically.
Requires `root` level privileges.

Additionally expands the `TierParameters` struct to allow changing of the _weight_ values of the linear equation used to determine number of slots.
