### PR TITLE
Frontier dep bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4015,7 +4015,7 @@ dependencies = [
 [[package]]
 name = "fc-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "async-trait",
  "fp-storage",
@@ -4027,7 +4027,7 @@ dependencies = [
 [[package]]
 name = "fc-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "async-trait",
  "fp-consensus",
@@ -4043,7 +4043,7 @@ dependencies = [
 [[package]]
 name = "fc-db"
 version = "2.0.0-dev"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "async-trait",
  "ethereum",
@@ -4073,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "fc-mapping-sync"
 version = "2.0.0-dev"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "fc-db",
  "fc-storage",
@@ -4096,7 +4096,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc"
 version = "2.0.0-dev"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -4149,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "fc-rpc-core"
 version = "1.1.0-dev"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -4164,7 +4164,7 @@ dependencies = [
 [[package]]
 name = "fc-storage"
 version = "1.0.0-dev"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -4357,7 +4357,7 @@ dependencies = [
 [[package]]
 name = "fp-account"
 version = "1.0.0-dev"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "hex",
  "impl-serde 0.5.0",
@@ -4376,7 +4376,7 @@ dependencies = [
 [[package]]
 name = "fp-consensus"
 version = "2.0.0-dev"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "ethereum",
  "parity-scale-codec",
@@ -4387,7 +4387,7 @@ dependencies = [
 [[package]]
 name = "fp-ethereum"
 version = "1.0.0-dev"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -4399,7 +4399,7 @@ dependencies = [
 [[package]]
 name = "fp-evm"
 version = "3.0.0-dev"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "environmental",
  "evm",
@@ -4415,7 +4415,7 @@ dependencies = [
 [[package]]
 name = "fp-rpc"
 version = "3.0.0-dev"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -4431,7 +4431,7 @@ dependencies = [
 [[package]]
 name = "fp-self-contained"
 version = "1.0.0-dev"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4443,7 +4443,7 @@ dependencies = [
 [[package]]
 name = "fp-storage"
 version = "2.0.0"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9262,7 +9262,7 @@ dependencies = [
 [[package]]
 name = "pallet-ethereum"
 version = "4.0.0-dev"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "ethereum",
  "ethereum-types 0.15.1",
@@ -9310,7 +9310,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm"
 version = "6.0.0-dev"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "environmental",
  "evm",
@@ -9333,7 +9333,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-chain-id"
 version = "1.0.0-dev"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9370,7 +9370,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "fp-evm",
 ]
@@ -9378,7 +9378,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-bn128"
 version = "2.0.0-dev"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "fp-evm",
  "sp-core",
@@ -9416,7 +9416,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-dispatch"
 version = "2.0.0-dev"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "fp-evm",
  "frame-support",
@@ -9454,7 +9454,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-ed25519"
 version = "2.0.0-dev"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "ed25519-dalek",
  "fp-evm",
@@ -9463,7 +9463,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-modexp"
 version = "2.0.0-dev"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "fp-evm",
  "num",
@@ -9472,7 +9472,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-sha3fips"
 version = "2.0.0-dev"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "fp-evm",
  "tiny-keccak",
@@ -9481,7 +9481,7 @@ dependencies = [
 [[package]]
 name = "pallet-evm-precompile-simple"
 version = "2.0.0-dev"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "fp-evm",
  "ripemd",
@@ -12101,7 +12101,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "derive_more 1.0.0",
  "environmental",
@@ -12130,7 +12130,7 @@ dependencies = [
 [[package]]
 name = "precompile-utils-macro"
 version = "0.1.0"
-source = "git+https://github.com/AstarNetwork/frontier?branch=stable2412-txpoolwrapper#ee6814a9c3b5487fe4cef9b63023509f90e3f0b8"
+source = "git+https://github.com/AstarNetwork/frontier?rev=e74325d1b2150a6e505c20a4190236db4daca2bb#e74325d1b2150a6e505c20a4190236db4daca2bb"
 dependencies = [
  "case",
  "num_enum 0.7.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,33 +196,33 @@ ethereum = { git = "https://github.com/rust-ethereum/ethereum", rev = "3be0d8fd4
 
 # Frontier
 # (wasm)
-fp-rpc = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper", default-features = false }
-fp-self-contained = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper", default-features = false, features = ["serde"] }
-pallet-ethereum = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper", default-features = false, features = ["forbid-evm-reentrancy"] }
-pallet-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper", default-features = false, features = ["forbid-evm-reentrancy"] }
-pallet-evm-precompile-blake2 = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper", default-features = false }
-pallet-evm-precompile-bn128 = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper", default-features = false }
-pallet-evm-precompile-dispatch = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper", default-features = false }
-pallet-evm-precompile-ed25519 = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper", default-features = false }
-pallet-evm-precompile-modexp = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper", default-features = false }
-pallet-evm-precompile-sha3fips = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper", default-features = false }
-pallet-evm-precompile-simple = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper", default-features = false }
-pallet-base-fee = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper", default-features = false }
-pallet-evm-chain-id = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper", default-features = false }
-fp-evm = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper", default-features = false }
-fp-ethereum = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper", default-features = false }
-precompile-utils = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper", default-features = false }
+fp-rpc = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb", default-features = false }
+fp-self-contained = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb", default-features = false, features = ["serde"] }
+pallet-ethereum = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb", default-features = false, features = ["forbid-evm-reentrancy"] }
+pallet-evm = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb", default-features = false, features = ["forbid-evm-reentrancy"] }
+pallet-evm-precompile-blake2 = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb", default-features = false }
+pallet-evm-precompile-bn128 = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb", default-features = false }
+pallet-evm-precompile-dispatch = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb", default-features = false }
+pallet-evm-precompile-ed25519 = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb", default-features = false }
+pallet-evm-precompile-modexp = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb", default-features = false }
+pallet-evm-precompile-sha3fips = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb", default-features = false }
+pallet-evm-precompile-simple = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb", default-features = false }
+pallet-base-fee = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb", default-features = false }
+pallet-evm-chain-id = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb", default-features = false }
+fp-evm = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb", default-features = false }
+fp-ethereum = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb", default-features = false }
+precompile-utils = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb", default-features = false }
 
 # (native)
-fc-consensus = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper" }
-fc-db = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper" }
-fc-api = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper" }
-fc-mapping-sync = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper" }
-fc-rpc = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper", features = ["rpc-binary-search-estimate", "txpool"] }
-fc-rpc-core = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper" }
-fp-consensus = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper" }
-fp-storage = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper" }
-fc-storage = { git = "https://github.com/AstarNetwork/frontier", branch = "stable2412-txpoolwrapper" }
+fc-consensus = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb" }
+fc-db = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb" }
+fc-api = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb" }
+fc-mapping-sync = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb" }
+fc-rpc = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb", features = ["rpc-binary-search-estimate", "txpool"] }
+fc-rpc-core = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb" }
+fp-consensus = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb" }
+fp-storage = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb" }
+fc-storage = { git = "https://github.com/AstarNetwork/frontier", rev = "e74325d1b2150a6e505c20a4190236db4daca2bb" }
 
 # Cumulus
 # (wasm)


### PR DESCRIPTION
**Pull Request Summary**

Bump `frontier` to latest deps.

Using `rev` to avoid bumping polkadot-sdk dependecies (lots of backports in the `stable2412` branch).
