### PR TITLE
chore: preparing for the Shibuya migration to Paseo

### DIFF
--- a/bin/collator/res/shibuya.json
+++ b/bin/collator/res/shibuya.json
@@ -17,8 +17,8 @@
     "tokenDecimals": 18,
     "tokenSymbol": "SBY"
   },
-  "relayChain": "tokyo",
-  "paraId": 1000,
+  "relayChain": "paseo",
+  "paraId": 2000,
   "consensusEngine": null,
   "codeSubstitutes": {},
   "badBlocks": [

--- a/bin/collator/res/shibuya.raw.json
+++ b/bin/collator/res/shibuya.raw.json
@@ -17,8 +17,8 @@
     "tokenDecimals": 18,
     "tokenSymbol": "SBY"
   },
-  "relayChain": "tokyo",
-  "paraId": 1000,
+  "relayChain": "paseo",
+  "paraId": 2000,
   "consensusEngine": null,
   "codeSubstitutes": {},
   "badBlocks": [


### PR DESCRIPTION
### Pull Request Summary
We are migrating Shibuya from Private testnet relayChain Tokyo to Paseo.
The default ChainSpec for shibuya should be changed as we are asking for para_id 2000 on Paseo and the relayChain network code will be `paseo`
