### PR TITLE
chore: bump deps 5.49.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,7 +822,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "astar-collator"
-version = "5.49.1"
+version = "5.49.2"
 dependencies = [
  "astar-primitives",
  "astar-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1501,7 +1501,7 @@ checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "hash-db",
  "log",
@@ -1759,7 +1759,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -2643,7 +2643,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-bootnodes"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -2669,7 +2669,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.24.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -2686,7 +2686,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.24.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -2708,8 +2708,8 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-aura"
-version = "0.24.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+version = "0.24.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -2756,7 +2756,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.24.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -2788,7 +2788,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.20.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2803,7 +2803,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.24.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -2826,7 +2826,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.24.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -2853,7 +2853,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2874,7 +2874,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.24.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2902,7 +2902,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.25.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-channel 1.9.0",
  "cumulus-client-cli",
@@ -2942,7 +2942,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -2959,7 +2959,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.21.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "array-bytes 6.2.3",
  "bytes",
@@ -2997,7 +2997,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -3008,7 +3008,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.20.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3023,7 +3023,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.21.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "approx",
  "bounded-collections",
@@ -3049,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -3058,7 +3058,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -3075,7 +3075,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3089,7 +3089,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -3099,7 +3099,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -3116,7 +3116,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3133,7 +3133,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -3161,7 +3161,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.24.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3181,7 +3181,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -3217,7 +3217,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.24.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3258,7 +3258,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-streams"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "cumulus-relay-chain-interface",
  "futures 0.3.32",
@@ -3272,7 +3272,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.20.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -3499,7 +3499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4180,7 +4180,7 @@ dependencies = [
 [[package]]
 name = "ethereum-standards"
 version = "0.1.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "alloy-core",
 ]
@@ -4949,7 +4949,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -5076,7 +5076,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 [[package]]
 name = "frame-benchmarking"
 version = "41.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -5100,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "49.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "Inflector",
  "array-bytes 6.2.3",
@@ -5179,7 +5179,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "16.1.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -5190,7 +5190,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -5207,7 +5207,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "41.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -5260,7 +5260,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "array-bytes 6.2.3",
  "const-hex",
@@ -5276,7 +5276,7 @@ dependencies = [
 [[package]]
 name = "frame-storage-access-test-runtime"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "parity-scale-codec",
@@ -5289,8 +5289,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "41.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+version = "41.0.2"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "aquamarine",
  "array-bytes 6.2.3",
@@ -5331,7 +5331,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -5351,7 +5351,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.4.0",
@@ -5363,7 +5363,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5373,7 +5373,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "41.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "cfg-if",
  "docify",
@@ -5392,7 +5392,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5406,7 +5406,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -5416,7 +5416,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -8080,7 +8080,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "46.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "futures 0.3.32",
  "log",
@@ -8099,7 +8099,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -9065,7 +9065,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9083,7 +9083,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9097,7 +9097,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9113,7 +9113,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "ethereum-standards",
  "frame-benchmarking",
@@ -9131,7 +9131,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9147,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9162,7 +9162,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9175,7 +9175,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9198,7 +9198,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "aquamarine",
  "docify",
@@ -9219,7 +9219,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9235,7 +9235,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9254,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "array-bytes 6.2.3",
  "binary-merkle-tree",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9296,7 +9296,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.20.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -9314,7 +9314,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9358,7 +9358,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9414,7 +9414,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9445,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "23.0.3"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9455,7 +9455,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-uapi"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -9465,8 +9465,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-conviction-voting"
-version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+version = "41.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -9505,7 +9505,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "8.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9520,7 +9520,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9557,7 +9557,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9578,7 +9578,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9591,7 +9591,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9903,7 +9903,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9921,7 +9921,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9943,7 +9943,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -9959,7 +9959,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9978,7 +9978,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10012,7 +10012,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10023,7 +10023,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10039,7 +10039,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -10058,7 +10058,7 @@ dependencies = [
 [[package]]
 name = "pallet-meta-tx"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10076,7 +10076,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10094,8 +10094,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-mmr"
-version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+version = "41.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10107,7 +10107,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10118,7 +10118,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10128,7 +10128,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10146,7 +10146,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10166,7 +10166,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -10176,7 +10176,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10191,7 +10191,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10214,7 +10214,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10231,7 +10231,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10247,7 +10247,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10257,7 +10257,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "41.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10275,7 +10275,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10285,7 +10285,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -10302,8 +10302,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-revive"
-version = "0.7.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+version = "0.7.2"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "alloy-core",
  "derive_more 0.99.20",
@@ -10348,8 +10348,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-revive-fixtures"
-version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+version = "0.4.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.15.4",
@@ -10363,7 +10363,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-proc-macro"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10373,7 +10373,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-uapi"
 version = "0.5.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "bitflags 1.3.2",
  "pallet-revive-proc-macro",
@@ -10385,7 +10385,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10398,7 +10398,7 @@ dependencies = [
 [[package]]
 name = "pallet-safe-mode"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "docify",
  "pallet-balances",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10429,7 +10429,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10450,7 +10450,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10466,7 +10466,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10483,7 +10483,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -10505,7 +10505,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-ah-client"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10524,7 +10524,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-rc-client"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10541,7 +10541,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -10550,7 +10550,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10560,7 +10560,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "46.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10576,7 +10576,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10591,7 +10591,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10609,7 +10609,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10627,7 +10627,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10642,7 +10642,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -10658,7 +10658,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -10689,7 +10689,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10708,7 +10708,7 @@ dependencies = [
 [[package]]
 name = "pallet-tx-pause"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -10719,7 +10719,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10734,7 +10734,7 @@ dependencies = [
 [[package]]
 name = "pallet-verify-signature"
 version = "0.4.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10749,7 +10749,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10763,7 +10763,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10793,7 +10793,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "20.1.3"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -10819,7 +10819,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10836,7 +10836,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -11203,7 +11203,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "24.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "futures 0.3.32",
  "futures-timer",
@@ -11221,7 +11221,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "futures 0.3.32",
  "futures-timer",
@@ -11236,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "fatality",
  "futures 0.3.32",
@@ -11259,7 +11259,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "fatality",
@@ -11292,7 +11292,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -11315,8 +11315,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-collator-protocol"
-version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+version = "24.0.3"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11339,7 +11339,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11350,7 +11350,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "fatality",
  "futures 0.3.32",
@@ -11372,7 +11372,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -11386,7 +11386,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "24.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "futures 0.3.32",
  "futures-timer",
@@ -11407,7 +11407,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -11430,7 +11430,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "futures 0.3.32",
  "parity-scale-codec",
@@ -11448,7 +11448,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -11480,7 +11480,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -11504,7 +11504,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "bitvec",
  "futures 0.3.32",
@@ -11523,7 +11523,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11544,7 +11544,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "futures 0.3.32",
  "polkadot-node-subsystem",
@@ -11559,7 +11559,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -11581,7 +11581,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "futures 0.3.32",
  "polkadot-node-metrics",
@@ -11595,7 +11595,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "futures 0.3.32",
  "futures-timer",
@@ -11611,7 +11611,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "fatality",
  "futures 0.3.32",
@@ -11629,7 +11629,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -11646,7 +11646,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "fatality",
  "futures 0.3.32",
@@ -11660,7 +11660,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11677,7 +11677,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "always-assert",
  "array-bytes 6.2.3",
@@ -11705,7 +11705,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "futures 0.3.32",
  "polkadot-node-subsystem",
@@ -11718,7 +11718,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "cpu-time",
  "futures 0.3.32",
@@ -11744,7 +11744,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "futures 0.3.32",
  "polkadot-node-metrics",
@@ -11759,7 +11759,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "bs58",
  "futures 0.3.32",
@@ -11776,7 +11776,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -11801,7 +11801,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "20.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -11825,7 +11825,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -11834,7 +11834,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -11862,7 +11862,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "24.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "fatality",
  "futures 0.3.32",
@@ -11893,7 +11893,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -11913,7 +11913,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "bounded-collections",
  "derive_more 0.99.20",
@@ -11929,7 +11929,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "bitvec",
  "bounded-collections",
@@ -11958,7 +11958,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -11991,7 +11991,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -12041,7 +12041,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -12053,7 +12053,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "20.0.3"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -12101,7 +12101,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -12136,7 +12136,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -12244,7 +12244,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12264,7 +12264,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -13420,7 +13420,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "24.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -13518,7 +13518,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -13904,7 +13904,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "32.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "log",
  "sp-core",
@@ -13914,8 +13914,8 @@ dependencies = [
 
 [[package]]
 name = "sc-authority-discovery"
-version = "0.51.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+version = "0.51.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -13946,7 +13946,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.50.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "futures 0.3.32",
  "log",
@@ -13967,7 +13967,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -13982,7 +13982,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "array-bytes 6.2.3",
  "docify",
@@ -14008,7 +14008,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -14019,7 +14019,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.53.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "array-bytes 6.2.3",
  "chrono",
@@ -14061,7 +14061,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "fnv",
  "futures 0.3.32",
@@ -14087,7 +14087,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -14115,7 +14115,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.50.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -14138,7 +14138,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.51.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -14167,7 +14167,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.51.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -14203,7 +14203,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.51.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "futures 0.3.32",
  "jsonrpsee",
@@ -14225,7 +14225,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -14259,7 +14259,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "futures 0.3.32",
  "jsonrpsee",
@@ -14279,7 +14279,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.50.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -14292,7 +14292,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.36.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "ahash",
  "array-bytes 6.2.3",
@@ -14336,7 +14336,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.36.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "finality-grandpa",
  "futures 0.3.32",
@@ -14356,7 +14356,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.52.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -14391,7 +14391,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.50.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -14414,7 +14414,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -14437,7 +14437,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.39.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "polkavm 0.24.0",
  "sc-allocator",
@@ -14450,7 +14450,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.36.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "log",
  "polkavm 0.24.0",
@@ -14461,7 +14461,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.39.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "anyhow",
  "log",
@@ -14477,7 +14477,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.50.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "console",
  "futures 0.3.32",
@@ -14493,7 +14493,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "array-bytes 6.2.3",
  "parking_lot 0.12.5",
@@ -14507,7 +14507,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "array-bytes 6.2.3",
  "arrayvec 0.7.6",
@@ -14534,8 +14534,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.51.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+version = "0.51.2"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -14585,7 +14585,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.49.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -14595,7 +14595,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.51.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "ahash",
  "futures 0.3.32",
@@ -14614,7 +14614,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.50.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -14635,7 +14635,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.50.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "array-bytes 6.2.3",
  "async-channel 1.9.0",
@@ -14670,7 +14670,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.50.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "array-bytes 6.2.3",
  "futures 0.3.32",
@@ -14689,7 +14689,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.17.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "bs58",
  "bytes",
@@ -14710,7 +14710,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "46.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "bytes",
  "fnv",
@@ -14744,7 +14744,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -14753,7 +14753,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "46.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "futures 0.3.32",
  "jsonrpsee",
@@ -14785,7 +14785,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.50.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -14805,7 +14805,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -14829,7 +14829,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.51.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "array-bytes 6.2.3",
  "futures 0.3.32",
@@ -14862,7 +14862,7 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
@@ -14877,7 +14877,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.52.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "directories",
@@ -14941,7 +14941,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.39.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -14952,7 +14952,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "clap",
  "fs4",
@@ -14965,7 +14965,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.51.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -14984,7 +14984,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "derive_more 0.99.20",
  "futures 0.3.32",
@@ -15004,7 +15004,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "chrono",
  "futures 0.3.32",
@@ -15023,7 +15023,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "40.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "chrono",
  "console",
@@ -15053,7 +15053,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -15064,7 +15064,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "40.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -15095,7 +15095,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -15112,7 +15112,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-channel 1.9.0",
  "futures 0.3.32",
@@ -16085,7 +16085,7 @@ dependencies = [
 [[package]]
 name = "slot-range-helper"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -16409,7 +16409,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "docify",
  "hash-db",
@@ -16431,7 +16431,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -16445,7 +16445,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16457,7 +16457,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -16471,7 +16471,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16483,7 +16483,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -16493,7 +16493,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "futures 0.3.32",
  "parity-scale-codec",
@@ -16512,7 +16512,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "futures 0.3.32",
@@ -16526,7 +16526,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16542,7 +16542,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16560,7 +16560,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16580,7 +16580,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -16597,7 +16597,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16608,7 +16608,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "ark-vrf",
  "array-bytes 6.2.3",
@@ -16670,7 +16670,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -16683,7 +16683,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "quote",
  "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?branch=stable2506)",
@@ -16693,7 +16693,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.5",
@@ -16702,7 +16702,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -16712,7 +16712,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.30.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -16722,7 +16722,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16734,7 +16734,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -16747,7 +16747,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "41.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "bytes",
  "docify",
@@ -16773,7 +16773,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -16783,7 +16783,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -16794,7 +16794,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -16803,7 +16803,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.11.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-metadata 23.0.1",
  "parity-scale-codec",
@@ -16813,7 +16813,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.15.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16824,7 +16824,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -16841,7 +16841,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16854,7 +16854,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -16864,7 +16864,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "backtrace",
  "regex",
@@ -16873,7 +16873,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -16883,7 +16883,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "binary-merkle-tree",
  "docify",
@@ -16912,7 +16912,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -16931,7 +16931,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "Inflector",
  "expander",
@@ -16944,7 +16944,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16958,7 +16958,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -16971,7 +16971,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.46.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "hash-db",
  "log",
@@ -16991,7 +16991,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "21.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -17015,12 +17015,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
@@ -17032,7 +17032,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17044,7 +17044,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -17055,7 +17055,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -17064,7 +17064,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -17077,8 +17077,8 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+version = "40.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "ahash",
  "foldhash 0.1.5",
@@ -17103,7 +17103,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "impl-serde 0.5.0",
  "parity-scale-codec",
@@ -17120,7 +17120,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -17132,7 +17132,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -17144,7 +17144,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "32.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -17333,7 +17333,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "staging-parachain-info"
 version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -17345,8 +17345,8 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm"
-version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+version = "17.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "array-bytes 6.2.3",
  "bounded-collections",
@@ -17367,7 +17367,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "21.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "environmental",
  "frame-support",
@@ -17391,7 +17391,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-executor"
 version = "20.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -17503,7 +17503,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2 0.12.2",
@@ -17528,12 +17528,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -17553,7 +17553,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.6"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "http-body-util",
  "hyper 1.8.1",
@@ -17567,7 +17567,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -17584,7 +17584,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "27.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "array-bytes 6.2.3",
  "build-helper",
@@ -18418,7 +18418,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -18429,7 +18429,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "expander",
  "proc-macro-crate 3.4.0",
@@ -19348,7 +19348,7 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 [[package]]
 name = "westend-runtime"
 version = "24.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -19455,7 +19455,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -20027,7 +20027,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -20038,7 +20038,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -20052,7 +20052,7 @@ dependencies = [
 [[package]]
 name = "xcm-simulator"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#510fed173e7459a3b030cdf20f1021236b367253"
+source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2506#93b592c0dc58bcda77c5c6666ec4d105f68e0e18"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/bin/collator/Cargo.toml
+++ b/bin/collator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-collator"
-version = "5.49.1"
+version = "5.49.2"
 description = "Astar collator implementation in Rust."
 build = "build.rs"
 default-run = "astar-collator"


### PR DESCRIPTION
Bump Polkadot SDK deps to benefit from https://github.com/paritytech/polkadot-sdk/pull/11330 and fix RPC nodes gap syncing 