### PR TITLE
Fix: Era Info voting stake discrepancy when performing unstake/move operations

### DIFF
--- a/pallets/dapp-staking/src/test/testing_utils.rs
+++ b/pallets/dapp-staking/src/test/testing_utils.rs
@@ -632,7 +632,6 @@ pub(crate) fn assert_unstake(
     let pre_era_info = pre_snapshot.current_era_info;
 
     let unstake_period = pre_snapshot.active_protocol_state.period_number();
-    let unstake_subperiod = pre_snapshot.active_protocol_state.subperiod();
 
     let minimum_stake_amount: Balance = <Test as Config>::MinimumStakeAmount::get();
     let is_full_unstake =
@@ -701,7 +700,6 @@ pub(crate) fn assert_unstake(
         &pre_contract_stake,
         &post_contract_stake,
         &pre_snapshot,
-        unstake_amount,
         unstake_amount_entries.clone(),
     );
 
@@ -709,34 +707,43 @@ pub(crate) fn assert_unstake(
     // =========================
     // =========================
 
-    assert_era_info_current(&pre_era_info, &post_era_info, unstake_amount_entries);
+    assert_era_info_current(
+        &pre_era_info,
+        &post_era_info,
+        unstake_amount_entries.clone(),
+    );
 
     assert_eq!(
         post_era_info.total_staked_amount_next_era(),
         pre_era_info.total_staked_amount_next_era() - unstake_amount,
         "Total staked amount for the next era must decrease by 'amount'. No overflow is allowed."
     );
-
-    // Check for unstake underflow.
-    if unstake_subperiod == Subperiod::BuildAndEarn
-        && pre_era_info.staked_amount_next_era(Subperiod::BuildAndEarn) < unstake_amount
-    {
-        let overflow =
-            unstake_amount - pre_era_info.staked_amount_next_era(Subperiod::BuildAndEarn);
-
-        assert!(post_era_info
-            .staked_amount_next_era(Subperiod::BuildAndEarn)
-            .is_zero());
-        assert_eq!(
-            post_era_info.staked_amount_next_era(Subperiod::Voting),
-            pre_era_info.staked_amount_next_era(Subperiod::Voting) - overflow
-        );
-    } else {
-        assert_eq!(
-            post_era_info.staked_amount_next_era(unstake_subperiod),
-            pre_era_info.staked_amount_next_era(unstake_subperiod) - unstake_amount
+    // expected to be non-zero in case we're past the voting sub-period
+    if !post_era_info.total_staked_amount().is_zero() {
+        // not fully correct, but good enough for unstake tests
+        assert!(
+            post_era_info.current_stake_amount.voting >= post_era_info.next_stake_amount.voting
         );
     }
+
+    let unstake_amount = unstake_amount_entries
+        .iter()
+        .max_by(|a, b| a.total().cmp(&b.total()))
+        .expect("At least one value exists, otherwise we wouldn't be here.");
+    assert_eq!(
+        post_era_info.staked_amount_next_era(Subperiod::Voting),
+        pre_era_info
+            .staked_amount_next_era(Subperiod::Voting)
+            .saturating_sub(unstake_amount.for_type(Subperiod::Voting)),
+        "Voting next era staked amount must decreased by the 'unstake_amount'"
+    );
+    assert_eq!(
+        post_era_info.staked_amount_next_era(Subperiod::BuildAndEarn),
+        pre_era_info
+            .staked_amount_next_era(Subperiod::BuildAndEarn)
+            .saturating_sub(unstake_amount.for_type(Subperiod::BuildAndEarn)),
+        "BuildAndEarn next era staked amount must decreased by the 'unstake_amount'"
+    );
 }
 
 /// Move stake funds from source contract to destination contract.
@@ -828,7 +835,7 @@ pub(crate) fn assert_move_stake(
     // =====================
     // =====================
 
-    let (amount_entries, bonus_status) = assert_staker_info_after_unstake(
+    let (amount_entries, updated_bonus_status) = assert_staker_info_after_unstake(
         &pre_snapshot,
         &post_snapshot,
         account,
@@ -836,6 +843,11 @@ pub(crate) fn assert_move_stake(
         amount_to_move,
         is_full_move_from_source,
     );
+    let bonus_status = if is_source_unregistered {
+        pre_staker_info.bonus_status
+    } else {
+        updated_bonus_status
+    };
 
     let pre_staker_info = pre_snapshot
         .staker_info
@@ -851,11 +863,18 @@ pub(crate) fn assert_move_stake(
         amount_entries
     };
 
-    let unstake_amount_entries_clone = unstake_amount_entries.clone();
+    let mut unstake_amount_entries_clone = unstake_amount_entries.clone();
     let stake_amount = unstake_amount_entries_clone
-        .iter()
+        .iter_mut()
         .max_by(|a, b| a.total().cmp(&b.total()))
         .expect("At least one value exists, otherwise we wouldn't be here.");
+
+    // Merge voting into b&e when bonus is lost
+    let is_voting_stake_converted = bonus_status == 0 && stake_amount.voting > 0;
+    if is_voting_stake_converted {
+        stake_amount.convert_bonus_into_regular_stake();
+    }
+
     assert_eq!(stake_amount.total(), amount_to_move);
 
     assert_staker_info_after_stake(
@@ -891,7 +910,6 @@ pub(crate) fn assert_move_stake(
             &pre_source_contract_stake,
             &post_source_contract_stake,
             &pre_snapshot,
-            amount_to_move,
             unstake_amount_entries.clone(),
         );
     }
@@ -933,7 +951,11 @@ pub(crate) fn assert_move_stake(
     // =========================
     // =========================
 
-    assert_era_info_current(&pre_era_info, &post_era_info, unstake_amount_entries);
+    assert_era_info_current(
+        &pre_era_info,
+        &post_era_info,
+        unstake_amount_entries.clone(),
+    );
 
     assert_eq!(
         post_era_info.total_staked_amount_next_era(),
@@ -1265,33 +1287,44 @@ pub(crate) fn assert_unstake_from_unregistered(
         pre_staker_info
             .clone()
             .unstake(amount, unstake_era, unstake_subperiod);
-    assert_era_info_current(&pre_era_info, &post_era_info, stake_amount_entries);
+    // expected to be non-zero in case we're past the voting sub-period
+    if !post_era_info.total_staked_amount().is_zero() {
+        // not fully correct, but good enough for unstake tests
+        assert!(
+            post_era_info.current_stake_amount.voting >= post_era_info.next_stake_amount.voting
+        );
+    }
 
     assert_eq!(
         post_era_info.total_staked_amount_next_era(),
         pre_era_info.total_staked_amount_next_era() - amount,
         "Total staked amount for the next era must decrease by 'amount'. No overflow is allowed."
     );
-
-    // Check for unstake underflow.
-    if unstake_subperiod == Subperiod::BuildAndEarn
-        && pre_era_info.staked_amount_next_era(Subperiod::BuildAndEarn) < amount
-    {
-        let overflow = amount - pre_era_info.staked_amount_next_era(Subperiod::BuildAndEarn);
-
-        assert!(post_era_info
-            .staked_amount_next_era(Subperiod::BuildAndEarn)
-            .is_zero());
-        assert_eq!(
-            post_era_info.staked_amount_next_era(Subperiod::Voting),
-            pre_era_info.staked_amount_next_era(Subperiod::Voting) - overflow
-        );
-    } else {
-        assert_eq!(
-            post_era_info.staked_amount_next_era(unstake_subperiod),
-            pre_era_info.staked_amount_next_era(unstake_subperiod) - amount
+    if !post_era_info.total_staked_amount().is_zero() {
+        // not fully correct, but good enough for unstake tests
+        assert!(
+            post_era_info.current_stake_amount.voting >= post_era_info.next_stake_amount.voting
         );
     }
+
+    let unstake_amount = stake_amount_entries
+        .iter()
+        .max_by(|a, b| a.total().cmp(&b.total()))
+        .expect("At least one value exists, otherwise we wouldn't be here.");
+    assert_eq!(
+        post_era_info.staked_amount_next_era(Subperiod::Voting),
+        pre_era_info
+            .staked_amount_next_era(Subperiod::Voting)
+            .saturating_sub(unstake_amount.for_type(Subperiod::Voting)),
+        "Voting next era staked amount must decreased by the 'unstake_amount'"
+    );
+    assert_eq!(
+        post_era_info.staked_amount_next_era(Subperiod::BuildAndEarn),
+        pre_era_info
+            .staked_amount_next_era(Subperiod::BuildAndEarn)
+            .saturating_sub(unstake_amount.for_type(Subperiod::BuildAndEarn)),
+        "BuildAndEarn next era staked amount must decreased by the 'unstake_amount'"
+    );
 }
 
 /// Cleanup expired DB entries for the account and verify post state.
@@ -1717,7 +1750,21 @@ fn assert_staker_info_after_unstake(
         .staker_info
         .get(&(account, smart_contract.clone()))
         .expect("Entry must exist since 'unstake' is being called.");
-    let was_bonus_eligible_snapshot = pre_staker_info.is_bonus_eligible();
+
+    let (stake_amount_entries, bonus_status) =
+        pre_staker_info
+            .clone()
+            .unstake(amount, unstake_era, unstake_subperiod);
+    assert!(
+        stake_amount_entries.len() <= 2 && stake_amount_entries.len() > 0,
+        "Sanity check"
+    );
+
+    let unstake_amount = stake_amount_entries
+        .iter()
+        .max_by(|a, b| a.total().cmp(&b.total()))
+        .expect("At least one value exists, otherwise we wouldn't be here.");
+    assert_eq!(unstake_amount.total(), amount);
 
     if is_full_unstake {
         assert!(
@@ -1736,7 +1783,6 @@ fn assert_staker_info_after_unstake(
                 || unstake_subperiod == Subperiod::Voting
                 || post_staker_info.staked_amount(Subperiod::Voting)
                     == pre_staker_info.staked_amount(Subperiod::Voting));
-        let is_bonus_lost = was_bonus_eligible_snapshot && !should_keep_bonus;
 
         assert_eq!(post_staker_info.period_number(), unstake_period);
         assert_eq!(
@@ -1745,26 +1791,20 @@ fn assert_staker_info_after_unstake(
             "Total staked amount must decrease by the 'amount'"
         );
 
-        if is_bonus_lost {
-            assert_eq!(
-                post_staker_info.staked_amount(Subperiod::Voting),
-                0,
-                "Voting staked amount must be moved to B&E"
-            );
-            assert_eq!(
-                post_staker_info.staked_amount(Subperiod::BuildAndEarn),
-                post_staker_info.total_staked_amount(),
-                "B&E unstake amount includes forfeited bonus amount from voting 'unstake_amount'"
-            );
-        } else {
-            assert_eq!(
-                post_staker_info.staked_amount(unstake_subperiod),
-                pre_staker_info
-                    .staked_amount(unstake_subperiod)
-                    .saturating_sub(amount),
-                "Staked amount must decrease by the 'amount'"
-            );
-        }
+        assert_eq!(
+            post_staker_info.staked_amount(Subperiod::Voting),
+            pre_staker_info
+                .staked_amount(Subperiod::Voting)
+                .saturating_sub(unstake_amount.for_type(Subperiod::Voting)),
+            "Voting next era staked amount must decreased by the 'unstake_amount'"
+        );
+        assert_eq!(
+            post_staker_info.staked_amount(Subperiod::BuildAndEarn),
+            pre_staker_info
+                .staked_amount(Subperiod::BuildAndEarn)
+                .saturating_sub(unstake_amount.for_type(Subperiod::BuildAndEarn)),
+            "BuildAndEarn next era staked amount must decreased by the 'unstake_amount'"
+        );
 
         assert_eq!(
             post_staker_info.is_bonus_eligible(),
@@ -1783,34 +1823,6 @@ fn assert_staker_info_after_unstake(
             );
         }
     }
-
-    let (stake_amount_entries, bonus_status) =
-        pre_staker_info
-            .clone()
-            .unstake(amount, unstake_era, unstake_subperiod);
-    assert!(stake_amount_entries.len() <= 2 && stake_amount_entries.len() > 0);
-
-    let is_bonus_lost = was_bonus_eligible_snapshot && bonus_status.is_zero();
-
-    // If unstake from next era exists, it must exactly match the expected unstake amount.
-    stake_amount_entries
-        .iter()
-        .filter(|stake_amount| stake_amount.era > unstake_era)
-        .for_each(|stake_amount| {
-            assert_eq!(stake_amount.total(), amount);
-            if is_bonus_lost {
-                assert_eq!(
-                    stake_amount.for_type(Subperiod::Voting),
-                    0,
-                    "Voting staked amount must be moved to bep 'unstake_amount'"
-                );
-                assert_eq!(
-                    stake_amount.for_type(Subperiod::BuildAndEarn),
-                    stake_amount.total(),
-                    "B&E unstake amount includes forfeited bonus amount from voting 'unstake_amount'"
-                );
-            }
-        });
 
     (stake_amount_entries, bonus_status)
 }
@@ -1912,24 +1924,34 @@ fn assert_contract_stake_after_unstake(
     pre_contract_stake: &ContractStakeAmount,
     post_contract_stake: &ContractStakeAmount,
     pre_snapshot: &MemorySnapshot,
-    unstake_amount: Balance,
     unstake_amount_entries: Vec<StakeAmount>,
 ) {
     let era_number = pre_snapshot.active_protocol_state.era;
     let period_number = pre_snapshot.active_protocol_state.period_number();
-    let subperiod = pre_snapshot.active_protocol_state.subperiod();
+    let unstake_amount_entries_clone = unstake_amount_entries.clone();
+    let unstake_amount = unstake_amount_entries_clone
+        .iter()
+        .max_by(|a, b| a.total().cmp(&b.total()))
+        .expect("At least one value exists, otherwise we wouldn't be here.");
 
     assert_eq!(
         post_contract_stake.total_staked_amount(period_number),
-        pre_contract_stake.total_staked_amount(period_number) - unstake_amount,
-        "Staked amount must decreased by the 'amount'"
+        pre_contract_stake.total_staked_amount(period_number) - unstake_amount.total(),
+        "Staked amount must decreased by the 'unstake_amount'"
     );
     assert_eq!(
-        post_contract_stake.staked_amount(period_number, subperiod),
+        post_contract_stake.staked_amount(period_number, Subperiod::Voting),
         pre_contract_stake
-            .staked_amount(period_number, subperiod)
-            .saturating_sub(unstake_amount),
-        "Staked amount must decreased by the 'amount'"
+            .staked_amount(period_number, Subperiod::Voting)
+            .saturating_sub(unstake_amount.for_type(Subperiod::Voting)),
+        "Voting staked amount must decreased by the 'unstake_amount'"
+    );
+    assert_eq!(
+        post_contract_stake.staked_amount(period_number, Subperiod::BuildAndEarn),
+        pre_contract_stake
+            .staked_amount(period_number, Subperiod::BuildAndEarn)
+            .saturating_sub(unstake_amount.for_type(Subperiod::BuildAndEarn)),
+        "BuildAndEarn staked amount must decreased by the 'unstake_amount'"
     );
 
     // A generic check, comparing what was received in the unstaked StakeAmount entries and the impact it had on the contract stake.
@@ -1956,7 +1978,7 @@ fn assert_contract_stake_after_unstake(
                 .get(era_number + 1, period_number)
                 .unwrap_or_default()
                 .total(),
-            entry.total() - unstake_amount
+            entry.total().saturating_sub(unstake_amount.total())
         );
     }
 }
@@ -2039,8 +2061,18 @@ fn assert_era_info_current(
             } else {
                 assert_eq!(
                     post_era_info.total_staked_amount(),
-                    pre_era_info.total_staked_amount() - amount,
+                    pre_era_info.total_staked_amount().saturating_sub(amount),
                     "Total staked amount for the current era must decrease by 'amount'."
+                );
+                assert_eq!(
+                    post_era_info.staked_amount(Subperiod::Voting),
+                    pre_era_info.staked_amount(Subperiod::Voting).saturating_sub(entry.voting),
+                    "Total Voting staked amount for the current era must decrease by 'entry.voting'."
+                );
+                assert_eq!(
+                    post_era_info.staked_amount(Subperiod::BuildAndEarn),
+                    pre_era_info.staked_amount(Subperiod::BuildAndEarn).saturating_sub(entry.build_and_earn),
+                    "Total BuildAndEarn staked amount for the current era must decrease by 'entry.voting'."
                 );
             }
         }

--- a/pallets/dapp-staking/src/test/tests_types.rs
+++ b/pallets/dapp-staking/src/test/tests_types.rs
@@ -3273,7 +3273,7 @@ fn contract_stake_amount_unstake_from_subsperiod_type_is_ok() {
     contract_stake.stake(stake_amount, era_1, period);
     let total_stake_amount = stake_amount.total();
 
-    // 1st scenario - unstake some amount from Voting stake don't affect B&E stake
+    // unstake some amount from Voting stake don't affect B&E stake
     let amount = 1;
     let unstake_amount = StakeAmount {
         voting: amount,

--- a/pallets/dapp-staking/src/test/tests_types.rs
+++ b/pallets/dapp-staking/src/test/tests_types.rs
@@ -2041,7 +2041,7 @@ fn era_info_unstake_works() {
         bep_stake_amount_2 - unstake_amount_1_next.build_and_earn
     );
 
-    // === Scenario 2: Overflow as no effect on era stake ===
+    // === Scenario 2: Overflow has no effect on era stake ===
     let overflow = 2;
     let unstake_amount_2_current = StakeAmount {
         voting: 0,
@@ -2051,7 +2051,7 @@ fn era_info_unstake_works() {
     };
     era_info.unstake_amount(vec![unstake_amount_2_current]);
 
-    // Era info remains unchanged, overflow tentative as no effect
+    // Era info remains unchanged, overflow tentative has no effect
     assert_eq!(era_info, era_info_snapshot_1);
 
     // === Scenario 3: Unstake per subperiod types works ===

--- a/pallets/dapp-staking/src/types.rs
+++ b/pallets/dapp-staking/src/types.rs
@@ -908,7 +908,7 @@ impl StakeAmount {
         }
     }
 
-    /// Stake the specified `amount` for the specified `subperiod`.
+    /// Subtract the specified [`StakeAmount`], updating both `subperiods`.
     pub fn subtract_stake(&mut self, amount: &StakeAmount) {
         self.voting.saturating_reduce(amount.voting);
         self.build_and_earn.saturating_reduce(amount.build_and_earn);

--- a/pallets/dapp-staking/src/types.rs
+++ b/pallets/dapp-staking/src/types.rs
@@ -908,6 +908,12 @@ impl StakeAmount {
         }
     }
 
+    /// Stake the specified `amount` for the specified `subperiod`.
+    pub fn subtract_stake(&mut self, amount: &StakeAmount) {
+        self.voting.saturating_reduce(amount.voting);
+        self.build_and_earn.saturating_reduce(amount.build_and_earn);
+    }
+
     /// Unstake the specified `amount`.
     ///
     /// Attempt to subtract from `Build&Earn` subperiod amount is done first. Any rollover is subtracted from
@@ -1007,12 +1013,10 @@ impl EraInfo {
     /// - If the entry is from a past era or invalid, it is ignored.
     pub fn unstake_amount(&mut self, stake_amount_entries: impl IntoIterator<Item = StakeAmount>) {
         for entry in stake_amount_entries {
-            let (era, amount) = (entry.era, entry.total());
-
-            if era == self.current_stake_amount.era {
-                self.current_stake_amount.subtract(amount);
-            } else if era == self.next_stake_amount.era {
-                self.next_stake_amount.subtract(amount);
+            if entry.era == self.current_stake_amount.era {
+                self.current_stake_amount.subtract_stake(&entry);
+            } else if entry.era == self.next_stake_amount.era {
+                self.next_stake_amount.subtract_stake(&entry);
             }
         }
     }
@@ -1167,7 +1171,6 @@ impl SingularStakingInfo {
     ) -> (Vec<StakeAmount>, BonusStatus) {
         let mut result = Vec::new();
         let staked_snapshot = self.staked;
-        let was_bonus_eligible_snapshot = self.is_bonus_eligible();
 
         // 1. Modify 'current' staked amount.
         self.staked.subtract(amount);
@@ -1180,13 +1183,6 @@ impl SingularStakingInfo {
         // In case voting subperiod has passed, and the 'voting' stake amount was reduced, we need to reduce the bonus eligibility counter.
         if subperiod != Subperiod::Voting && self.staked.voting < staked_snapshot.voting {
             self.bonus_status = self.bonus_status.saturating_sub(1);
-        }
-        let is_bonus_lost = was_bonus_eligible_snapshot && !self.is_bonus_eligible();
-
-        // If bonus is just forfeited, previously existing Voting stake amount is moved to BuildAndEarn stake amount
-        if is_bonus_lost && unstaked_amount.voting > 0 {
-            self.staked.convert_bonus_into_regular_stake();
-            unstaked_amount.convert_bonus_into_regular_stake();
         }
 
         // Store the unstaked amount result
@@ -1238,11 +1234,6 @@ impl SingularStakingInfo {
                     let mut temp_unstaked_amount =
                         previous_staked_snapshot.saturating_difference(&self.previous_staked);
                     temp_unstaked_amount.era = self.previous_staked.era;
-
-                    if is_bonus_lost && temp_unstaked_amount.voting > 0 {
-                        temp_unstaked_amount.convert_bonus_into_regular_stake();
-                    }
-
                     result.insert(0, temp_unstaked_amount);
                 }
                 _ => {}
@@ -1459,15 +1450,14 @@ impl ContractStakeAmount {
 
         // 2. Value updates - only after alignment
         for entry in stake_amount_entries {
-            let (era, amount) = (entry.era, entry.total());
-            if self.staked.era == era {
-                self.staked.subtract(amount);
+            if self.staked.era == entry.era {
+                self.staked.subtract_stake(&entry);
                 continue;
             }
 
             match self.staked_future.as_mut() {
-                Some(future_stake_amount) if future_stake_amount.era == era => {
-                    future_stake_amount.subtract(amount);
+                Some(future_stake_amount) if future_stake_amount.era == entry.era => {
+                    future_stake_amount.subtract_stake(&entry);
                 }
                 // Otherwise do nothing
                 _ => (),


### PR DESCRIPTION
**Pull Request Summary**

This PR fixes a bug that caused discrepancies in the voting stake in `EraInfo`, particularly during unstake or move operations.

### Context

Previously, the `EraInfo::unstake_amount` method incorrectly aggregated the unstaked **voting** and **build_and_earn** stakes using the `total` method, and subtracted the combined amount starting with **build_and_earn**. While this logic was acceptable for the current era (due to delayed staking eligibility after a move), it was incorrect for the next era leading to an inflated voting stake.

### Fixes

- Replaced the total-based subtraction in `EraInfo::unstake_amount` with a new `subtract_stake` method that subtracts **voting** and **build_and_earn** balances independently.
- Applied the same fix to `ContractStake` to ensure consistency across smart contract staking records.
-  Moved the logic for converting **voting** stake into **build_and_earn** (when bonus is forfeited) into the `SingularStakingInfo` unstake flow. This is now performed explicitly during a move operation (before applying the `inner_stake`) and no longer handled during unstake operations.

The `era_info_stakes_remain_synced` test was implemented to reproduce the bug.

**Check list**
- [X] added or updated unit tests
- [ ] add unit `try-state` tests
- [ ] update Astar official documentation
