### PR TITLE
Fix Typos in Comments Across Multiple Files

### DIFF
--- a/primitives/src/evm.rs
+++ b/primitives/src/evm.rs
@@ -105,7 +105,7 @@ pub trait UnifiedAddressMapper<AccountId> {
     fn to_default_h160(account_id: &AccountId) -> EvmAddress;
 }
 
-/// Mappings derieved from hashing the original address
+/// Mappings derived from hashing the original address
 pub struct HashedDefaultMappings<H>(PhantomData<H>);
 impl<H: Hasher<Out = H256>> UnifiedAddressMapper<AccountId> for HashedDefaultMappings<H> {
     fn to_default_account_id(evm_address: &EvmAddress) -> AccountId {

--- a/tests/integration/src/unified_accounts.rs
+++ b/tests/integration/src/unified_accounts.rs
@@ -31,7 +31,7 @@ fn transfer_to_h160_via_lookup() {
         // make sure account is empty
         assert!(EVM::is_account_empty(&eth_address));
 
-        // tranfer to evm account
+        // transfer to evm account
         assert_ok!(Balances::transfer_allow_death(
             RuntimeOrigin::signed(ALICE),
             MultiAddress::Address20(eth_address.clone().into()),

--- a/tests/xcm-simulator/src/tests/fungible_assets.rs
+++ b/tests/xcm-simulator/src/tests/fungible_assets.rs
@@ -291,7 +291,7 @@ fn para_to_para_reserve_transfer_and_back_with_extra_native() {
         );
     });
 
-    // Registring Para B native asset on Para A
+    // Registering Para B native asset on Para A
     ParaA::execute_with(|| {
         assert_ok!(register_and_setup_xcm_asset::<parachain::Runtime, _>(
             parachain::RuntimeOrigin::root(),


### PR DESCRIPTION


**Description:**  
This pull request corrects several typographical errors in comments across the codebase. Specifically:
- Fixed the spelling of "derived" in `primitives/src/evm.rs`.
- Corrected "tranfer" to "transfer" in `tests/integration/src/unified_accounts.rs`.
- Fixed "Registring" to "Registering" in `tests/xcm-simulator/src/tests/fungible_assets.rs`.

These changes improve code readability and maintain consistency in documentation. No functional code was modified.
