### PR TITLE
fix: dead link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ $ curl -H 'Content-Type: application/json' --data '{ "jsonrpc":"2.0", "method":"
 ```
 
 After this step, you should have a validator node online with a session key for your node.
-For key management and validator rewards, consult our [validator guide online](https://docs.astar.network/build/validator-guide/configure-node).
+For key management and validator rewards, consult our [validator guide online](https://docs.astar.network/docs/build/nodes/).
 
 ## Versioning
 


### PR DESCRIPTION
Fixed link in `README.md`:
   - Updated the link to validator guide online  from https://docs.astar.network/build/validator-guide/configure-node to `https://docs.astar.network/docs/build/nodes/
   

   The previous one was broken.



