### PR TITLE
feat: release prep collator v5.46.0 and runtime 1500

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "astar-collator"
-version = "5.45.0"
+version = "5.46.0"
 dependencies = [
  "astar-primitives",
  "astar-runtime",
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "astar-runtime"
-version = "14.0.1"
+version = "15.0.0"
 dependencies = [
  "array-bytes",
  "astar-primitives",
@@ -15240,7 +15240,7 @@ dependencies = [
 
 [[package]]
 name = "shibuya-runtime"
-version = "14.0.1"
+version = "15.0.0"
 dependencies = [
  "array-bytes",
  "astar-primitives",
@@ -15364,7 +15364,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "14.0.1"
+version = "15.0.0"
 dependencies = [
  "array-bytes",
  "astar-primitives",

--- a/bin/collator/Cargo.toml
+++ b/bin/collator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-collator"
-version = "5.45.0"
+version = "5.46.0"
 description = "Astar collator implementation in Rust."
 build = "build.rs"
 default-run = "astar-collator"

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-runtime"
-version = "14.0.1"
+version = "15.0.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -188,7 +188,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: Cow::Borrowed("astar"),
     impl_name: Cow::Borrowed("astar"),
     authoring_version: 1,
-    spec_version: 1401,
+    spec_version: 1500,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "14.0.1"
+version = "15.0.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -210,7 +210,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: Cow::Borrowed("shibuya"),
     impl_name: Cow::Borrowed("shibuya"),
     authoring_version: 1,
-    spec_version: 1401,
+    spec_version: 1500,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "14.0.1"
+version = "15.0.0"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -181,7 +181,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: Cow::Borrowed("shiden"),
     impl_name: Cow::Borrowed("shiden"),
     authoring_version: 1,
-    spec_version: 1401,
+    spec_version: 1500,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,


### PR DESCRIPTION
**Pull Request Summary**
New release for uplift 2412 & other changes. Bump version and spec version for
- collator release v5.46.0
- runtime release 1500

**Check list**
- [ ] added or updated unit tests
- [ ] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [ ] added benchmarks & weights for any modified runtime logics.
