### PR TITLE
Fix transfer_multi_assets precompile function signature

### DIFF
--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -748,7 +748,7 @@ where
     }
 
     #[precompile::public(
-        "transfet_multi_assets(((uint8,bytes[]),uint256)[],uint32,(uint8,bytes[]),(uint64,uint64))"
+        "transfer_multi_assets(((uint8,bytes[]),uint256)[],uint32,(uint8,bytes[]),(uint64,uint64))"
     )]
     fn transfer_multi_assets(
         handle: &mut impl PrecompileHandle,


### PR DESCRIPTION
A 4-byte EVM function selector is computed as the first 4 bytes of `keccak256(<function_signature_string>)`. Because the registered string of the XCM precompile function is `transfet_multi_assets()` rather than `transfer_multi_assets()` the on-chain selector is derived from the misspelled string.