### PR TITLE
Corrected Substrate link, fixed no_std typo, and improved wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 </div>
 
-Astar Network is an interoperable blockchain based the Substrate framework and the hub for dApps within the Polkadot Ecosystem.
+Astar Network is an interoperable blockchain based on the Substrate framework and the hub for dApps within the Polkadot Ecosystem.
 With Astar Network and Shiden Network, people can stake their tokens to a Smart Contract for rewarding projects that provide value to the network.
 
 For contributing to this project, please read our [Contribution Guideline](./CONTRIBUTING.md).
@@ -30,7 +30,7 @@ Execute the following command from your terminal to set up the development envir
 
 ```bash
 # install Substrate development environment via the automatic script
-$ curl https://getsubstrate.io -sSf | bash -s -- --fast
+$ curl https://docs.substrate.io/install/ -sSf | bash -s -- --fast
 
 # clone the Git repository
 $ git clone --recurse-submodules https://github.com/AstarNetwork/Astar.git
@@ -112,7 +112,7 @@ The runtime crate version will align its major and minor versions with the Rust 
 All dependencies should be listed inside the workspace's root `Cargo.toml` file.
 This allows us to easily change version of a crate used by the entire repo by modifying the version in a single place.
 
-Right now, if **non_std** is required, `default-features = false` must be set in the root `Cargo.toml` file (related to this [issue](https://github.com/rust-lang/cargo/pull/11409)). Otherwise, it will have no effect, causing your compilation to fail.
+Right now, if **no_std** is required, `default-features = false` must be set in the root `Cargo.toml` file (related to this [issue](https://github.com/rust-lang/cargo/pull/11409)). Otherwise, it will have no effect, causing your compilation to fail.
 Also `package` imports aren't properly propagated from root to sub-crates, so defining those should be avoided.
 
 Defining _features_ in the root `Cargo.toml` is additive with the features defined in concrete crate's `Cargo.toml`.
@@ -122,7 +122,7 @@ Defining _features_ in the root `Cargo.toml` is additive with the features defin
 1. Check if the dependency is already defined in the root `Cargo.toml`
     1. if **yes**, nothing to do, just take note of the enabled features
     2. if **no**, add it (make sure to use `default-features = false` if dependency is used in _no_std_ context)
-2. Add `new_dependecy = { workspace = true }` to the required crate
+2. Add `new_dependency = { workspace = true }` to the required crate
 3. In case dependency is defined with `default-features = false` but you need it in _std_ context, add `features = ["std"]` to the required crate.
 
 ## Further Reading


### PR DESCRIPTION
### 1.Updated Substrate installation link

Before:

$ curl https://getsubstrate.io -ssf | bash -s -- --fast
After:

$ curl https://docs.substrate.io/install/ -ssf | bash -s -- --fast**
Explanation: Replaced an outdated Substrate installation link with the correct one (docs.substrate.io/install/).

### 2. Fixed incorrect command (non_std → no_std)

Before:
Right now, if non_std is required, default-features = false must be set in the root Cargo.toml file (related to this [issue](https://github.com/rust-lang/cargo/pull/114089)). Otherwise, it will have no effect, causing your compilation to fail.

After:
Right now, if no_std is required, default-features = false must be set in the root Cargo.toml file (related to this [issue](https://github.com/rust-lang/cargo/pull/114089)). Otherwise, it will have no effect, causing your compilation to fail.

Explanation: Fixed a typo in the flag name: "non_std" was incorrect and was replaced with "no_std", which is the correct Rust terminology for using a standard library-free environment.


### 3. Correction in the Astar Network description

Before:
"Astar Network is an interoperable blockchain based the Substrate framework and the hub for dApps within the Polkadot Ecosystem."

After:
"Astar Network is an interoperable blockchain based on the Substrate framework and the hub for dApps within the Polkadot Ecosystem."

Explanation: Fixed a grammatical mistake ("based the" → "based on the").