### PR TITLE
fix: `previous_staked` remains unchanged for future era stake amounts

### DIFF
--- a/pallets/dapp-staking/src/test/tests_types.rs
+++ b/pallets/dapp-staking/src/test/tests_types.rs
@@ -2325,8 +2325,14 @@ fn singular_previous_stake_is_ok() {
         period: period_number,
     };
     staking_info.stake(stake_amount_3, era_2, 0);
-    assert_eq!(staking_info.previous_staked.total(), stake_amount_1.total() + stake_amount_2.total());
-    assert_eq!(staking_info.staked.total(), stake_amount_1.total() + stake_amount_2.total() + stake_amount_3.total());
+    assert_eq!(
+        staking_info.previous_staked.total(),
+        stake_amount_1.total() + stake_amount_2.total()
+    );
+    assert_eq!(
+        staking_info.staked.total(),
+        stake_amount_1.total() + stake_amount_2.total() + stake_amount_3.total()
+    );
 }
 
 #[test]

--- a/pallets/dapp-staking/src/test/tests_types.rs
+++ b/pallets/dapp-staking/src/test/tests_types.rs
@@ -2287,6 +2287,49 @@ fn singular_staking_info_basics_are_ok() {
 }
 
 #[test]
+fn singular_previous_stake_is_ok() {
+    let period_number = 1;
+    let bonus_status = 0;
+    let mut staking_info = SingularStakingInfo::new(period_number, bonus_status);
+
+    // Add some staked amount during `Build&Earn` period
+    let era_1 = 7;
+    let bep_stake_amount_1 = 10;
+    let stake_amount_1 = StakeAmount {
+        voting: 0,
+        build_and_earn: bep_stake_amount_1,
+        era: era_1,
+        period: period_number,
+    };
+    staking_info.stake(stake_amount_1, era_1, 0);
+    assert!(staking_info.previous_staked.is_empty());
+
+    // Add more staked amount during same era
+    let bep_stake_amount_2 = 20;
+    let stake_amount_2 = StakeAmount {
+        voting: 0,
+        build_and_earn: bep_stake_amount_2,
+        era: era_1,
+        period: period_number,
+    };
+    staking_info.stake(stake_amount_2, era_1, 0);
+    assert!(staking_info.previous_staked.is_empty());
+
+    // Add more staked amount during a future era
+    let era_2 = 17;
+    let bep_stake_amount_3 = 30;
+    let stake_amount_3 = StakeAmount {
+        voting: 0,
+        build_and_earn: bep_stake_amount_3,
+        era: era_2,
+        period: period_number,
+    };
+    staking_info.stake(stake_amount_3, era_2, 0);
+    assert_eq!(staking_info.previous_staked.total(), stake_amount_1.total() + stake_amount_2.total());
+    assert_eq!(staking_info.staked.total(), stake_amount_1.total() + stake_amount_2.total() + stake_amount_3.total());
+}
+
+#[test]
 fn singular_staking_info_unstake_during_voting_is_ok() {
     get_u8_type!(MaxMoves, 1);
     type TestBonusStatusWrapper = BonusStatusWrapper<MaxMoves>;

--- a/pallets/dapp-staking/src/types.rs
+++ b/pallets/dapp-staking/src/types.rs
@@ -1123,7 +1123,7 @@ impl SingularStakingInfo {
         bonus_status: BonusStatus,
     ) {
         // Keep the previous stake amount for future reference
-        if self.previous_staked.era < current_era {
+        if self.staked.era <= current_era {
             self.previous_staked = self.staked;
             self.previous_staked.era = current_era;
             if self.previous_staked.total().is_zero() {


### PR DESCRIPTION
**Pull Request Summary**

Fixes an invariant for the `SingularStakingInfo` type where the `previous_staked` value was updated with future stakes.


**Check list**
- [X] added or updated unit tests
- [ ] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [ ] added benchmarks & weights for any modified runtime logics.
