### PR TITLE
Fix/xcm precompile

### DIFF
--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -196,6 +196,8 @@ where
             .map(Into::into)
             .collect::<Vec<Asset>>();
 
+        Self::ensure_dot_transfer_policy(&assets, &destination)?;
+
         log::trace!(target: "xcm-precompile:assets_withdraw", "Processed arguments: assets {:?}, destination: {:?}", assets, destination);
 
         // Build call with origin.
@@ -363,6 +365,7 @@ where
             .map(Into::into)
             .collect::<Vec<Asset>>();
 
+        Self::ensure_dot_transfer_policy(&assets, &destination)?;
         log::trace!(target: "xcm-precompile:assets_reserve_transfer", "Processed arguments: assets {:?}, destination: {:?}", assets, destination);
 
         // Build call with origin.
@@ -802,6 +805,41 @@ where
         RuntimeHelper::<Runtime>::try_dispatch(handle, origin, call, 0)?;
 
         Ok(true)
+    }
+
+    /// Enforces DOT transfer routing policy.
+    ///
+    /// Currently prevents direct DOT transfers to the relay chain,
+    /// requiring routing through AssetHub (parachain 1000).
+    fn ensure_dot_transfer_policy(
+        assets: &[Asset],
+        destination: &Location,
+    ) -> EvmResult<()> {
+        let dest_chain = {
+            let mut d = destination.clone();
+            // Remove the final interior junction (the beneficiary AccountId32 / AccountKey20)
+            // to get just the chain root, e.g. (1, Here) or (1, Parachain(1000)).
+            d.interior.take_last();
+            d
+        };
+
+        if dest_chain != Location::parent() {
+            return Ok(());
+        }
+
+        let deprecated_dot_location = Location::new(1, Junctions::Here);
+
+        for asset in assets {
+            let AssetId(location) = &asset.id;
+            if location == &deprecated_dot_location {
+                return Err(revert(
+                    "DOT cannot be sent directly to the relay. \
+                 Route via AssetHub (parachain 1000).",
+                ));
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -751,7 +751,7 @@ where
     }
 
     #[precompile::public(
-        "transfet_multi_assets(((uint8,bytes[]),uint256)[],uint32,(uint8,bytes[]),(uint64,uint64))"
+        "transfer_multi_assets(((uint8,bytes[]),uint256)[],uint32,(uint8,bytes[]),(uint64,uint64))"
     )]
     fn transfer_multi_assets(
         handle: &mut impl PrecompileHandle,

--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -811,10 +811,7 @@ where
     ///
     /// Currently prevents direct DOT transfers to the relay chain,
     /// requiring routing through AssetHub (parachain 1000).
-    fn ensure_dot_transfer_policy(
-        assets: &[Asset],
-        destination: &Location,
-    ) -> EvmResult<()> {
+    fn ensure_dot_transfer_policy(assets: &[Asset], destination: &Location) -> EvmResult<()> {
         let dest_chain = {
             let mut d = destination.clone();
             // Remove the final interior junction (the beneficiary AccountId32 / AccountKey20)

--- a/precompiles/xcm/src/mock.rs
+++ b/precompiles/xcm/src/mock.rs
@@ -40,15 +40,13 @@ use sp_core::{ConstU32, DecodeWithMemTracking, H160};
 use sp_runtime::{traits::IdentityLookup, BuildStorage};
 use sp_std::cell::RefCell;
 
-use astar_primitives::xcm::AllowTopLevelPaidExecutionFrom;
+use astar_primitives::xcm::{AllowTopLevelPaidExecutionFrom, AbsoluteAndRelativeReserveProvider};
 use xcm::prelude::XcmVersion;
 use xcm_builder::{
     test_utils::TransactAsset, AllowKnownQueryResponses, AllowSubscriptionsFrom, FixedWeightBounds,
     SignedToAccountId32, TakeWeightCredit,
 };
 use xcm_executor::XcmExecutor;
-// orml imports
-use orml_traits::location::{RelativeReserveProvider, Reserve};
 use orml_xcm_support::DisabledParachainFee;
 
 pub type AccountId = TestAccount;
@@ -189,23 +187,6 @@ impl sp_runtime::traits::Convert<AccountId, Location> for AccountIdToLocation {
             id: account.into(),
         }
         .into()
-    }
-}
-
-/// `Asset` reserve location provider. It's based on `RelativeReserveProvider` and in
-/// addition will convert self absolute location to relative location.
-pub struct AbsoluteAndRelativeReserveProvider<AbsoluteLocation>(PhantomData<AbsoluteLocation>);
-impl<AbsoluteLocation: Get<Location>> Reserve
-    for AbsoluteAndRelativeReserveProvider<AbsoluteLocation>
-{
-    fn reserve(asset: &Asset) -> Option<Location> {
-        RelativeReserveProvider::reserve(asset).map(|reserve_location| {
-            if reserve_location == AbsoluteLocation::get() {
-                Location::here()
-            } else {
-                reserve_location
-            }
-        })
     }
 }
 

--- a/precompiles/xcm/src/mock.rs
+++ b/precompiles/xcm/src/mock.rs
@@ -40,14 +40,14 @@ use sp_core::{ConstU32, DecodeWithMemTracking, H160};
 use sp_runtime::{traits::IdentityLookup, BuildStorage};
 use sp_std::cell::RefCell;
 
-use astar_primitives::xcm::{AllowTopLevelPaidExecutionFrom, AbsoluteAndRelativeReserveProvider};
+use astar_primitives::xcm::{AbsoluteAndRelativeReserveProvider, AllowTopLevelPaidExecutionFrom};
+use orml_xcm_support::DisabledParachainFee;
 use xcm::prelude::XcmVersion;
 use xcm_builder::{
     test_utils::TransactAsset, AllowKnownQueryResponses, AllowSubscriptionsFrom, FixedWeightBounds,
     SignedToAccountId32, TakeWeightCredit,
 };
 use xcm_executor::XcmExecutor;
-use orml_xcm_support::DisabledParachainFee;
 
 pub type AccountId = TestAccount;
 pub type AssetId = u128;

--- a/precompiles/xcm/src/tests.rs
+++ b/precompiles/xcm/src/tests.rs
@@ -59,8 +59,8 @@ mod xcm_old_interface_test {
                         assets: vec![Address::from(Runtime::asset_id_to_address(1u128))].into(),
                         amounts: vec![42000u64.into()].into(),
                         recipient_account_id: H256::repeat_byte(0xF1),
-                        is_relay: true,
-                        parachain_id: 0.into(),
+                        is_relay: false,
+                        parachain_id: 1000.into(),
                         fee_index: 2.into(),
                     },
                 )
@@ -138,8 +138,8 @@ mod xcm_old_interface_test {
                         assets: vec![Address::from(Runtime::asset_id_to_address(1u128))].into(),
                         amounts: vec![42000u64.into()].into(),
                         recipient_account_id: H256::repeat_byte(0xF1),
-                        is_relay: true,
-                        parachain_id: 0.into(),
+                        is_relay: false,
+                        parachain_id: 1000.into(),
                         fee_index: 0.into(),
                     },
                 )
@@ -183,6 +183,29 @@ mod xcm_old_interface_test {
     }
 
     #[test]
+    fn assets_withdraw_dot_to_relay_reverts() {
+        ExtBuilder.build().execute_with(|| {
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::assets_withdraw_native_v1 {
+                        assets: vec![Address::from(Runtime::asset_id_to_address(1u128))].into(), // DOT
+                        amounts: vec![42000u64.into()].into(),
+                        recipient_account_id: H256::repeat_byte(0xF1),
+                        is_relay: true,
+                        parachain_id: 0.into(),
+                        fee_index: 0.into(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_reverts(|output| {
+                    output == b"DOT cannot be sent directly to the relay. Route via AssetHub (parachain 1000)."
+                });
+        });
+    }
+
+    #[test]
     fn remote_transact_works() {
         ExtBuilder.build().execute_with(|| {
             // SS58
@@ -222,8 +245,8 @@ mod xcm_old_interface_test {
                         assets: vec![Address::from(Runtime::asset_id_to_address(1u128))].into(),
                         amounts: vec![U256::from(42000u64)].into(),
                         recipient_account_id: H256::repeat_byte(0xF1),
-                        is_relay: true,
-                        parachain_id: 0.into(),
+                        is_relay: false,
+                        parachain_id: 1000.into(),
                         fee_index: 0.into(),
                     },
                 )
@@ -239,8 +262,8 @@ mod xcm_old_interface_test {
                         assets: vec![Address::from(Runtime::asset_id_to_address(1u128))].into(),
                         amounts: vec![U256::from(42000u64)].into(),
                         recipient_account_id: Address::from(H160::repeat_byte(0xDE)),
-                        is_relay: true,
-                        parachain_id: 0.into(),
+                        is_relay: false,
+                        parachain_id: 1000.into(),
                         fee_index: 0.into(),
                     },
                 )
@@ -252,14 +275,14 @@ mod xcm_old_interface_test {
                     location,
                     Location {
                         parents: 1,
-                        interior: Here
+                        interior: Parachain(1000).into()
                     }
                 );
 
                 let non_native_asset = Asset {
                     fun: Fungible(42000),
                     id: xcm::v5::AssetId::from(Location {
-                        parents: 0,
+                        parents: 1,
                         interior: Here,
                     }),
                 };


### PR DESCRIPTION
# Pull Request Summary

Closes #1609 

Calling `assets_withdraw` with `is_relay=true` builds `destination = Location::parent()` (the relay chain). But DOT's reserve is now AssetHub, so xtokens will attempt a two-hop transfer instead of a direct one, causing funds to get stuck.

This PR adds a simple validation guard that rejects invalid routing explicitly and forces the caller to fix their calldata. This prevents any interface breaking change.

In addition for later, the DOT location in the XcAsset pallet could be updated to (1, [Parachain(1000)]) but it requires more coordination which is not planed yet.

## Check list**

- [X] added or updated unit tests
