### PR TITLE
Update validator guide link in README to current Astar documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ $ curl -H 'Content-Type: application/json' --data '{ "jsonrpc":"2.0", "method":"
 ```
 
 After this step, you should have a validator node online with a session key for your node.
-For key management and validator rewards, consult our [validator guide online](https://docs.astar.network/build/validator-guide/configure-node).
+For key management and validator rewards, consult our [validator guide online](https://docs.astar.network/docs/build/nodes/).
 
 ## Versioning
 


### PR DESCRIPTION
Replaced the outdated link to the validator guide (https://docs.astar.network/build/validator-guide/configure-node) in the README with the new, up-to-date Node Operators Guide (https://docs.astar.network/docs/build/nodes/). This ensures users have access to the latest instructions for configuring and managing validator nodes on Astar Network.