### PR TITLE
fix: add missing space in argument check for -rpc-url

### DIFF
--- a/scripts/graph.sh
+++ b/scripts/graph.sh
@@ -21,7 +21,7 @@ if [ "$1" != "-chain" ]; then
   usage;
 fi
 
-if [ "$3" != "-rpc-url"]; then
+if [ "$3" != "-rpc-url" ]; then
   usage;
 fi
 


### PR DESCRIPTION
Corrected a syntax error in the argument validation for the -rpc-url parameter by adding a missing space before the closing bracket in the conditional statement. This ensures the script runs as expected when checking input arguments.