### PR TITLE
Migrate collator client from `lookahead` to `slot-based` Aura consensus

### DIFF
--- a/bin/collator/src/parachain/fake_runtime_api.rs
+++ b/bin/collator/src/parachain/fake_runtime_api.rs
@@ -73,6 +73,18 @@ impl_runtime_apis! {
         }
     }
 
+    impl cumulus_primitives_core::RelayParentOffsetApi<Block> for Runtime {
+        fn relay_parent_offset() -> u32 {
+            unimplemented!()
+        }
+    }
+
+    impl cumulus_primitives_core::GetCoreSelectorApi<Block> for Runtime {
+        fn core_selector() -> (cumulus_primitives_core::CoreSelector, cumulus_primitives_core::ClaimQueueOffset) {
+            unimplemented!()
+        }
+    }
+
     impl sp_consensus_aura::AuraApi<Block, AuraId> for Runtime {
         fn slot_duration() -> sp_consensus_aura::SlotDuration {
             unimplemented!()

--- a/bin/collator/src/parachain/service.rs
+++ b/bin/collator/src/parachain/service.rs
@@ -20,8 +20,10 @@
 
 use astar_primitives::*;
 use cumulus_client_cli::CollatorOptions;
-use cumulus_client_consensus_aura::collators::lookahead::{self as aura, Params as AuraParams};
-use cumulus_client_consensus_common::ParachainBlockImport;
+use cumulus_client_consensus_aura::collators::slot_based::{
+    self as aura, Params as AuraParams, SlotBasedBlockImport, SlotBasedBlockImportHandle,
+};
+use cumulus_client_consensus_common::ParachainBlockImport as TParachainBlockImport;
 use cumulus_client_consensus_relay_chain::Verifier as RelayChainVerifier;
 use cumulus_client_service::{
     prepare_node_config, start_relay_chain_tasks, BuildNetworkParams, DARecoveryProfile,
@@ -34,7 +36,7 @@ use cumulus_primitives_core::{
 use cumulus_relay_chain_inprocess_interface::build_inprocess_relay_chain;
 use cumulus_relay_chain_interface::{RelayChainInterface, RelayChainResult};
 use cumulus_relay_chain_minimal_node::build_minimal_relay_chain_node_with_rpc;
-use fc_consensus::FrontierBlockImport;
+use fc_consensus::FrontierBlockImport as TFrontierBlockImport;
 use fc_rpc_core::types::{FeeHistoryCache, FilterPool};
 use fc_storage::StorageOverrideHandler;
 use futures::StreamExt;
@@ -82,6 +84,15 @@ pub type ParachainExecutor = WasmExecutor<HostFunctions>;
 type FullClient =
     TFullClient<Block, crate::parachain::fake_runtime_api::RuntimeApi, ParachainExecutor>;
 
+/// Frontier block import, wrapping the inner client.
+type FrontierBlockImportType = TFrontierBlockImport<Block, Arc<FullClient>, FullClient>;
+
+/// Slot-based block import sitting on top of Frontier.
+type SlotBasedImport = SlotBasedBlockImport<Block, FrontierBlockImportType, FullClient>;
+
+/// The full parachain block-import.
+type ParachainBlockImport = TParachainBlockImport<Block, SlotBasedImport, TFullBackend<Block>>;
+
 /// Starts a `ServiceBuilder` for a full service.
 ///
 /// Use this macro if you don't actually need the full service, but just the builder in order to
@@ -97,11 +108,8 @@ pub fn new_partial(
         sc_consensus::DefaultImportQueue<Block>,
         sc_transaction_pool::TransactionPoolHandle<Block, FullClient>,
         (
-            ParachainBlockImport<
-                Block,
-                FrontierBlockImport<Block, Arc<FullClient>, FullClient>,
-                TFullBackend<Block>,
-            >,
+            ParachainBlockImport,
+            SlotBasedBlockImportHandle<Block>,
             Option<Telemetry>,
             Option<TelemetryWorkerHandle>,
             Arc<fc_db::Backend<Block, FullClient>>,
@@ -167,10 +175,12 @@ pub fn new_partial(
         config,
         evm_tracing_config,
     )?);
-    let frontier_block_import = FrontierBlockImport::new(client.clone(), client.clone());
 
-    let parachain_block_import: ParachainBlockImport<_, _, _> =
-        ParachainBlockImport::new(frontier_block_import, backend.clone());
+    let frontier_block_import = TFrontierBlockImport::new(client.clone(), client.clone());
+    let (slot_based_block_import, slot_based_import_handle) =
+        SlotBasedBlockImport::new(frontier_block_import, client.clone());
+    let parachain_block_import: ParachainBlockImport =
+        ParachainBlockImport::new(slot_based_block_import, backend.clone());
 
     let import_queue = build_import_queue(
         client.clone(),
@@ -190,6 +200,7 @@ pub fn new_partial(
         select_chain: (),
         other: (
             parachain_block_import,
+            slot_based_import_handle,
             telemetry,
             telemetry_worker_handle,
             frontier_backend,
@@ -278,7 +289,14 @@ where
         select_chain: _,
         import_queue,
         transaction_pool,
-        other: (parachain_block_import, mut telemetry, telemetry_worker_handle, frontier_backend),
+        other:
+            (
+                parachain_block_import,
+                block_import_handle,
+                mut telemetry,
+                telemetry_worker_handle,
+                frontier_backend,
+            ),
     } = new_partial(&parachain_config, &additional_config.evm_tracing_config)?;
 
     let prometheus_registry = parachain_config.prometheus_registry().cloned();
@@ -540,6 +558,7 @@ where
             client.clone(),
             backend,
             parachain_block_import,
+            block_import_handle,
             prometheus_registry.as_ref(),
             telemetry.map(|t| t.handle()),
             &mut task_manager,
@@ -560,11 +579,7 @@ where
 /// Starts with relay-chain verifier until aura becomes available.
 pub fn build_import_queue(
     client: Arc<FullClient>,
-    block_import: ParachainBlockImport<
-        Block,
-        FrontierBlockImport<Block, Arc<FullClient>, FullClient>,
-        TFullBackend<Block>,
-    >,
+    block_import: ParachainBlockImport,
     config: &Configuration,
     telemetry_handle: Option<TelemetryHandle>,
     task_manager: &TaskManager,
@@ -627,11 +642,8 @@ pub fn build_import_queue(
 fn start_aura_consensus(
     client: Arc<FullClient>,
     backend: Arc<TFullBackend<Block>>,
-    parachain_block_import: ParachainBlockImport<
-        Block,
-        FrontierBlockImport<Block, Arc<FullClient>, FullClient>,
-        TFullBackend<Block>,
-    >,
+    block_import: ParachainBlockImport,
+    block_import_handle: SlotBasedBlockImportHandle<Block>,
     prometheus_registry: Option<&Registry>,
     telemetry: Option<TelemetryHandle>,
     task_manager: &TaskManager,
@@ -656,10 +668,6 @@ fn start_aura_consensus(
         additional_config.proposer_soft_deadline_percent,
     ));
 
-    let overseer_handle = relay_chain_interface
-        .overseer_handle()
-        .map_err(|e| sc_service::Error::Application(Box::new(e)))?;
-
     let announce_block = {
         let sync_service = sync_oracle.clone();
         Arc::new(move |hash, data| sync_service.announce_block(hash, data))
@@ -674,7 +682,7 @@ fn start_aura_consensus(
 
     let params = AuraParams {
         create_inherent_data_providers: move |_, ()| async move { Ok(()) },
-        block_import: parachain_block_import.clone(),
+        block_import,
         para_client: client.clone(),
         para_backend: backend,
         relay_client: relay_chain_interface.clone(),
@@ -690,20 +698,23 @@ fn start_aura_consensus(
         keystore,
         collator_key,
         para_id,
-        overseer_handle,
+        slot_offset: Duration::from_secs(1),
         relay_chain_slot_duration: Duration::from_secs(6),
         proposer: cumulus_client_consensus_proposer::Proposer::new(proposer_factory),
         collator_service,
         authoring_duration: Duration::from_millis(2000),
         reinitialize: false,
+        block_import_handle,
+        spawner: task_manager.spawn_handle(),
         // If necessary, AdditionalConfig CLI params could be extend to make it configurable.
         // However, it will be removed once https://github.com/paritytech/polkadot-sdk/issues/6020 is fixed.
         max_pov_percentage: None, // default is 85%
+        export_pov: None,
     };
 
     let fut = async move {
         wait_for_aura(client).await;
-        aura::run::<Block, AuraPair, _, _, _, _, _, _, _, _>(params).await
+        aura::run::<Block, AuraPair, _, _, _, _, _, _, _, _, _>(params);
     };
 
     task_manager

--- a/bin/collator/src/parachain/service.rs
+++ b/bin/collator/src/parachain/service.rs
@@ -717,9 +717,7 @@ fn start_aura_consensus(
         aura::run::<Block, AuraPair, _, _, _, _, _, _, _, _, _>(params);
     };
 
-    task_manager
-        .spawn_essential_handle()
-        .spawn("aura", None, fut);
+    task_manager.spawn_handle().spawn("aura", None, fut);
     Ok(())
 }
 

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -173,6 +173,8 @@ pub const UNINCLUDED_SEGMENT_CAPACITY: u32 = 3;
 pub const BLOCK_PROCESSING_VELOCITY: u32 = 1;
 /// Relay chain slot duration, in milliseconds.
 pub const RELAY_CHAIN_SLOT_DURATION_MILLIS: u32 = 6000;
+/// Relay chain best block offset to build blocks on.
+const RELAY_PARENT_OFFSET: u32 = 0;
 
 // Make the WASM binary available.
 #[cfg(feature = "std")]
@@ -544,7 +546,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
     type ConsensusHook = ConsensusHook;
     type SelectCore = cumulus_pallet_parachain_system::DefaultCoreSelector<Runtime>;
     type WeightInfo = cumulus_pallet_parachain_system::weights::SubstrateWeight<Runtime>;
-    type RelayParentOffset = ConstU32<0>;
+    type RelayParentOffset = ConstU32<RELAY_PARENT_OFFSET>;
 }
 
 type ConsensusHook = cumulus_pallet_aura_ext::FixedVelocityConsensusHook<
@@ -1948,6 +1950,18 @@ impl_runtime_apis! {
     impl cumulus_primitives_core::CollectCollationInfo<Block> for Runtime {
         fn collect_collation_info(header: &<Block as BlockT>::Header) -> cumulus_primitives_core::CollationInfo {
             ParachainSystem::collect_collation_info(header)
+        }
+    }
+
+    impl cumulus_primitives_core::RelayParentOffsetApi<Block> for Runtime {
+        fn relay_parent_offset() -> u32 {
+            RELAY_PARENT_OFFSET
+        }
+    }
+
+    impl cumulus_primitives_core::GetCoreSelectorApi<Block> for Runtime {
+        fn core_selector() -> (cumulus_primitives_core::CoreSelector, cumulus_primitives_core::ClaimQueueOffset) {
+            ParachainSystem::core_selector()
         }
     }
 

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -171,6 +171,8 @@ pub const UNINCLUDED_SEGMENT_CAPACITY: u32 = 3;
 pub const BLOCK_PROCESSING_VELOCITY: u32 = 1;
 /// Relay chain slot duration, in milliseconds.
 pub const RELAY_CHAIN_SLOT_DURATION_MILLIS: u32 = 6000;
+/// Relay chain best block offset to build blocks on.
+const RELAY_PARENT_OFFSET: u32 = 0;
 
 impl AddressToAssetId<AssetId> for Runtime {
     fn address_to_asset_id(address: H160) -> Option<AssetId> {
@@ -568,7 +570,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
     type ConsensusHook = ConsensusHook;
     type SelectCore = cumulus_pallet_parachain_system::DefaultCoreSelector<Runtime>;
     type WeightInfo = cumulus_pallet_parachain_system::weights::SubstrateWeight<Runtime>;
-    type RelayParentOffset = ConstU32<0>;
+    type RelayParentOffset = ConstU32<RELAY_PARENT_OFFSET>;
 }
 
 type ConsensusHook = cumulus_pallet_aura_ext::FixedVelocityConsensusHook<
@@ -1973,6 +1975,18 @@ impl_runtime_apis! {
     impl cumulus_primitives_core::CollectCollationInfo<Block> for Runtime {
         fn collect_collation_info(header: &<Block as BlockT>::Header) -> cumulus_primitives_core::CollationInfo {
             ParachainSystem::collect_collation_info(header)
+        }
+    }
+
+    impl cumulus_primitives_core::RelayParentOffsetApi<Block> for Runtime {
+        fn relay_parent_offset() -> u32 {
+            RELAY_PARENT_OFFSET
+        }
+    }
+
+    impl cumulus_primitives_core::GetCoreSelectorApi<Block> for Runtime {
+        fn core_selector() -> (cumulus_primitives_core::CoreSelector, cumulus_primitives_core::ClaimQueueOffset) {
+            ParachainSystem::core_selector()
         }
     }
 

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -163,6 +163,8 @@ pub const UNINCLUDED_SEGMENT_CAPACITY: u32 = 3;
 pub const BLOCK_PROCESSING_VELOCITY: u32 = 1;
 /// Relay chain slot duration, in milliseconds.
 pub const RELAY_CHAIN_SLOT_DURATION_MILLIS: u32 = 6000;
+/// Relay chain best block offset to build blocks on.
+const RELAY_PARENT_OFFSET: u32 = 0;
 
 // Make the WASM binary available.
 #[cfg(feature = "std")]
@@ -521,7 +523,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
     type ConsensusHook = ConsensusHook;
     type SelectCore = cumulus_pallet_parachain_system::DefaultCoreSelector<Runtime>;
     type WeightInfo = cumulus_pallet_parachain_system::weights::SubstrateWeight<Runtime>;
-    type RelayParentOffset = ConstU32<0>;
+    type RelayParentOffset = ConstU32<RELAY_PARENT_OFFSET>;
 }
 
 type ConsensusHook = cumulus_pallet_aura_ext::FixedVelocityConsensusHook<
@@ -1506,6 +1508,18 @@ impl_runtime_apis! {
             encoded: Vec<u8>,
         ) -> Option<Vec<(Vec<u8>, sp_core::crypto::KeyTypeId)>> {
             SessionKeys::decode_into_raw_public_keys(&encoded)
+        }
+    }
+
+    impl cumulus_primitives_core::RelayParentOffsetApi<Block> for Runtime {
+        fn relay_parent_offset() -> u32 {
+            RELAY_PARENT_OFFSET
+        }
+    }
+
+    impl cumulus_primitives_core::GetCoreSelectorApi<Block> for Runtime {
+        fn core_selector() -> (cumulus_primitives_core::CoreSelector, cumulus_primitives_core::ClaimQueueOffset) {
+            ParachainSystem::core_selector()
         }
     }
 


### PR DESCRIPTION
# Pull Request Summary

This PR replaces `lookahead` with `slot_based` Aura consensus, which fires on a time-based trigger rather than on every relay import event, minimising the fork-chasing behavior.

## Problem

The lookahead collator reacts to every relay chain block import, including forks. When 3–5 relay chain forks are live simultaneously, the collator speculatively builds on all of them, exhausting the unincluded segment capacity across competing fork heads. When forks resolve, all speculative blocks are discarded, producing observable slot gaps of 5+ missed slots and occasional depth-3 parachain reorgs.

## Follow-up parameter tuning

RelayParentOffset is configured at 0 for a first monitoring on Shibuya. If relay fork-induced drift persists, it must be increased to 1 to build on relay parents that are one block behind the tip where forks have already settled. This adds additional XCM message latency though.

## Check list

- [ ] monitor Shibuya collator for slot gaps
