### PR TITLE
fix(xcm): Change weight.ref_time() casting from u128 to u64

### DIFF
--- a/pallets/xc-asset-config/src/lib.rs
+++ b/pallets/xc-asset-config/src/lib.rs
@@ -122,7 +122,7 @@ pub mod pallet {
     impl<T: Config> Pallet<T> {
         /// Convert weight to fee based on units per second and weight.
         pub fn weight_to_fee(weight: Weight, units_per_second: u128) -> u128 {
-            units_per_second.saturating_mul(weight.ref_time() as u128)
+            units_per_second.saturating_mul(weight.ref_time() as u64)
                 / (WEIGHT_REF_TIME_PER_SECOND as u128)
         }
     }

--- a/primitives/src/xcm/mod.rs
+++ b/primitives/src/xcm/mod.rs
@@ -124,7 +124,7 @@ impl<T: ExecutionPaymentRate, R: TakeRevenue> WeightTrader for FixedRateOfForeig
                 fun: Fungibility::Fungible(_),
             } => {
                 if let Some(units_per_second) = T::get_units_per_second(asset_location.clone()) {
-                    let amount = units_per_second.saturating_mul(weight.ref_time() as u128) // TODO: change this to u64?
+                    let amount = units_per_second.saturating_mul(weight.ref_time() as u64)
                         / (WEIGHT_REF_TIME_PER_SECOND as u128);
                     if amount == 0 {
                         return Ok(payment);
@@ -167,7 +167,7 @@ impl<T: ExecutionPaymentRate, R: TakeRevenue> WeightTrader for FixedRateOfForeig
             self.asset_location_and_units_per_second.clone()
         {
             let weight = weight.min(self.weight);
-            let amount = units_per_second.saturating_mul(weight.ref_time() as u128)
+            let amount = units_per_second.saturating_mul(weight.ref_time() as u64)
                 / (WEIGHT_REF_TIME_PER_SECOND as u128);
 
             self.weight = self.weight.saturating_sub(weight);

--- a/primitives/src/xcm/tests.rs
+++ b/primitives/src/xcm/tests.rs
@@ -72,7 +72,7 @@ impl ExecutionPaymentRate for ExecutionPayment {
 
 /// Execution fee for the specified weight, using provided `units_per_second`
 fn execution_fee(weight: Weight, units_per_second: u128) -> u128 {
-    units_per_second * (weight.ref_time() as u128) / (WEIGHT_REF_TIME_PER_SECOND as u128)
+    units_per_second * (weight.ref_time() as u64) / (WEIGHT_REF_TIME_PER_SECOND as u128)
 }
 
 #[test]


### PR DESCRIPTION
Convert weight.ref_time() casting from u128 to u64 as appropriate for the Weight implementation.

Changed in:
- primitives/src/xcm/mod.rs (buy_weight and refund_weight methods)
- primitives/src/xcm/tests.rs (execution_fee function)
- pallets/xc-asset-config/src/lib.rs (weight_to_fee method)

This fixes a potential overflow issue when working with large weight values.