### PR TITLE
Added Asset Hub as relay chain token reserve in Filter

### DIFF
--- a/pallets/astar-xcm-benchmarks/src/mock.rs
+++ b/pallets/astar-xcm-benchmarks/src/mock.rs
@@ -19,7 +19,7 @@
 //! A mock runtime for XCM benchmarking.
 
 use crate::{fungible, generic, *};
-use astar_primitives::xcm::ReserveAssetFilter;
+use astar_primitives::xcm::Reserves;
 use frame_benchmarking::BenchmarkError;
 use frame_support::{
     assert_ok, derive_impl, parameter_types,
@@ -190,7 +190,7 @@ impl xcm_executor::Config for XcmConfig {
     type XcmSender = DevNull;
     type AssetTransactor = AssetTransactor;
     type OriginConverter = ();
-    type IsReserve = ReserveAssetFilter;
+    type IsReserve = Reserves;
     type IsTeleporter = ();
     type UniversalLocation = UniversalLocation;
     type Barrier = AllowUnpaidExecutionFrom<Everything>;

--- a/primitives/src/xcm/mod.rs
+++ b/primitives/src/xcm/mod.rs
@@ -55,6 +55,7 @@ mod tests;
 
 pub const XCM_SIZE_LIMIT: u32 = 2u32.pow(16);
 pub const MAX_ASSETS: u32 = 64;
+pub const ASSET_HUB_PARA_ID: u32 = 1000;
 
 /// Used to convert between cross-chain asset multilocation and local asset Id.
 ///
@@ -219,6 +220,32 @@ impl ContainsPair<Asset, Location> for ReserveAssetFilter {
         }
     }
 }
+
+/// Allow DOT from Asset Hub.
+pub struct DotFromAssetHub;
+impl ContainsPair<Asset, Location> for DotFromAssetHub {
+    fn contains(asset: &Asset, origin: &Location) -> bool {
+        Location::new(1, Parachain(ASSET_HUB_PARA_ID)) == *origin
+            && matches!(
+                asset,
+                Asset {
+                    id: AssetId(Location {
+                        parents: 1,
+                        interior: Here
+                    }),
+                    fun: Fungible(_),
+                },
+            )
+    }
+}
+
+/// All locations we trust as reserves for particular assets.
+pub type Reserves = (
+    // Trusted reserves and DOT from relay
+    ReserveAssetFilter,
+    // DOT from Asset Hub
+    DotFromAssetHub,
+);
 
 /// Used to deposit XCM fees into a destination account.
 ///

--- a/runtime/astar/src/xcm_config.rs
+++ b/runtime/astar/src/xcm_config.rs
@@ -244,12 +244,6 @@ pub type AstarXcmFungibleFeeHandler = XcmFungibleFeeHandler<
     TreasuryAccountId,
 >;
 
-const ASSET_HUB_PARA_ID: u32 = 1000;
-
-parameter_types! {
-    pub AssetHubLocation: Location = (Parent, Parachain(ASSET_HUB_PARA_ID)).into();
-}
-
 pub struct XcmConfig;
 impl xcm_executor::Config for XcmConfig {
     type RuntimeCall = RuntimeCall;

--- a/runtime/astar/src/xcm_config.rs
+++ b/runtime/astar/src/xcm_config.rs
@@ -56,7 +56,7 @@ use orml_xcm_support::DisabledParachainFee;
 // Astar imports
 use astar_primitives::xcm::{
     AbsoluteAndRelativeReserveProvider, AccountIdToMultiLocation, AllowTopLevelPaidExecutionFrom,
-    FixedRateOfForeignAsset, ReserveAssetFilter, XcmFungibleFeeHandler,
+    FixedRateOfForeignAsset, Reserves, XcmFungibleFeeHandler,
 };
 
 parameter_types! {
@@ -244,13 +244,19 @@ pub type AstarXcmFungibleFeeHandler = XcmFungibleFeeHandler<
     TreasuryAccountId,
 >;
 
+const ASSET_HUB_PARA_ID: u32 = 1000;
+
+parameter_types! {
+    pub AssetHubLocation: Location = (Parent, Parachain(ASSET_HUB_PARA_ID)).into();
+}
+
 pub struct XcmConfig;
 impl xcm_executor::Config for XcmConfig {
     type RuntimeCall = RuntimeCall;
     type XcmSender = XcmRouter;
     type AssetTransactor = AssetTransactors;
     type OriginConverter = XcmOriginToTransactDispatchOrigin;
-    type IsReserve = ReserveAssetFilter;
+    type IsReserve = Reserves;
     type IsTeleporter = ();
     type UniversalLocation = UniversalLocation;
     type Barrier = XcmBarrier;

--- a/runtime/shibuya/src/xcm_config.rs
+++ b/runtime/shibuya/src/xcm_config.rs
@@ -54,7 +54,7 @@ use orml_xcm_support::DisabledParachainFee;
 // Astar imports
 use astar_primitives::xcm::{
     AbsoluteAndRelativeReserveProvider, AccountIdToMultiLocation, AllowTopLevelPaidExecutionFrom,
-    FixedRateOfForeignAsset, ReserveAssetFilter, XcmFungibleFeeHandler, MAX_ASSETS,
+    FixedRateOfForeignAsset, Reserves, XcmFungibleFeeHandler, MAX_ASSETS,
 };
 
 parameter_types! {
@@ -183,7 +183,7 @@ impl xcm_executor::Config for XcmConfig {
     type XcmSender = XcmRouter;
     type AssetTransactor = AssetTransactors;
     type OriginConverter = XcmOriginToTransactDispatchOrigin;
-    type IsReserve = ReserveAssetFilter;
+    type IsReserve = Reserves;
     type IsTeleporter = ();
     type UniversalLocation = UniversalLocation;
     type Barrier = XcmBarrier;

--- a/runtime/shiden/src/xcm_config.rs
+++ b/runtime/shiden/src/xcm_config.rs
@@ -57,7 +57,7 @@ use parachains_common::message_queue::ParaIdToSibling;
 // Astar imports
 use astar_primitives::xcm::{
     AbsoluteAndRelativeReserveProvider, AccountIdToMultiLocation, AllowTopLevelPaidExecutionFrom,
-    FixedRateOfForeignAsset, ReserveAssetFilter, XcmFungibleFeeHandler,
+    FixedRateOfForeignAsset, Reserves, XcmFungibleFeeHandler,
 };
 
 parameter_types! {
@@ -254,7 +254,7 @@ impl xcm_executor::Config for XcmConfig {
     type XcmSender = XcmRouter;
     type AssetTransactor = AssetTransactors;
     type OriginConverter = XcmOriginToTransactDispatchOrigin;
-    type IsReserve = ReserveAssetFilter;
+    type IsReserve = Reserves;
     type IsTeleporter = ();
     type UniversalLocation = UniversalLocation;
     type Barrier = XcmBarrier;

--- a/tests/xcm-simulator/src/mocks/parachain.rs
+++ b/tests/xcm-simulator/src/mocks/parachain.rs
@@ -65,7 +65,7 @@ use astar_primitives::{
     oracle::PriceProvider,
     xcm::{
         AllowTopLevelPaidExecutionFrom, AssetLocationIdConverter, FixedRateOfForeignAsset,
-        ReserveAssetFilter, XcmFungibleFeeHandler,
+        Reserves, XcmFungibleFeeHandler,
     },
 };
 
@@ -442,7 +442,7 @@ impl xcm_executor::Config for XcmConfig {
     type XcmSender = XcmRouter;
     type AssetTransactor = AssetTransactors;
     type OriginConverter = XcmOriginToTransactDispatchOrigin;
-    type IsReserve = ReserveAssetFilter;
+    type IsReserve = Reserves;
     type IsTeleporter = ();
     type UniversalLocation = UniversalLocation;
     type Barrier = XcmBarrier;


### PR DESCRIPTION
**Pull Request Summary**

Added Asset Hub as relay chain token reserve in Filter without removing Relay chain as reserve. Both reserved are accepted from DOT/KSM

**Check list**
- [ ] added or updated unit tests
- [ ] updated Astar official documentation
- [ ] added OnRuntimeUpgrade hook for precompile revert code registration
- [ ] added benchmarks & weights for any modified runtime logics.
