### PR TITLE
chore: upgrade actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/base_checks.yaml
+++ b/.github/workflows/base_checks.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
     steps:
     - name: Checkout the source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install deps
       run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -95,7 +95,7 @@ jobs:
           })
 
     - name: Checkout the source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ steps.get_branch_sha.outputs.sha }}
         submodules: true

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -22,7 +22,7 @@ jobs:
         df -h
 
     - name: Checkout the source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install & display rust toolchain
       run: rustup show


### PR DESCRIPTION
Updates the GitHub Actions checkout action from v3 to v4 across workflow files.

Changes:
- Updated actions/checkout@v3 to actions/checkout@v4 in:
  - base_checks.yaml
  - benchmark.yml
  - coverage.yaml (implied)

This update brings the latest improvements and security fixes from the checkout action.