### PR TITLE
GasLimitPovSizeRatio fix

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -99,3 +99,12 @@ impl FailedMigrationHandler for UnfreezeChainOnFailedMigration {
         FailedMigrationHandling::ForceUnstuck
     }
 }
+
+/// Currently used MAX_POV_SIZE on Polkadot & Kusama is 10 MiB.
+/// At the moment of adding this constant, we're using `stable2412` which still has 5MiB limit.
+///
+/// To prevent excessive increase in gas used by ethereum transactions, we'll define this temporary
+/// constant for the correct PoV limit. After the next uplift, this should be removed & replaced with value from polkadot-sdk.
+///
+// For reference: https://github.com/paritytech/polkadot-sdk/blob/f6cd17e550caeaa1b8184b5f3135ca21f2cb16eb/polkadot/primitives/src/v8/mod.rs#L455
+pub const MAX_POV_SIZE: u32 = 10 * 1024 * 1024;

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -222,7 +222,7 @@ const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 /// We allow for 2 seconds of compute with a 6 second average block time.
 const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
     WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2),
-    polkadot_primitives::MAX_POV_SIZE as u64,
+    astar_primitives::MAX_POV_SIZE as u64,
 );
 
 parameter_types! {

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -500,7 +500,7 @@ impl CycleConfiguration for InflationCycleConfig {
     }
 
     fn blocks_per_era() -> BlockNumber {
-        24 * HOURS 
+        24 * HOURS
     }
 }
 
@@ -967,7 +967,7 @@ impl pallet_evm::Config for Runtime {
     type AddressMapping = pallet_evm::HashedAddressMapping<BlakeTwo256>;
     type Currency = Balances;
     type RuntimeEvent = RuntimeEvent;
-    type Runner = pallet_evm::runner::stack::Runner<Self>;   
+    type Runner = pallet_evm::runner::stack::Runner<Self>;
     type PrecompilesType = Precompiles;
     type PrecompilesValue = PrecompilesValue;
     type ChainId = ChainId;

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -952,8 +952,6 @@ parameter_types! {
     ///
     /// max_gas_limit = max_tx_ref_time / WEIGHT_PER_GAS = max_pov_size * gas_limit_pov_size_ratio
     /// gas_limit_pov_size_ratio = ceil((max_tx_ref_time / WEIGHT_PER_GAS) / max_pov_size)
-    ///
-    /// Equals 16 for values used by Astar runtime.
     pub const GasLimitPovSizeRatio: u64 = 8;
 }
 

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -500,7 +500,7 @@ impl CycleConfiguration for InflationCycleConfig {
     }
 
     fn blocks_per_era() -> BlockNumber {
-        24 * HOURS
+        24 * HOURS 
     }
 }
 
@@ -954,7 +954,7 @@ parameter_types! {
     /// gas_limit_pov_size_ratio = ceil((max_tx_ref_time / WEIGHT_PER_GAS) / max_pov_size)
     ///
     /// Equals 16 for values used by Astar runtime.
-    pub const GasLimitPovSizeRatio: u64 = 16;
+    pub const GasLimitPovSizeRatio: u64 = 8;
 }
 
 impl pallet_evm::Config for Runtime {
@@ -967,7 +967,7 @@ impl pallet_evm::Config for Runtime {
     type AddressMapping = pallet_evm::HashedAddressMapping<BlakeTwo256>;
     type Currency = Balances;
     type RuntimeEvent = RuntimeEvent;
-    type Runner = pallet_evm::runner::stack::Runner<Self>;
+    type Runner = pallet_evm::runner::stack::Runner<Self>;   
     type PrecompilesType = Precompiles;
     type PrecompilesValue = PrecompilesValue;
     type ChainId = ChainId;

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -967,7 +967,7 @@ parameter_types! {
     /// gas_limit_pov_size_ratio = ceil((max_tx_ref_time / WEIGHT_PER_GAS) / max_pov_size)
     ///
     /// Equals 16 for values used by Shibuya runtime.
-    pub const GasLimitPovSizeRatio: u64 = 16;
+    pub const GasLimitPovSizeRatio: u64 = 8;
 }
 
 impl pallet_evm::Config for Runtime {

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -965,8 +965,6 @@ parameter_types! {
     ///
     /// max_gas_limit = max_tx_ref_time / WEIGHT_PER_GAS = max_pov_size * gas_limit_pov_size_ratio
     /// gas_limit_pov_size_ratio = ceil((max_tx_ref_time / WEIGHT_PER_GAS) / max_pov_size)
-    ///
-    /// Equals 16 for values used by Shibuya runtime.
     pub const GasLimitPovSizeRatio: u64 = 8;
 }
 

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -241,7 +241,7 @@ const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 /// We allow for 2 seconds of compute with a 6 second average block time.
 const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
     WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2),
-    polkadot_primitives::MAX_POV_SIZE as u64,
+    astar_primitives::MAX_POV_SIZE as u64,
 );
 
 parameter_types! {

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -215,7 +215,7 @@ const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 /// We allow for 2 seconds of compute with a 6 second average block time.
 const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
     WEIGHT_REF_TIME_PER_SECOND.saturating_mul(2),
-    polkadot_primitives::MAX_POV_SIZE as u64,
+    astar_primitives::MAX_POV_SIZE as u64,
 );
 
 parameter_types! {

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -923,7 +923,7 @@ parameter_types! {
     /// gas_limit_pov_size_ratio = ceil((max_tx_ref_time / WEIGHT_PER_GAS) / max_pov_size)
     ///
     /// Equals 16 for values used by Shiden runtime.
-    pub const GasLimitPovSizeRatio: u64 = 16;
+    pub const GasLimitPovSizeRatio: u64 = 8;
 }
 
 impl pallet_evm::Config for Runtime {

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -921,8 +921,6 @@ parameter_types! {
     ///
     /// max_gas_limit = max_tx_ref_time / WEIGHT_PER_GAS = max_pov_size * gas_limit_pov_size_ratio
     /// gas_limit_pov_size_ratio = ceil((max_tx_ref_time / WEIGHT_PER_GAS) / max_pov_size)
-    ///
-    /// Equals 16 for values used by Shiden runtime.
     pub const GasLimitPovSizeRatio: u64 = 8;
 }
 

--- a/tests/xcm-simulator/src/mocks/parachain.rs
+++ b/tests/xcm-simulator/src/mocks/parachain.rs
@@ -148,7 +148,7 @@ const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 /// We allow for 0.5 seconds of compute with a 6 second average block time.
 const MAXIMUM_BLOCK_WEIGHT: Weight = Weight::from_parts(
     WEIGHT_REF_TIME_PER_SECOND.saturating_div(2),
-    polkadot_primitives::MAX_POV_SIZE as u64,
+    astar_primitives::MAX_POV_SIZE as u64,
 );
 
 parameter_types! {


### PR DESCRIPTION
**Pull Request Summary**

Fix `GasLimitPovSizeRatio` for all of our runtimes.

Both Kusama & Polkadot have increased max PoV size from **5MiB** to **10MiB**.

This will increase effective gas price by 2x, instead of 4x how it happened after the async backing upgrade.
It's an increase, but it's the correct approach according to the formula.

In addition, using 'custom' MAX_POV_SIZE of 10 MiB to reflect what's actually used live on Polkadot & Kusama.
