### PR TITLE
Allow tech comm & council to trigger maintenance

### DIFF
--- a/primitives/src/governance.rs
+++ b/primitives/src/governance.rs
@@ -85,3 +85,9 @@ pub type EnsureRootOrFourFifthsCommunityCouncil = EitherOfDiverse<
     EnsureRoot<AccountId>,
     pallet_collective::EnsureProportionAtLeast<AccountId, CommunityCouncilCollectiveInst, 4, 5>,
 >;
+
+// Combination
+pub type EnsureRootOrHalfTechCommitteeOrTwoThirdCouncil = EitherOfDiverse<
+    EnsureRootOrHalfTechnicalCommittee,
+    pallet_collective::EnsureProportionAtLeast<AccountId, MainCouncilCollectiveInst, 2, 3>,
+>;

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -93,10 +93,11 @@ use astar_primitives::{
     governance::{
         CommunityCouncilCollectiveInst, CommunityCouncilMembershipInst, CommunityTreasuryInst,
         EnsureRootOrAllMainCouncil, EnsureRootOrAllTechnicalCommittee,
-        EnsureRootOrFourFifthsCommunityCouncil, EnsureRootOrTwoThirdsCommunityCouncil,
-        EnsureRootOrTwoThirdsMainCouncil, EnsureRootOrTwoThirdsTechnicalCommittee,
-        MainCouncilCollectiveInst, MainCouncilMembershipInst, MainTreasuryInst,
-        OracleMembershipInst, TechnicalCommitteeCollectiveInst, TechnicalCommitteeMembershipInst,
+        EnsureRootOrFourFifthsCommunityCouncil, EnsureRootOrHalfTechCommitteeOrTwoThirdCouncil,
+        EnsureRootOrTwoThirdsCommunityCouncil, EnsureRootOrTwoThirdsMainCouncil,
+        EnsureRootOrTwoThirdsTechnicalCommittee, MainCouncilCollectiveInst,
+        MainCouncilMembershipInst, MainTreasuryInst, OracleMembershipInst,
+        TechnicalCommitteeCollectiveInst, TechnicalCommitteeMembershipInst,
     },
     oracle::{CurrencyAmount, CurrencyId, DummyCombineData, Price},
     xcm::AssetLocationIdConverter,
@@ -450,7 +451,7 @@ impl pallet_dapp_staking::Config for Runtime {
     type SmartContract = SmartContract<AccountId>;
     type ContractRegisterOrigin = EnsureRootOrTwoThirdsCommunityCouncil;
     type ContractUnregisterOrigin = EnsureRootOrFourFifthsCommunityCouncil;
-    type ManagerOrigin = frame_system::EnsureRoot<AccountId>;
+    type ManagerOrigin = EnsureRootOrHalfTechCommitteeOrTwoThirdCouncil;
     type NativePriceProvider = PriceAggregator;
     type StakingRewardHandler = Inflation;
     type CycleConfiguration = InflationCycleConfig;


### PR DESCRIPTION
**Pull Request Summary**

Allows tech committee or main council to enable/disable maintenance mode in dApp staking.
This can be used to allow for a quicker reaction in case of an emergency.