### PR TITLE
Shiden spec version fix

### DIFF
--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -184,7 +184,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: Cow::Borrowed("shiden"),
     impl_name: Cow::Borrowed("shiden"),
     authoring_version: 1,
-    spec_version: 1600,
+    spec_version: 1601,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,


### PR DESCRIPTION
**Pull Request Summary**

I somehow missed to modify Shiden spec version prior to the 1601 release.
This PR fixes it.
