### PR TITLE
feat: dAppStaking max tier thresholds

### DIFF
--- a/pallets/dapp-staking/src/benchmarking/utils.rs
+++ b/pallets/dapp-staking/src/benchmarking/utils.rs
@@ -180,17 +180,17 @@ pub(super) fn init_tier_settings<T: Config>() {
             TierThreshold::DynamicPercentage {
                 percentage: Perbill::from_parts(11_112_000), // 1.1112%
                 minimum_required_percentage: Perbill::from_parts(8_889_000), // 0.8889%
-                maximum_possible_percentage: None,
+                maximum_possible_percentage: Perbill::from_percent(100),
             },
             TierThreshold::DynamicPercentage {
                 percentage: Perbill::from_parts(5_556_000), // 0.5556%
                 minimum_required_percentage: Perbill::from_parts(4_400_000), // 0.44%
-                maximum_possible_percentage: None,
+                maximum_possible_percentage: Perbill::from_percent(100),
             },
             TierThreshold::DynamicPercentage {
                 percentage: Perbill::from_parts(2_223_000), // 0.2223%
                 minimum_required_percentage: Perbill::from_parts(2_223_000), // 0.2223%
-                maximum_possible_percentage: None,
+                maximum_possible_percentage: Perbill::from_percent(100),
             },
             TierThreshold::FixedPercentage {
                 required_percentage: Perbill::from_parts(1_667_000), // 0.1667%

--- a/pallets/dapp-staking/src/benchmarking/utils.rs
+++ b/pallets/dapp-staking/src/benchmarking/utils.rs
@@ -180,14 +180,17 @@ pub(super) fn init_tier_settings<T: Config>() {
             TierThreshold::DynamicPercentage {
                 percentage: Perbill::from_parts(11_112_000), // 1.1112%
                 minimum_required_percentage: Perbill::from_parts(8_889_000), // 0.8889%
+                maximum_possible_percentage: None,
             },
             TierThreshold::DynamicPercentage {
                 percentage: Perbill::from_parts(5_556_000), // 0.5556%
                 minimum_required_percentage: Perbill::from_parts(4_400_000), // 0.44%
+                maximum_possible_percentage: None,
             },
             TierThreshold::DynamicPercentage {
                 percentage: Perbill::from_parts(2_223_000), // 0.2223%
                 minimum_required_percentage: Perbill::from_parts(2_223_000), // 0.2223%
+                maximum_possible_percentage: None,
             },
             TierThreshold::FixedPercentage {
                 required_percentage: Perbill::from_parts(1_667_000), // 0.1667%

--- a/pallets/dapp-staking/src/lib.rs
+++ b/pallets/dapp-staking/src/lib.rs
@@ -94,7 +94,7 @@ pub mod pallet {
     use super::*;
 
     /// The current storage version.
-    pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(9);
+    pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(10);
 
     #[pallet::pallet]
     #[pallet::storage_version(STORAGE_VERSION)]

--- a/pallets/dapp-staking/src/test/mock.rs
+++ b/pallets/dapp-staking/src/test/mock.rs
@@ -321,17 +321,17 @@ impl ExtBuilder {
                     TierThreshold::DynamicPercentage {
                         percentage: Perbill::from_parts(11_112_000), // 1.1112%
                         minimum_required_percentage: Perbill::from_parts(8_889_000), // 0.8889%
-                        maximum_possible_percentage: Some(Perbill::from_parts(13_000_000)), // 1.3%
+                        maximum_possible_percentage: Perbill::from_parts(13_000_000), // 1.3%
                     },
                     TierThreshold::DynamicPercentage {
                         percentage: Perbill::from_parts(5_556_000), // 0.5556%
                         minimum_required_percentage: Perbill::from_parts(4_400_000), // 0.44%
-                        maximum_possible_percentage: None,
+                        maximum_possible_percentage: Perbill::from_percent(100),
                     },
                     TierThreshold::DynamicPercentage {
                         percentage: Perbill::from_parts(2_223_000), // 0.2223%
                         minimum_required_percentage: Perbill::from_parts(2_223_000), // 0.2223%
-                        maximum_possible_percentage: None,
+                        maximum_possible_percentage: Perbill::from_percent(100),
                     },
                     TierThreshold::FixedPercentage {
                         required_percentage: Perbill::from_parts(1_667_000), // 0.1667%

--- a/pallets/dapp-staking/src/test/mock.rs
+++ b/pallets/dapp-staking/src/test/mock.rs
@@ -321,14 +321,17 @@ impl ExtBuilder {
                     TierThreshold::DynamicPercentage {
                         percentage: Perbill::from_parts(11_112_000), // 1.1112%
                         minimum_required_percentage: Perbill::from_parts(8_889_000), // 0.8889%
+                        maximum_possible_percentage: Some(Perbill::from_parts(13_000_000)), // 1.3%
                     },
                     TierThreshold::DynamicPercentage {
                         percentage: Perbill::from_parts(5_556_000), // 0.5556%
                         minimum_required_percentage: Perbill::from_parts(4_400_000), // 0.44%
+                        maximum_possible_percentage: None,
                     },
                     TierThreshold::DynamicPercentage {
                         percentage: Perbill::from_parts(2_223_000), // 0.2223%
                         minimum_required_percentage: Perbill::from_parts(2_223_000), // 0.2223%
+                        maximum_possible_percentage: None,
                     },
                     TierThreshold::FixedPercentage {
                         required_percentage: Perbill::from_parts(1_667_000), // 0.1667%

--- a/pallets/dapp-staking/src/test/tests.rs
+++ b/pallets/dapp-staking/src/test/tests.rs
@@ -2777,14 +2777,14 @@ fn tier_config_recalculation_works() {
             })
             .collect();
 
-        // Check that each tier's threshold has increased but doesn't exceed its maximum
+        // Check that each tier's threshold has increased (or remains equal for fixed percentages) but doesn't exceed its maximum
         assert!(
             new_tier_config
                 .tier_thresholds
                 .iter()
                 .zip(init_tier_config.tier_thresholds.iter())
                 .zip(max_amounts.iter())
-                .all(|((new, init), max_amount)| new > init && new <= max_amount),
+                .all(|((new, init), max_amount)| new >= init && new <= max_amount),
             "Tier threshold values should increase with lower price but not exceed their maximums"
         );
     })

--- a/pallets/dapp-staking/src/test/tests.rs
+++ b/pallets/dapp-staking/src/test/tests.rs
@@ -2787,7 +2787,7 @@ fn tier_config_recalculation_works() {
                 .iter()
                 .zip(init_tier_config.tier_thresholds.iter())
                 .zip(max_amounts.iter())
-                .all(|((new, init), max_amount)| new >= init && new <= max_amount),
+                .all(|((new, init), max_amount)| new > init && new <= max_amount),
             "Tier threshold values should increase with lower price but not exceed their maximums"
         );
     })

--- a/pallets/dapp-staking/src/test/tests.rs
+++ b/pallets/dapp-staking/src/test/tests.rs
@@ -2763,20 +2763,17 @@ fn tier_config_recalculation_works() {
         let max_amounts: Vec<Balance> = tier_params
             .tier_thresholds
             .iter()
-            .map(|threshold| {
-                match threshold {
-                    TierThreshold::DynamicPercentage {
-                        maximum_possible_percentage,
-                        ..
-                    } => {
-                        let max_percent =
-                            maximum_possible_percentage.unwrap_or(Perbill::from_percent(100)); // Default to 100%
-                        max_percent * total_issuance
-                    }
-                    TierThreshold::FixedPercentage {
-                        required_percentage,
-                    } => *required_percentage * total_issuance,
+            .map(|threshold| match threshold {
+                TierThreshold::DynamicPercentage {
+                    maximum_possible_percentage,
+                    ..
+                } => {
+                    let max_percent = maximum_possible_percentage;
+                    *max_percent * total_issuance
                 }
+                TierThreshold::FixedPercentage {
+                    required_percentage,
+                } => *required_percentage * total_issuance,
             })
             .collect();
 

--- a/pallets/dapp-staking/src/test/tests.rs
+++ b/pallets/dapp-staking/src/test/tests.rs
@@ -4235,6 +4235,26 @@ fn set_static_tier_params_invalid_params_fails() {
             DappStaking::set_static_tier_params(RuntimeOrigin::root(), invalid_tier_params),
             Error::<Test>::InvalidTierParams
         );
+
+        // invalid dynamic percentage (min > max)
+        let mut tier_thresholds = tier_params.tier_thresholds.clone().to_vec();
+        tier_thresholds[0] = TierThreshold::DynamicPercentage {
+            percentage: Perbill::from_percent(2),
+            minimum_required_percentage: Perbill::from_percent(5),
+            maximum_possible_percentage: Perbill::from_percent(3),
+        };
+
+        let invalid_min_max_params = TierParameters::<NumberOfTiers> {
+            tier_thresholds: tier_thresholds.try_into().unwrap(),
+            ..tier_params.clone()
+        };
+
+        assert!(!invalid_min_max_params.is_valid(), "Invalid min/max");
+
+        assert_noop!(
+            DappStaking::set_static_tier_params(RuntimeOrigin::root(), invalid_min_max_params),
+            Error::<Test>::InvalidTierParams
+        );
     })
 }
 

--- a/pallets/dapp-staking/src/test/tests_types.rs
+++ b/pallets/dapp-staking/src/test/tests_types.rs
@@ -3489,14 +3489,17 @@ fn tier_configuration_basic_tests() {
             TierThreshold::DynamicPercentage {
                 percentage: Perbill::from_percent(12),
                 minimum_required_percentage: Perbill::from_percent(8),
+                maximum_possible_percentage: None,
             },
             TierThreshold::DynamicPercentage {
                 percentage: Perbill::from_percent(7),
                 minimum_required_percentage: Perbill::from_percent(5),
+                maximum_possible_percentage: None,
             },
             TierThreshold::DynamicPercentage {
                 percentage: Perbill::from_percent(4),
                 minimum_required_percentage: Perbill::from_percent(3),
+                maximum_possible_percentage: None,
             },
             TierThreshold::FixedPercentage {
                 required_percentage: Perbill::from_percent(3),
@@ -3692,6 +3695,7 @@ fn tier_thresholds_conversion_test() {
         TierThreshold::DynamicPercentage {
             percentage: Perbill::from_percent(5),
             minimum_required_percentage: Perbill::from_percent(2),
+            maximum_possible_percentage: None,
         },
     ])
     .unwrap();
@@ -3705,4 +3709,144 @@ fn tier_thresholds_conversion_test() {
 
     assert_eq!(tier_thresholds[0], 100_000); // 10% of total issuance
     assert_eq!(tier_thresholds[1], 50_000); // 5% of total issuance
+}
+
+#[test]
+fn tier_configuration_calculate_new_with_maximum_threshold() {
+    get_u32_type!(TiersNum, 4);
+
+    let slot_distribution = BoundedVec::<Permill, TiersNum>::try_from(vec![
+        Permill::from_percent(10),
+        Permill::from_percent(20),
+        Permill::from_percent(30),
+        Permill::from_percent(40),
+    ])
+    .unwrap();
+
+    let reward_portion = BoundedVec::<Permill, TiersNum>::try_from(vec![
+        Permill::from_percent(10),
+        Permill::from_percent(20),
+        Permill::from_percent(30),
+        Permill::from_percent(40),
+    ])
+    .unwrap();
+
+    // Create tier thresholds (legacy without maximum)
+    let tier_thresholds_legacy = BoundedVec::<TierThreshold, TiersNum>::try_from(vec![
+        TierThreshold::DynamicPercentage {
+            percentage: Perbill::from_percent(4),
+            minimum_required_percentage: Perbill::from_percent(3),
+            maximum_possible_percentage: None,
+        },
+        TierThreshold::DynamicPercentage {
+            percentage: Perbill::from_percent(3),
+            minimum_required_percentage: Perbill::from_percent(2),
+            maximum_possible_percentage: None,
+        },
+        TierThreshold::DynamicPercentage {
+            percentage: Perbill::from_percent(2),
+            minimum_required_percentage: Perbill::from_percent(1),
+            maximum_possible_percentage: None,
+        },
+        TierThreshold::FixedPercentage {
+            required_percentage: Perbill::from_parts(5_000_000), // 0.5%
+        },
+    ])
+    .unwrap();
+
+    // Create tier thresholds (with maximum)
+    let tier_thresholds_with_max = BoundedVec::<TierThreshold, TiersNum>::try_from(vec![
+        TierThreshold::DynamicPercentage {
+            percentage: Perbill::from_percent(4),
+            minimum_required_percentage: Perbill::from_percent(3),
+            maximum_possible_percentage: Some(Perbill::from_percent(5)),
+        },
+        TierThreshold::DynamicPercentage {
+            percentage: Perbill::from_percent(3),
+            minimum_required_percentage: Perbill::from_percent(2),
+            maximum_possible_percentage: Some(Perbill::from_percent(4)),
+        },
+        TierThreshold::DynamicPercentage {
+            percentage: Perbill::from_percent(2),
+            minimum_required_percentage: Perbill::from_percent(1),
+            maximum_possible_percentage: Some(Perbill::from_percent(3)),
+        },
+        TierThreshold::FixedPercentage {
+            required_percentage: Perbill::from_parts(5_000_000), // 0.5%
+        },
+    ])
+    .unwrap();
+
+    let params_legacy = TierParameters::<TiersNum> {
+        slot_distribution: slot_distribution.clone(),
+        tier_thresholds: tier_thresholds_legacy,
+        reward_portion: reward_portion.clone(),
+        slot_number_args: STANDARD_TIER_SLOTS_ARGS,
+    };
+
+    let params_with_max = TierParameters::<TiersNum> {
+        slot_distribution,
+        tier_thresholds: tier_thresholds_with_max,
+        reward_portion: reward_portion.clone(),
+        slot_number_args: STANDARD_TIER_SLOTS_ARGS,
+    };
+
+    // Create a starting configuration with some values
+    parameter_types! {
+        pub const BaseNativeCurrencyPrice: FixedU128 = FixedU128::from_rational(5, 100);
+    }
+    let total_issuance: Balance = 8_400_000_000;
+    let tier_thresholds = params_legacy
+        .tier_thresholds
+        .iter()
+        .map(|t| t.threshold(total_issuance))
+        .collect::<Vec<Balance>>()
+        .try_into()
+        .expect("Invalid number of tier thresholds provided.");
+
+    let init_config = TiersConfiguration::<TiersNum, StandardTierSlots, BaseNativeCurrencyPrice> {
+        slots_per_tier: BoundedVec::try_from(vec![10, 20, 30, 40]).unwrap(),
+        reward_portion: reward_portion.clone(),
+        tier_thresholds,
+        _phantom: PhantomData::default(),
+    };
+    assert!(init_config.is_valid(), "Init config must be valid!");
+
+    // Test Case: When price decreases significantly, legacy thresholds might exceed the maximum
+    let very_low_price = FixedU128::from_rational(1, 100); // 0.2x base price
+
+    // For legacy parameters (no maximum)
+    let new_config_legacy =
+        init_config.calculate_new(&params_legacy, very_low_price, total_issuance);
+
+    // For parameters with maximum
+    let new_config_with_max =
+        init_config.calculate_new(&params_with_max, very_low_price, total_issuance);
+
+    // Legacy thresholds will be high
+    assert!(new_config_legacy.tier_thresholds[0] > Perbill::from_percent(5) * total_issuance);
+    assert!(new_config_legacy.tier_thresholds[1] > Perbill::from_percent(4) * total_issuance);
+    assert!(new_config_legacy.tier_thresholds[2] > Perbill::from_percent(3) * total_issuance);
+    assert_eq!(
+        new_config_legacy.tier_thresholds[3],
+        Perbill::from_parts(5_000_000) * total_issuance
+    );
+
+    // Maximum thresholds will be capped
+    assert_eq!(
+        new_config_with_max.tier_thresholds[0],
+        Perbill::from_percent(5) * total_issuance
+    );
+    assert_eq!(
+        new_config_with_max.tier_thresholds[1],
+        Perbill::from_percent(4) * total_issuance
+    );
+    assert_eq!(
+        new_config_with_max.tier_thresholds[2],
+        Perbill::from_percent(3) * total_issuance
+    );
+    assert_eq!(
+        new_config_with_max.tier_thresholds[3],
+        Perbill::from_parts(5_000_000) * total_issuance
+    );
 }

--- a/pallets/dapp-staking/src/test/tests_types.rs
+++ b/pallets/dapp-staking/src/test/tests_types.rs
@@ -3464,6 +3464,44 @@ fn tier_params_check_is_ok() {
     }])
     .unwrap();
     assert!(!new_params.is_valid());
+
+    // 5th scenario - DynamicPercentage with valid min/max (min <= max)
+    let mut valid_dynamic_params = params.clone();
+    valid_dynamic_params.tier_thresholds = BoundedVec::try_from(vec![
+        TierThreshold::DynamicPercentage {
+            percentage: Perbill::from_percent(2),
+            minimum_required_percentage: Perbill::from_percent(1),
+            maximum_possible_percentage: Perbill::from_percent(3),
+        },
+        TierThreshold::DynamicPercentage {
+            percentage: Perbill::from_percent(2),
+            minimum_required_percentage: Perbill::from_percent(2), // equal min and max is valid
+            maximum_possible_percentage: Perbill::from_percent(2),
+        },
+        TierThreshold::FixedPercentage {
+            required_percentage: Perbill::from_percent(1),
+        },
+    ])
+    .unwrap();
+    assert!(valid_dynamic_params.is_valid());
+
+    // 6th scenario - DynamicPercentage with invalid min/max (min > max)
+    let mut invalid_dynamic_params = params.clone();
+    invalid_dynamic_params.tier_thresholds = BoundedVec::try_from(vec![
+        TierThreshold::DynamicPercentage {
+            percentage: Perbill::from_percent(2),
+            minimum_required_percentage: Perbill::from_percent(4), // min > max is invalid
+            maximum_possible_percentage: Perbill::from_percent(3),
+        },
+        TierThreshold::FixedPercentage {
+            required_percentage: Perbill::from_percent(2),
+        },
+        TierThreshold::FixedPercentage {
+            required_percentage: Perbill::from_percent(1),
+        },
+    ])
+    .unwrap();
+    assert!(!invalid_dynamic_params.is_valid());
 }
 
 #[test]

--- a/pallets/dapp-staking/src/test/tests_types.rs
+++ b/pallets/dapp-staking/src/test/tests_types.rs
@@ -3489,17 +3489,17 @@ fn tier_configuration_basic_tests() {
             TierThreshold::DynamicPercentage {
                 percentage: Perbill::from_percent(12),
                 minimum_required_percentage: Perbill::from_percent(8),
-                maximum_possible_percentage: None,
+                maximum_possible_percentage: Perbill::from_percent(100),
             },
             TierThreshold::DynamicPercentage {
                 percentage: Perbill::from_percent(7),
                 minimum_required_percentage: Perbill::from_percent(5),
-                maximum_possible_percentage: None,
+                maximum_possible_percentage: Perbill::from_percent(100),
             },
             TierThreshold::DynamicPercentage {
                 percentage: Perbill::from_percent(4),
                 minimum_required_percentage: Perbill::from_percent(3),
-                maximum_possible_percentage: None,
+                maximum_possible_percentage: Perbill::from_percent(100),
             },
             TierThreshold::FixedPercentage {
                 required_percentage: Perbill::from_percent(3),
@@ -3695,7 +3695,7 @@ fn tier_thresholds_conversion_test() {
         TierThreshold::DynamicPercentage {
             percentage: Perbill::from_percent(5),
             minimum_required_percentage: Perbill::from_percent(2),
-            maximum_possible_percentage: None,
+            maximum_possible_percentage: Perbill::from_percent(100),
         },
     ])
     .unwrap();
@@ -3736,17 +3736,17 @@ fn tier_configuration_calculate_new_with_maximum_threshold() {
         TierThreshold::DynamicPercentage {
             percentage: Perbill::from_percent(4),
             minimum_required_percentage: Perbill::from_percent(3),
-            maximum_possible_percentage: None,
+            maximum_possible_percentage: Perbill::from_percent(100),
         },
         TierThreshold::DynamicPercentage {
             percentage: Perbill::from_percent(3),
             minimum_required_percentage: Perbill::from_percent(2),
-            maximum_possible_percentage: None,
+            maximum_possible_percentage: Perbill::from_percent(100),
         },
         TierThreshold::DynamicPercentage {
             percentage: Perbill::from_percent(2),
             minimum_required_percentage: Perbill::from_percent(1),
-            maximum_possible_percentage: None,
+            maximum_possible_percentage: Perbill::from_percent(100),
         },
         TierThreshold::FixedPercentage {
             required_percentage: Perbill::from_parts(5_000_000), // 0.5%
@@ -3759,17 +3759,17 @@ fn tier_configuration_calculate_new_with_maximum_threshold() {
         TierThreshold::DynamicPercentage {
             percentage: Perbill::from_percent(4),
             minimum_required_percentage: Perbill::from_percent(3),
-            maximum_possible_percentage: Some(Perbill::from_percent(5)),
+            maximum_possible_percentage: Perbill::from_percent(5),
         },
         TierThreshold::DynamicPercentage {
             percentage: Perbill::from_percent(3),
             minimum_required_percentage: Perbill::from_percent(2),
-            maximum_possible_percentage: Some(Perbill::from_percent(4)),
+            maximum_possible_percentage: Perbill::from_percent(4),
         },
         TierThreshold::DynamicPercentage {
             percentage: Perbill::from_percent(2),
             minimum_required_percentage: Perbill::from_percent(1),
-            maximum_possible_percentage: Some(Perbill::from_percent(3)),
+            maximum_possible_percentage: Perbill::from_percent(3),
         },
         TierThreshold::FixedPercentage {
             required_percentage: Perbill::from_parts(5_000_000), // 0.5%

--- a/pallets/dapp-staking/src/types.rs
+++ b/pallets/dapp-staking/src/types.rs
@@ -1646,7 +1646,7 @@ pub enum TierThreshold {
     DynamicPercentage {
         percentage: Perbill,
         minimum_required_percentage: Perbill,
-        maximum_possible_percentage: Option<Perbill>,
+        maximum_possible_percentage: Perbill,
     },
 }
 
@@ -1857,9 +1857,7 @@ impl<NT: Get<u32>, T: TierSlotsFunc, P: Get<FixedU128>> TiersConfiguration<NT, T
                         amount.saturating_add(delta_threshold.saturating_mul_int(amount))
                     };
                     let minimum_amount = *minimum_required_percentage * total_issuance;
-                    let maximum_amount = maximum_possible_percentage
-                        .unwrap_or(Perbill::from_percent(100)) // Default to 100% if not specified
-                        * total_issuance;
+                    let maximum_amount = *maximum_possible_percentage * total_issuance;
                     adjusted_amount.max(minimum_amount).min(maximum_amount)
                 }
                 TierThreshold::FixedPercentage {

--- a/runtime/astar/src/genesis_config.rs
+++ b/runtime/astar/src/genesis_config.rs
@@ -136,14 +136,17 @@ pub fn default_config(para_id: u32) -> serde_json::Value {
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(35_700_000), // 3.57%
                     minimum_required_percentage: Perbill::from_parts(23_800_000), // 2.38%
+                    maximum_possible_percentage: None,
                 },
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(8_900_000), // 0.89%
                     minimum_required_percentage: Perbill::from_parts(6_000_000), // 0.6%
+                    maximum_possible_percentage: None,
                 },
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(2_380_000), // 0.238%
                     minimum_required_percentage: Perbill::from_parts(1_790_000), // 0.179%
+                    maximum_possible_percentage: None,
                 },
                 TierThreshold::FixedPercentage {
                     required_percentage: Perbill::from_parts(600_000), // 0.06%

--- a/runtime/astar/src/genesis_config.rs
+++ b/runtime/astar/src/genesis_config.rs
@@ -136,17 +136,17 @@ pub fn default_config(para_id: u32) -> serde_json::Value {
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(35_700_000), // 3.57%
                     minimum_required_percentage: Perbill::from_parts(23_800_000), // 2.38%
-                    maximum_possible_percentage: None,
+                    maximum_possible_percentage: Perbill::from_percent(100),
                 },
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(8_900_000), // 0.89%
                     minimum_required_percentage: Perbill::from_parts(6_000_000), // 0.6%
-                    maximum_possible_percentage: None,
+                    maximum_possible_percentage: Perbill::from_percent(100),
                 },
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(2_380_000), // 0.238%
                     minimum_required_percentage: Perbill::from_parts(1_790_000), // 0.179%
-                    maximum_possible_percentage: None,
+                    maximum_possible_percentage: Perbill::from_percent(100),
                 },
                 TierThreshold::FixedPercentage {
                     required_percentage: Perbill::from_parts(600_000), // 0.06%

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -1591,32 +1591,17 @@ pub type Executive = frame_executive::Executive<
 pub type Migrations = (Unreleased, Permanent);
 
 parameter_types! {
-    // max percentages are derived from an Astar token price of $0.035
-    pub const TierThresholds: [TierThreshold; 4] = [
-        TierThreshold::DynamicPercentage {
-            percentage: Perbill::from_parts(35_700_000), // 3.57%
-            minimum_required_percentage: Perbill::from_parts(23_800_000), // 2.38%
-            maximum_possible_percentage: Some(Perbill::from_parts(35_700_000)), // 3.57%
-        },
-        TierThreshold::DynamicPercentage {
-            percentage: Perbill::from_parts(8_900_000), // 0.89%
-            minimum_required_percentage: Perbill::from_parts(6_000_000), // 0.6%
-            maximum_possible_percentage: Some(Perbill::from_parts(8_900_000)), // 0.89%
-        },
-        TierThreshold::DynamicPercentage {
-            percentage: Perbill::from_parts(2_380_000), // 0.238%
-            minimum_required_percentage: Perbill::from_parts(1_790_000), // 0.179%
-            maximum_possible_percentage: Some(Perbill::from_parts(2_380_000)), // 0.238%
-        },
-        TierThreshold::FixedPercentage {
-            required_percentage: Perbill::from_parts(200_000), // 0.02%
-        },
+    pub const MaxPercentages: [Option<Perbill>; 4] = [
+        Some(Perbill::from_parts(35_700_000)), // 3.57%
+        Some(Perbill::from_parts(8_900_000)), // 0.89%
+        Some(Perbill::from_parts(2_380_000)), // 0.238%
+        None
     ];
 }
 
 /// Unreleased migrations. Add new ones here:
 pub type Unreleased =
-    (pallet_dapp_staking::migration::versioned_migrations::V9ToV10<Runtime, TierThresholds>,);
+    (pallet_dapp_staking::migration::versioned_migrations::V9ToV10<Runtime, MaxPercentages>,);
 
 /// Migrations/checks that do not need to be versioned and can run on every upgrade.
 pub type Permanent = (pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,);

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -1596,17 +1596,17 @@ parameter_types! {
         TierThreshold::DynamicPercentage {
             percentage: Perbill::from_parts(35_700_000), // 3.57%
             minimum_required_percentage: Perbill::from_parts(23_800_000), // 2.38%
-            maximum_possible_percentage: Some(Perbill::from_parts(42_000_000)), // 4.20%
+            maximum_possible_percentage: Some(Perbill::from_parts(35_700_000)), // 3.57%
         },
         TierThreshold::DynamicPercentage {
             percentage: Perbill::from_parts(8_900_000), // 0.89%
             minimum_required_percentage: Perbill::from_parts(6_000_000), // 0.6%
-            maximum_possible_percentage: Some(Perbill::from_parts(10_400_000)), // 1.04%
+            maximum_possible_percentage: Some(Perbill::from_parts(8_900_000)), // 0.89%
         },
         TierThreshold::DynamicPercentage {
             percentage: Perbill::from_parts(2_380_000), // 0.238%
             minimum_required_percentage: Perbill::from_parts(1_790_000), // 0.179%
-            maximum_possible_percentage: Some(Perbill::from_parts(2_800_000)), // 0.280%
+            maximum_possible_percentage: Some(Perbill::from_parts(2_380_000)), // 0.238%
         },
         TierThreshold::FixedPercentage {
             required_percentage: Perbill::from_parts(200_000), // 0.02%

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -1590,8 +1590,33 @@ pub type Executive = frame_executive::Executive<
 /// __NOTE:__ THE ORDER IS IMPORTANT.
 pub type Migrations = (Unreleased, Permanent);
 
+parameter_types! {
+    // max percentages are derived from an Astar token price of $0.035
+    pub const TierThresholds: [TierThreshold; 4] = [
+        TierThreshold::DynamicPercentage {
+            percentage: Perbill::from_parts(35_700_000), // 3.57%
+            minimum_required_percentage: Perbill::from_parts(23_800_000), // 2.38%
+            maximum_possible_percentage: Some(Perbill::from_parts(42_000_000)), // 4.20%
+        },
+        TierThreshold::DynamicPercentage {
+            percentage: Perbill::from_parts(8_900_000), // 0.89%
+            minimum_required_percentage: Perbill::from_parts(6_000_000), // 0.6%
+            maximum_possible_percentage: Some(Perbill::from_parts(10_400_000)), // 1.04%
+        },
+        TierThreshold::DynamicPercentage {
+            percentage: Perbill::from_parts(2_380_000), // 0.238%
+            minimum_required_percentage: Perbill::from_parts(1_790_000), // 0.179%
+            maximum_possible_percentage: Some(Perbill::from_parts(2_800_000)), // 0.280%
+        },
+        TierThreshold::FixedPercentage {
+            required_percentage: Perbill::from_parts(200_000), // 0.02%
+        },
+    ];
+}
+
 /// Unreleased migrations. Add new ones here:
-pub type Unreleased = (pallet_dapp_staking::migration::DappStakingCleanupMigration<Runtime>,);
+pub type Unreleased =
+    (pallet_dapp_staking::migration::versioned_migrations::V9ToV10<Runtime, TierThresholds>,);
 
 /// Migrations/checks that do not need to be versioned and can run on every upgrade.
 pub type Permanent = (pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,);

--- a/runtime/local/src/genesis_config.rs
+++ b/runtime/local/src/genesis_config.rs
@@ -117,17 +117,17 @@ pub fn default_config() -> serde_json::Value {
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(35_700_000), // 3.57%
                     minimum_required_percentage: Perbill::from_parts(23_800_000), // 2.38%
-                    maximum_possible_percentage: None,
+                    maximum_possible_percentage: Perbill::from_percent(100),
                 },
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(8_900_000), // 0.89%
                     minimum_required_percentage: Perbill::from_parts(6_000_000), // 0.6%
-                    maximum_possible_percentage: None,
+                    maximum_possible_percentage: Perbill::from_percent(100),
                 },
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(23_800_000), // 2.38%
                     minimum_required_percentage: Perbill::from_parts(17_900_000), // 1.79%
-                    maximum_possible_percentage: None,
+                    maximum_possible_percentage: Perbill::from_percent(100),
                 },
                 TierThreshold::FixedPercentage {
                     required_percentage: Perbill::from_parts(600_000), // 0.06%

--- a/runtime/local/src/genesis_config.rs
+++ b/runtime/local/src/genesis_config.rs
@@ -117,14 +117,17 @@ pub fn default_config() -> serde_json::Value {
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(35_700_000), // 3.57%
                     minimum_required_percentage: Perbill::from_parts(23_800_000), // 2.38%
+                    maximum_possible_percentage: None,
                 },
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(8_900_000), // 0.89%
                     minimum_required_percentage: Perbill::from_parts(6_000_000), // 0.6%
+                    maximum_possible_percentage: None,
                 },
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(23_800_000), // 2.38%
                     minimum_required_percentage: Perbill::from_parts(17_900_000), // 1.79%
+                    maximum_possible_percentage: None,
                 },
                 TierThreshold::FixedPercentage {
                     required_percentage: Perbill::from_parts(600_000), // 0.06%

--- a/runtime/shibuya/src/genesis_config.rs
+++ b/runtime/shibuya/src/genesis_config.rs
@@ -135,19 +135,22 @@ pub fn default_config(para_id: u32) -> serde_json::Value {
                 Permill::from_percent(30),
                 Permill::from_percent(40),
             ],
-            // percentages below are calulated based on a total issuance at the time when dApp staking v3 was launched (147M)
+            // percentages below are calculated based on a total issuance at the time when dApp staking v3 was launched (147M)
             tier_thresholds: vec![
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(20_000), // 0.0020%
                     minimum_required_percentage: Perbill::from_parts(17_000), // 0.0017%
+                    maximum_possible_percentage: None,
                 },
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(13_000), // 0.0013%
                     minimum_required_percentage: Perbill::from_parts(10_000), // 0.0010%
+                    maximum_possible_percentage: None,
                 },
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(5_400), // 0.00054%
                     minimum_required_percentage: Perbill::from_parts(3_400), // 0.00034%
+                    maximum_possible_percentage: None,
                 },
                 TierThreshold::FixedPercentage {
                     required_percentage: Perbill::from_parts(1_400), // 0.00014%

--- a/runtime/shibuya/src/genesis_config.rs
+++ b/runtime/shibuya/src/genesis_config.rs
@@ -140,17 +140,17 @@ pub fn default_config(para_id: u32) -> serde_json::Value {
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(20_000), // 0.0020%
                     minimum_required_percentage: Perbill::from_parts(17_000), // 0.0017%
-                    maximum_possible_percentage: None,
+                    maximum_possible_percentage: Perbill::from_percent(100),
                 },
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(13_000), // 0.0013%
                     minimum_required_percentage: Perbill::from_parts(10_000), // 0.0010%
-                    maximum_possible_percentage: None,
+                    maximum_possible_percentage: Perbill::from_percent(100),
                 },
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(5_400), // 0.00054%
                     minimum_required_percentage: Perbill::from_parts(3_400), // 0.00034%
-                    maximum_possible_percentage: None,
+                    maximum_possible_percentage: Perbill::from_percent(100),
                 },
                 TierThreshold::FixedPercentage {
                     required_percentage: Perbill::from_parts(1_400), // 0.00014%

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -1688,31 +1688,12 @@ pub type Executive = frame_executive::Executive<
 pub type Migrations = (Unreleased, Permanent);
 
 parameter_types! {
-    pub const TierThresholds: [TierThreshold; 4] = [
-        TierThreshold::DynamicPercentage {
-            percentage: Perbill::from_parts(20_000), // 0.0020%
-            minimum_required_percentage: Perbill::from_parts(17_000), // 0.0017%
-            maximum_possible_percentage: None,
-        },
-        TierThreshold::DynamicPercentage {
-            percentage: Perbill::from_parts(13_000), // 0.0013%
-            minimum_required_percentage: Perbill::from_parts(10_000), // 0.0010%
-            maximum_possible_percentage: None,
-        },
-        TierThreshold::DynamicPercentage {
-            percentage: Perbill::from_parts(5_400), // 0.00054%
-            minimum_required_percentage: Perbill::from_parts(3_400), // 0.00034%
-            maximum_possible_percentage: None,
-        },
-        TierThreshold::FixedPercentage {
-            required_percentage: Perbill::from_parts(1_400), // 0.00014%
-        },
-    ];
+    pub const MaxPercentages: [Option<Perbill>; 4] = [None, None, None, None];
 }
 
 /// Unreleased migrations. Add new ones here:
 pub type Unreleased =
-    (pallet_dapp_staking::migration::versioned_migrations::V9ToV10<Runtime, TierThresholds>,);
+    (pallet_dapp_staking::migration::versioned_migrations::V9ToV10<Runtime, MaxPercentages>,);
 
 /// Migrations/checks that do not need to be versioned and can run on every upgrade.
 pub type Permanent = (pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,);

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -1688,7 +1688,12 @@ pub type Executive = frame_executive::Executive<
 pub type Migrations = (Unreleased, Permanent);
 
 parameter_types! {
-    pub const MaxPercentages: [Option<Perbill>; 4] = [None, None, None, None];
+    pub const MaxPercentages: [Option<Perbill>; 4] = [
+        Some(Perbill::from_parts(30_000)), // 0.0030%
+        Some(Perbill::from_parts(20_000)), // 0.0020%
+        Some(Perbill::from_parts(10_000)), // 0.0010%
+        None
+    ];
 }
 
 /// Unreleased migrations. Add new ones here:

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -1687,8 +1687,32 @@ pub type Executive = frame_executive::Executive<
 /// __NOTE:__ THE ORDER IS IMPORTANT.
 pub type Migrations = (Unreleased, Permanent);
 
+parameter_types! {
+    pub const TierThresholds: [TierThreshold; 4] = [
+        TierThreshold::DynamicPercentage {
+            percentage: Perbill::from_parts(20_000), // 0.0020%
+            minimum_required_percentage: Perbill::from_parts(17_000), // 0.0017%
+            maximum_possible_percentage: None,
+        },
+        TierThreshold::DynamicPercentage {
+            percentage: Perbill::from_parts(13_000), // 0.0013%
+            minimum_required_percentage: Perbill::from_parts(10_000), // 0.0010%
+            maximum_possible_percentage: None,
+        },
+        TierThreshold::DynamicPercentage {
+            percentage: Perbill::from_parts(5_400), // 0.00054%
+            minimum_required_percentage: Perbill::from_parts(3_400), // 0.00034%
+            maximum_possible_percentage: None,
+        },
+        TierThreshold::FixedPercentage {
+            required_percentage: Perbill::from_parts(1_400), // 0.00014%
+        },
+    ];
+}
+
 /// Unreleased migrations. Add new ones here:
-pub type Unreleased = (pallet_dapp_staking::migration::DappStakingCleanupMigration<Runtime>,);
+pub type Unreleased =
+    (pallet_dapp_staking::migration::versioned_migrations::V9ToV10<Runtime, TierThresholds>,);
 
 /// Migrations/checks that do not need to be versioned and can run on every upgrade.
 pub type Permanent = (pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,);

--- a/runtime/shiden/src/genesis_config.rs
+++ b/runtime/shiden/src/genesis_config.rs
@@ -126,14 +126,17 @@ pub fn default_config(para_id: u32) -> serde_json::Value {
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(35_700_000), // 3.57%
                     minimum_required_percentage: Perbill::from_parts(23_800_000), // 2.38%
+                    maximum_possible_percentage: None,
                 },
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(8_900_000), // 0.89%
                     minimum_required_percentage: Perbill::from_parts(6_000_000), // 0.6%
+                    maximum_possible_percentage: None,
                 },
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(2_380_000), // 0.238%
                     minimum_required_percentage: Perbill::from_parts(1_790_000), // 0.179%
+                    maximum_possible_percentage: None,
                 },
                 TierThreshold::FixedPercentage {
                     required_percentage: Perbill::from_parts(600_000), // 0.06%

--- a/runtime/shiden/src/genesis_config.rs
+++ b/runtime/shiden/src/genesis_config.rs
@@ -126,17 +126,17 @@ pub fn default_config(para_id: u32) -> serde_json::Value {
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(35_700_000), // 3.57%
                     minimum_required_percentage: Perbill::from_parts(23_800_000), // 2.38%
-                    maximum_possible_percentage: None,
+                    maximum_possible_percentage: Perbill::from_percent(100),
                 },
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(8_900_000), // 0.89%
                     minimum_required_percentage: Perbill::from_parts(6_000_000), // 0.6%
-                    maximum_possible_percentage: None,
+                    maximum_possible_percentage: Perbill::from_percent(100),
                 },
                 TierThreshold::DynamicPercentage {
                     percentage: Perbill::from_parts(2_380_000), // 0.238%
                     minimum_required_percentage: Perbill::from_parts(1_790_000), // 0.179%
-                    maximum_possible_percentage: None,
+                    maximum_possible_percentage: Perbill::from_percent(100),
                 },
                 TierThreshold::FixedPercentage {
                     required_percentage: Perbill::from_parts(600_000), // 0.06%

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -1285,8 +1285,32 @@ pub type Executive = frame_executive::Executive<
 /// __NOTE:__ THE ORDER IS IMPORTANT.
 pub type Migrations = (Unreleased, Permanent);
 
+parameter_types! {
+    pub const TierThresholds: [TierThreshold; 4] = [
+        TierThreshold::DynamicPercentage {
+            percentage: Perbill::from_parts(35_700_000), // 3.57%
+            minimum_required_percentage: Perbill::from_parts(23_800_000), // 2.38%
+            maximum_possible_percentage: None,
+        },
+        TierThreshold::DynamicPercentage {
+            percentage: Perbill::from_parts(8_900_000), // 0.89%
+            minimum_required_percentage: Perbill::from_parts(6_000_000), // 0.6%
+            maximum_possible_percentage: None,
+        },
+        TierThreshold::DynamicPercentage {
+            percentage: Perbill::from_parts(2_380_000), // 0.238%
+            minimum_required_percentage: Perbill::from_parts(1_790_000), // 0.179%
+            maximum_possible_percentage: None,
+        },
+        TierThreshold::FixedPercentage {
+            required_percentage: Perbill::from_parts(600_000), // 0.06%
+        },
+    ];
+}
+
 /// Unreleased migrations. Add new ones here:
-pub type Unreleased = ();
+pub type Unreleased =
+    (pallet_dapp_staking::migration::versioned_migrations::V9ToV10<Runtime, TierThresholds>,);
 
 /// Migrations/checks that do not need to be versioned and can run on every upgrade.
 pub type Permanent = (pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,);

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -1286,31 +1286,12 @@ pub type Executive = frame_executive::Executive<
 pub type Migrations = (Unreleased, Permanent);
 
 parameter_types! {
-    pub const TierThresholds: [TierThreshold; 4] = [
-        TierThreshold::DynamicPercentage {
-            percentage: Perbill::from_parts(35_700_000), // 3.57%
-            minimum_required_percentage: Perbill::from_parts(23_800_000), // 2.38%
-            maximum_possible_percentage: None,
-        },
-        TierThreshold::DynamicPercentage {
-            percentage: Perbill::from_parts(8_900_000), // 0.89%
-            minimum_required_percentage: Perbill::from_parts(6_000_000), // 0.6%
-            maximum_possible_percentage: None,
-        },
-        TierThreshold::DynamicPercentage {
-            percentage: Perbill::from_parts(2_380_000), // 0.238%
-            minimum_required_percentage: Perbill::from_parts(1_790_000), // 0.179%
-            maximum_possible_percentage: None,
-        },
-        TierThreshold::FixedPercentage {
-            required_percentage: Perbill::from_parts(600_000), // 0.06%
-        },
-    ];
+    pub const MaxPercentages: [Option<Perbill>; 4] = [None, None, None, None];
 }
 
 /// Unreleased migrations. Add new ones here:
 pub type Unreleased =
-    (pallet_dapp_staking::migration::versioned_migrations::V9ToV10<Runtime, TierThresholds>,);
+    (pallet_dapp_staking::migration::versioned_migrations::V9ToV10<Runtime, MaxPercentages>,);
 
 /// Migrations/checks that do not need to be versioned and can run on every upgrade.
 pub type Permanent = (pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,);


### PR DESCRIPTION
**Pull Request Summary**

Closes #1458 

Maximum percentages are derived from an Astar token price of **$0.05** (base values from dAppStaking v3 launch).
The `maximum_possible_percentage` value is optional. If is not specified, the default value used is 100% which reflects the entire total supply.

**Check list**
- [X] added or updated unit tests
- [X] updated Astar documentation - https://github.com/AstarNetwork/astar-docs/pull/742
- [X] update E2E tests - https://github.com/AstarNetwork/e2e-tests/pull/117
