### PR TITLE
ci: remove aarch64 build for now

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         target:
           - x86_64-unknown-linux-gnu
-          - aarch64-unknown-linux-gnu
+          # - aarch64-unknown-linux-gnu
 
     steps:
       - name: Checkout the source code
@@ -240,7 +240,8 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu", "macOS"]
-        arch: ["x86_64", "aarch64"]
+        # arch: ["x86_64", "aarch64"]
+        arch: ["x86_64"]
         exclude:
           - os: macOS
             arch: aarch64


### PR DESCRIPTION
**Pull Request Summary**
arm build is failing due to openssl cross compiling error, so disabling it temp to unblock the release

**Check list**
- [ ] added or updated unit tests
- [ ] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [ ] added benchmarks & weights for any modified runtime logics.
