### PR TITLE
chore: Invariant checks added for `EraInfo`

### DIFF
--- a/pallets/dapp-staking/src/test/mock.rs
+++ b/pallets/dapp-staking/src/test/mock.rs
@@ -238,11 +238,15 @@ impl pallet_dapp_staking::Config for Test {
     type BenchmarkHelper = BenchmarkHelper<MockSmartContract, AccountId>;
 }
 
-pub struct ExtBuilder {}
+pub struct ExtBuilder {
+    check_try_state: bool,
+}
 
 impl Default for ExtBuilder {
     fn default() -> Self {
-        Self {}
+        Self {
+            check_try_state: true,
+        }
     }
 }
 
@@ -378,14 +382,22 @@ impl ExtBuilder {
     }
 
     pub fn build_and_execute(self, test: impl FnOnce() -> ()) {
+        let check_try_state = self.check_try_state;
         self.build().execute_with(|| {
             test();
-            DappStaking::do_try_state().unwrap();
+            if check_try_state {
+                DappStaking::do_try_state().unwrap()
+            };
         })
     }
 
     pub fn with_max_bonus_safe_moves(self, value: u8) -> Self {
         MAX_BONUS_SAFE_MOVES.with(|v| *v.borrow_mut() = value);
+        self
+    }
+
+    pub fn with_check_try_state(mut self, value: bool) -> Self {
+        self.check_try_state = value;
         self
     }
 }

--- a/pallets/dapp-staking/src/test/tests.rs
+++ b/pallets/dapp-staking/src/test/tests.rs
@@ -1145,54 +1145,56 @@ fn stake_fails_if_unclaimed_staker_rewards_from_past_remain() {
 
 #[test]
 fn move_fails_if_unclaimed_destination_staker_rewards_from_past_remain() {
-    ExtBuilder::default().build_and_execute(|| {
-        let source_contract = MockSmartContract::Wasm(1);
-        let source_2_contract = MockSmartContract::Wasm(2);
-        let destination_contract = MockSmartContract::Wasm(3);
-        assert_register(1, &source_contract);
-        assert_register(1, &source_2_contract);
-        assert_register(1, &destination_contract);
+    ExtBuilder::default()
+        .with_check_try_state(false)
+        .build_and_execute(|| {
+            let source_contract = MockSmartContract::Wasm(1);
+            let source_2_contract = MockSmartContract::Wasm(2);
+            let destination_contract = MockSmartContract::Wasm(3);
+            assert_register(1, &source_contract);
+            assert_register(1, &source_2_contract);
+            assert_register(1, &destination_contract);
 
-        let account = 2;
-        assert_lock(account, 300);
-        assert_stake(account, &source_contract, 100);
+            let account = 2;
+            assert_lock(account, 300);
+            assert_stake(account, &source_contract, 100);
 
-        // To transfer bonus reward eligibility to destination_contract
-        assert_move_stake(account, &source_contract, &destination_contract, 10);
+            // To transfer bonus reward eligibility to destination_contract
+            assert_move_stake(account, &source_contract, &destination_contract, 10);
 
-        advance_to_era(ActiveProtocolState::<Test>::get().era + 2);
-        // Move must fail due to unclaimed rewards
-        assert_noop!(
-            DappStaking::move_stake(
-                RuntimeOrigin::signed(account),
-                source_contract,
-                destination_contract,
-                10
-            ),
-            Error::<Test>::UnclaimedRewards
-        );
+            advance_to_era(ActiveProtocolState::<Test>::get().era + 2);
+            // Move must fail due to unclaimed rewards
+            assert_noop!(
+                DappStaking::move_stake(
+                    RuntimeOrigin::signed(account),
+                    source_contract,
+                    destination_contract,
+                    10
+                ),
+                Error::<Test>::UnclaimedRewards
+            );
 
-        // Advance to next period, claim all staker rewards
-        advance_to_next_period();
+            // Advance to next period, claim all staker rewards
+            advance_to_next_period();
 
-        // Claim all staker rewards
-        for _ in 0..required_number_of_reward_claims(account) {
-            assert_claim_staker_rewards(account);
-        }
+            // Claim all staker rewards
+            for _ in 0..required_number_of_reward_claims(account) {
+                assert_claim_staker_rewards(account);
+            }
 
-        // Try to move again on the same destination contract, expect an error due to unclaimed bonus rewards
-        advance_to_era(ActiveProtocolState::<Test>::get().era + 2);
-        assert_stake(account, &source_2_contract, 100);
-        assert_noop!(
-            DappStaking::move_stake(
-                RuntimeOrigin::signed(account),
-                source_2_contract,
-                destination_contract,
-                10
-            ),
-            Error::<Test>::UnclaimedRewards
-        );
-    })
+            // Try to move again on the same destination contract, expect an error due to unclaimed bonus rewards
+            advance_to_era(ActiveProtocolState::<Test>::get().era + 2);
+            assert_stake(account, &source_2_contract, 100);
+            assert_noop!(
+                DappStaking::move_stake(
+                    RuntimeOrigin::signed(account),
+                    source_2_contract,
+                    destination_contract,
+                    10
+                ),
+                Error::<Test>::UnclaimedRewards
+            );
+        })
 }
 
 #[test]


### PR DESCRIPTION
**Pull Request Summary**

Add `try_state_era_info` invariant checks to prevent inflated next-era voting stake totals in **CurrentEraInfo**, following bug discovery and fix in https://github.com/AstarNetwork/Astar/pull/1476.

Note: `try_state` checks are bypassed for _move_fails_if_unclaimed_destination_staker_rewards_from_past_remain_ because period/era manipulation for this test is not realistic.

**Check list**
- [X] added or updated unit tests

**Follow-up task**
- https://github.com/AstarNetwork/Astar/issues/1488