### PR TITLE
Chore/prep release runtime 2207

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "astar-runtime"
-version = "22.0.6"
+version = "22.0.7"
 dependencies = [
  "array-bytes 6.2.3",
  "astar-primitives",
@@ -15737,7 +15737,7 @@ dependencies = [
 
 [[package]]
 name = "shibuya-runtime"
-version = "22.0.5"
+version = "22.0.7"
 dependencies = [
  "astar-primitives",
  "astar-xcm-benchmarks",
@@ -15853,7 +15853,7 @@ dependencies = [
 
 [[package]]
 name = "shiden-runtime"
-version = "22.0.6"
+version = "22.0.7"
 dependencies = [
  "array-bytes 6.2.3",
  "astar-primitives",

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astar-runtime"
-version = "22.0.6"
+version = "22.0.7"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -194,7 +194,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: Cow::Borrowed("astar"),
     impl_name: Cow::Borrowed("astar"),
     authoring_version: 1,
-    spec_version: 2206,
+    spec_version: 2207,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -545,8 +545,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
     type ConsensusHook = ConsensusHook;
     type SelectCore = cumulus_pallet_parachain_system::DefaultCoreSelector<Runtime>;
     type WeightInfo = cumulus_pallet_parachain_system::weights::SubstrateWeight<Runtime>;
-    // TODO: Set offset to RelayParentOffset once the majority of collators have migrated to slot_based
-    type RelayParentOffset = ConstU32<0>;
+    type RelayParentOffset = RelayParentOffset;
 }
 
 type ConsensusHook = cumulus_pallet_aura_ext::FixedVelocityConsensusHook<

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shibuya-runtime"
-version = "22.0.5"
+version = "22.0.7"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -215,7 +215,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: Cow::Borrowed("shibuya"),
     impl_name: Cow::Borrowed("shibuya"),
     authoring_version: 1,
-    spec_version: 2205,
+    spec_version: 2207,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 4,
@@ -1697,16 +1697,8 @@ pub type Executive = frame_executive::Executive<
 /// __NOTE:__ THE ORDER IS IMPORTANT.
 pub type Migrations = (Unreleased, Permanent);
 
-parameter_types! {
-    pub const UnifiedAccountsPalletName: &'static str = "UnifiedAccounts";
-    pub const EthereumCheckedPalletName: &'static str = "EthereumChecked";
-}
-
 /// Unreleased migrations. Add new ones here:
-pub type Unreleased = (
-    frame_support::migrations::RemovePallet<UnifiedAccountsPalletName, RocksDbWeight>,
-    frame_support::migrations::RemovePallet<EthereumCheckedPalletName, RocksDbWeight>,
-);
+pub type Unreleased = ();
 
 /// Migrations/checks that do not need to be versioned and can run on every upgrade.
 pub type Permanent = (pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,);

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shiden-runtime"
-version = "22.0.6"
+version = "22.0.7"
 build = "build.rs"
 authors.workspace = true
 edition.workspace = true

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -522,8 +522,7 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
     type ConsensusHook = ConsensusHook;
     type SelectCore = cumulus_pallet_parachain_system::DefaultCoreSelector<Runtime>;
     type WeightInfo = cumulus_pallet_parachain_system::weights::SubstrateWeight<Runtime>;
-    // TODO: Set offset to RelayParentOffset once the majority of collators have migrated to slot_based
-    type RelayParentOffset = ConstU32<0>;
+    type RelayParentOffset = RelayParentOffset;
 }
 
 type ConsensusHook = cumulus_pallet_aura_ext::FixedVelocityConsensusHook<

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -184,7 +184,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: Cow::Borrowed("shiden"),
     impl_name: Cow::Borrowed("shiden"),
     authoring_version: 1,
-    spec_version: 2206,
+    spec_version: 2207,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 3,


### PR DESCRIPTION
This PR prepares `runtime-2207` release and enforces runtime validation of `RelayParentOffset` by checking the correct parent and descendants in inherent data. 