### PR TITLE
Fix: xcm hardening

### DIFF
--- a/.github/workflows/runtime-compatibility.yml
+++ b/.github/workflows/runtime-compatibility.yml
@@ -204,7 +204,7 @@ jobs:
         if: matrix.chain == 'astar'
         working-directory: runtime-src
         run: |
-          cargo build --release -p astar-collator --features astar-sudo
+          cargo build --release --locked -p astar-collator --features astar-sudo
 
       - name: Generate spec from matching runtime, patch sudo key and WASM
         if: matrix.chain == 'astar'

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -29,7 +29,7 @@ jobs:
           if taplo --version &> /dev/null; then
             echo "taplo-cli is already installed"
           else
-            cargo install taplo-cli
+            cargo install taplo-cli --locked
           fi
           taplo fmt --check
 
@@ -58,7 +58,7 @@ jobs:
       - name: Clippy
         env:
           SKIP_WASM_BUILD: 1
-        run: cargo clippy --features evm-tracing,try-runtime,runtime-benchmarks -- -D warnings
+        run: cargo clippy --locked --features evm-tracing,try-runtime,runtime-benchmarks -- -D warnings
 
   check-license:
     if: github.event.pull_request.draft == false

--- a/precompiles/xcm/src/mock.rs
+++ b/precompiles/xcm/src/mock.rs
@@ -40,12 +40,12 @@ use sp_core::{ConstU32, DecodeWithMemTracking, H160};
 use sp_runtime::{traits::IdentityLookup, BuildStorage};
 use sp_std::cell::RefCell;
 
-use astar_primitives::xcm::{AbsoluteAndRelativeReserveProvider, AllowTopLevelPaidExecutionFrom};
+use astar_primitives::xcm::AbsoluteAndRelativeReserveProvider;
 use orml_xcm_support::DisabledParachainFee;
 use xcm::prelude::XcmVersion;
 use xcm_builder::{
-    test_utils::TransactAsset, AllowKnownQueryResponses, AllowSubscriptionsFrom, FixedWeightBounds,
-    SignedToAccountId32, TakeWeightCredit,
+    test_utils::TransactAsset, AllowKnownQueryResponses, AllowSubscriptionsFrom,
+    AllowTopLevelPaidExecutionFrom, FixedWeightBounds, SignedToAccountId32, TakeWeightCredit,
 };
 use xcm_executor::XcmExecutor;
 

--- a/primitives/src/xcm/mod.rs
+++ b/primitives/src/xcm/mod.rs
@@ -33,8 +33,7 @@
 use crate::AccountId;
 
 use frame_support::{
-    ensure,
-    traits::{tokens::fungibles, Contains, ContainsPair, Get, ProcessMessageError},
+    traits::{tokens::fungibles, ContainsPair, Get},
     weights::constants::WEIGHT_REF_TIME_PER_SECOND,
 };
 use sp_runtime::traits::{Bounded, Convert, MaybeEquivalence, Zero};
@@ -42,8 +41,8 @@ use sp_std::marker::PhantomData;
 
 // Polkadot imports
 use xcm::latest::{prelude::*, Weight};
-use xcm_builder::{CreateMatcher, MatchXcm, TakeRevenue};
-use xcm_executor::traits::{MatchesFungibles, Properties, ShouldExecute, WeightTrader};
+use xcm_builder::TakeRevenue;
+use xcm_executor::traits::{MatchesFungibles, WeightTrader};
 
 // ORML imports
 use orml_traits::location::Reserve;
@@ -79,7 +78,7 @@ where
 
 /// Used as weight trader for foreign assets.
 ///
-/// In case foreigin asset is supported as payment asset, XCM execution time
+/// In case foreign asset is supported as payment asset, XCM execution time
 /// on-chain can be paid by the foreign asset, using the configured rate.
 pub struct FixedRateOfForeignAsset<T: ExecutionPaymentRate, R: TakeRevenue> {
     /// Total used weight
@@ -131,26 +130,23 @@ impl<T: ExecutionPaymentRate, R: TakeRevenue> WeightTrader for FixedRateOfForeig
                         return Ok(payment);
                     }
 
+                    // This trader tracks a single fee asset.
+                    if let Some((tracked_asset_location, _)) =
+                        &self.asset_location_and_units_per_second
+                    {
+                        if *tracked_asset_location != asset_location {
+                            return Err(XcmError::NotWithdrawable);
+                        }
+                    }
+
                     let unused = payment
                         .checked_sub((asset_location.clone(), amount).into())
                         .map_err(|_| XcmError::TooExpensive)?;
 
                     self.weight = self.weight.saturating_add(weight);
-
-                    // If there are multiple calls to `BuyExecution` but with different assets, we need to be able to handle that.
-                    // Current primitive implementation will just keep total track of consumed asset for the FIRST consumed asset.
-                    // Others will just be ignored when refund is concerned.
-                    if let Some((old_asset_location, _)) =
-                        self.asset_location_and_units_per_second.clone()
-                    {
-                        if old_asset_location == asset_location {
-                            self.consumed = self.consumed.saturating_add(amount);
-                        }
-                    } else {
-                        self.consumed = self.consumed.saturating_add(amount);
-                        self.asset_location_and_units_per_second =
-                            Some((asset_location, units_per_second));
-                    }
+                    self.consumed = self.consumed.saturating_add(amount);
+                    self.asset_location_and_units_per_second =
+                        Some((asset_location, units_per_second));
 
                     Ok(unused)
                 } else {
@@ -168,8 +164,11 @@ impl<T: ExecutionPaymentRate, R: TakeRevenue> WeightTrader for FixedRateOfForeig
             self.asset_location_and_units_per_second.clone()
         {
             let weight = weight.min(self.weight);
-            let amount = units_per_second.saturating_mul(weight.ref_time() as u128)
-                / (WEIGHT_REF_TIME_PER_SECOND as u128);
+            // Never hand back more of the asset than was actually taken for it.
+            let amount = units_per_second
+                .saturating_mul(weight.ref_time() as u128)
+                .saturating_div(WEIGHT_REF_TIME_PER_SECOND as u128)
+                .min(self.consumed);
 
             self.weight = self.weight.saturating_sub(weight);
             self.consumed = self.consumed.saturating_sub(amount);
@@ -301,67 +300,5 @@ impl<AbsoluteLocation: Get<Location>> Reserve
         }
 
         Some(reserve_location)
-    }
-}
-
-// Copying the barrier here due to this issue - https://github.com/paritytech/polkadot-sdk/issues/1638
-// The fix was introduced in v1.3.0 via this PR - https://github.com/paritytech/polkadot-sdk/pull/1733
-// Below is the exact same copy from the fix PR.
-
-const MAX_ASSETS_FOR_BUY_EXECUTION: usize = 2;
-
-/// Allows execution from `origin` if it is contained in `T` (i.e. `T::Contains(origin)`) taking
-/// payments into account.
-///
-/// Only allows for `TeleportAsset`, `WithdrawAsset`, `ClaimAsset` and `ReserveAssetDeposit` XCMs
-/// because they are the only ones that place assets in the Holding Register to pay for execution.
-pub struct AllowTopLevelPaidExecutionFrom<T>(PhantomData<T>);
-impl<T: Contains<Location>> ShouldExecute for AllowTopLevelPaidExecutionFrom<T> {
-    fn should_execute<RuntimeCall>(
-        origin: &Location,
-        instructions: &mut [Instruction<RuntimeCall>],
-        max_weight: Weight,
-        _properties: &mut Properties,
-    ) -> Result<(), ProcessMessageError> {
-        log::trace!(
-            target: "xcm::barriers",
-            "AllowTopLevelPaidExecutionFrom origin: {:?}, instructions: {:?}, max_weight: {:?}, properties: {:?}",
-            origin, instructions, max_weight, _properties,
-        );
-
-        ensure!(T::contains(origin), ProcessMessageError::Unsupported);
-        // We will read up to 5 instructions. This allows up to 3 `ClearOrigin` instructions. We
-        // allow for more than one since anything beyond the first is a no-op and it's conceivable
-        // that composition of operations might result in more than one being appended.
-        let end = instructions.len().min(5);
-        instructions[..end]
-            .matcher()
-            .match_next_inst(|inst| match inst {
-                ReceiveTeleportedAsset(..) | ReserveAssetDeposited(..) => Ok(()),
-                WithdrawAsset(ref assets) if assets.len() <= MAX_ASSETS_FOR_BUY_EXECUTION => Ok(()),
-                ClaimAsset { ref assets, .. } if assets.len() <= MAX_ASSETS_FOR_BUY_EXECUTION => {
-                    Ok(())
-                }
-                _ => Err(ProcessMessageError::BadFormat),
-            })?
-            .skip_inst_while(|inst| matches!(inst, ClearOrigin))?
-            .match_next_inst(|inst| match inst {
-                BuyExecution {
-                    weight_limit: Limited(ref mut weight),
-                    ..
-                } if weight.all_gte(max_weight) => {
-                    *weight = max_weight;
-                    Ok(())
-                }
-                BuyExecution {
-                    ref mut weight_limit,
-                    ..
-                } if weight_limit == &Unlimited => {
-                    *weight_limit = Limited(max_weight);
-                    Ok(())
-                }
-                _ => Err(ProcessMessageError::Overweight(max_weight)),
-            })?;
-        Ok(())
     }
 }

--- a/primitives/src/xcm/tests.rs
+++ b/primitives/src/xcm/tests.rs
@@ -202,7 +202,7 @@ fn fixed_rate_of_foreign_asset_buy_is_ok() {
         panic!("Should have been `Ok` wrapped Assets!");
     }
 
-    // 3. Buy even more weight, but use a different type of asset now while reusing the old trader instance.
+    // 3. Buying with a *different* asset on the same trader instance must be rejected.
     let (old_weight, old_consumed) = (fixed_rate_trader.weight, fixed_rate_trader.consumed);
 
     // Note that the concrete asset type differs now from previous buys
@@ -219,28 +219,51 @@ fn fixed_rate_of_foreign_asset_buy_is_ok() {
     );
     assert!(expected_execution_fee > 0); // sanity check
 
-    let result = fixed_rate_trader.buy_weight(weight, payment_multi_asset.clone().into(), &ctx);
-    if let Ok(assets) = result {
-        // We expect only one unused payment asset and specific amount
-        assert_eq!(assets.len(), 1);
-        assert_ok!(assets.ensure_contains(
-            &Asset::from(((*PARACHAIN).clone(), total_payment - expected_execution_fee)).into()
-        ));
+    assert_eq!(
+        fixed_rate_trader.buy_weight(weight, payment_multi_asset.into(), &ctx),
+        Err(XcmError::NotWithdrawable)
+    );
 
-        assert_eq!(fixed_rate_trader.weight, weight + old_weight);
-        // We don't expect this to change since trader already contains data about previous asset type.
-        // Current rule is not to update in this case.
-        assert_eq!(fixed_rate_trader.consumed, old_consumed);
-        assert_eq!(
-            fixed_rate_trader.asset_location_and_units_per_second,
-            Some((
-                PARENT,
-                ExecutionPayment::get_units_per_second(PARENT).unwrap()
-            ))
-        );
-    } else {
-        panic!("Should have been `Ok` wrapped Assets!");
-    }
+    // Trader state must be untouched by the rejected buy.
+    assert_eq!(fixed_rate_trader.weight, old_weight);
+    assert_eq!(fixed_rate_trader.consumed, old_consumed);
+    assert_eq!(
+        fixed_rate_trader.asset_location_and_units_per_second,
+        Some((
+            PARENT,
+            ExecutionPayment::get_units_per_second(PARENT).unwrap()
+        ))
+    );
+}
+
+/// `refund_weight` must never return more of the fee asset than `buy_weight` actually took,
+/// otherwise the surplus is minted into the holding register out of nothing.
+#[test]
+fn fixed_rate_of_foreign_asset_refund_is_capped_by_what_was_paid() {
+    let mut fixed_rate_trader = FixedRateOfForeignAsset::<ExecutionPayment, ()>::new();
+    let ctx = XcmContext {
+        origin: Some(Location::here()),
+        message_id: XcmHash::default(),
+        topic: None,
+    };
+
+    let weight: Weight = Weight::from_parts(1_000_000_000, 0);
+    let paid = execution_fee(
+        weight,
+        ExecutionPayment::get_units_per_second(PARENT).unwrap(),
+    );
+    assert!(paid > 0); // sanity check
+    assert_ok!(fixed_rate_trader.buy_weight(weight, Asset::from((PARENT, paid)).into(), &ctx));
+    assert_eq!(fixed_rate_trader.consumed, paid);
+
+    // Ask to refund far more weight than was ever bought.
+    let refund = fixed_rate_trader
+        .refund_weight(Weight::from_parts(u64::MAX, u64::MAX), &ctx)
+        .expect("something was bought, so something is refundable");
+
+    assert_eq!(refund, (PARENT, paid).into());
+    assert!(fixed_rate_trader.consumed.is_zero());
+    assert!(fixed_rate_trader.weight.is_zero());
 }
 
 #[test]

--- a/runtime/astar/src/weights/xcm/mod.rs
+++ b/runtime/astar/src/weights/xcm/mod.rs
@@ -69,8 +69,8 @@ where
             .saturating_mul(assets.inner().into_iter().count() as u64)
     }
 
-    fn reserve_asset_deposited(_assets: &Assets) -> XCMWeight {
-        XcmFungibleWeight::<Runtime>::reserve_asset_deposited()
+    fn reserve_asset_deposited(assets: &Assets) -> XCMWeight {
+        assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::reserve_asset_deposited())
     }
     fn receive_teleported_asset(assets: &Assets) -> XCMWeight {
         assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::receive_teleported_asset())
@@ -133,14 +133,15 @@ where
         Weight::MAX
     }
     fn initiate_reserve_withdraw(
-        _assets: &AssetFilter,
+        assets: &AssetFilter,
         _reserve: &Location,
         _xcm: &Xcm<()>,
     ) -> XCMWeight {
-        // This is not correct. initiate reserve withdraw does not to that many db reads
-        // the only thing it does based on number of assets is a take from a local variable
-        //assets.weigh_multi_assets(XcmGeneric::<Runtime>::initiate_reserve_withdraw())
-        XcmFungibleWeight::<Runtime>::initiate_reserve_withdraw()
+        // The executor reanchors and re-encodes every matched asset, so this is linear in the
+        // number of assets taken out of holding.
+        // The base weight is a floor: a filter that matches nothing still builds and sends a message.
+        let base = XcmFungibleWeight::<Runtime>::initiate_reserve_withdraw();
+        assets.weigh_multi_assets_filter(base).max(base)
     }
     fn initiate_teleport(_assets: &AssetFilter, _dest: &Location, _xcm: &Xcm<()>) -> XCMWeight {
         XcmFungibleWeight::<Runtime>::initiate_teleport()

--- a/runtime/astar/src/xcm_config.rs
+++ b/runtime/astar/src/xcm_config.rs
@@ -41,11 +41,12 @@ use polkadot_runtime_common::xcm_sender::NoPriceForMessageDelivery;
 use xcm::latest::prelude::*;
 use xcm_builder::{
     Account32Hash, AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
-    AllowUnpaidExecutionFrom, ConvertedConcreteId, EnsureXcmOrigin, FrameTransactionalProcessor,
-    FungibleAdapter, FungiblesAdapter, IsConcrete, NoChecking, ParentAsSuperuser, ParentIsPreset,
-    RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
-    SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit,
-    TrailingSetTopicAsId, UsingComponents, WeightInfoBounds, WithComputedOrigin,
+    AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom, ConvertedConcreteId, EnsureXcmOrigin,
+    FrameTransactionalProcessor, FungibleAdapter, FungiblesAdapter, IsConcrete, NoChecking,
+    ParentAsSuperuser, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
+    SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
+    SovereignSignedViaLocation, TakeWeightCredit, TrailingSetTopicAsId, UsingComponents,
+    WeightInfoBounds, WithComputedOrigin,
 };
 use xcm_executor::{
     traits::{JustTry, WithOriginFilter},
@@ -57,8 +58,8 @@ use orml_xcm_support::DisabledParachainFee;
 
 // Astar imports
 use astar_primitives::xcm::{
-    AbsoluteAndRelativeReserveProvider, AccountIdToMultiLocation, AllowTopLevelPaidExecutionFrom,
-    FixedRateOfForeignAsset, ReserveAssetFilter, XcmFungibleFeeHandler,
+    AbsoluteAndRelativeReserveProvider, AccountIdToMultiLocation, FixedRateOfForeignAsset,
+    ReserveAssetFilter, XcmFungibleFeeHandler,
 };
 
 parameter_types! {

--- a/runtime/shibuya/src/weights/xcm/mod.rs
+++ b/runtime/shibuya/src/weights/xcm/mod.rs
@@ -69,8 +69,8 @@ where
             .saturating_mul(assets.inner().into_iter().count() as u64)
     }
 
-    fn reserve_asset_deposited(_assets: &Assets) -> XCMWeight {
-        XcmFungibleWeight::<Runtime>::reserve_asset_deposited()
+    fn reserve_asset_deposited(assets: &Assets) -> XCMWeight {
+        assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::reserve_asset_deposited())
     }
     fn receive_teleported_asset(assets: &Assets) -> XCMWeight {
         assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::receive_teleported_asset())
@@ -133,14 +133,15 @@ where
         Weight::MAX
     }
     fn initiate_reserve_withdraw(
-        _assets: &AssetFilter,
+        assets: &AssetFilter,
         _reserve: &Location,
         _xcm: &Xcm<()>,
     ) -> XCMWeight {
-        // This is not correct. initiate reserve withdraw does not to that many db reads
-        // the only thing it does based on number of assets is a take from a local variable
-        //assets.weigh_multi_assets(XcmGeneric::<Runtime>::initiate_reserve_withdraw())
-        XcmFungibleWeight::<Runtime>::initiate_reserve_withdraw()
+        // The executor reanchors and re-encodes every matched asset, so this is linear in the
+        // number of assets taken out of holding.
+        // The base weight is a floor: a filter that matches nothing still builds and sends a message.
+        let base = XcmFungibleWeight::<Runtime>::initiate_reserve_withdraw();
+        assets.weigh_multi_assets_filter(base).max(base)
     }
     fn initiate_teleport(_assets: &AssetFilter, _dest: &Location, _xcm: &Xcm<()>) -> XCMWeight {
         XcmFungibleWeight::<Runtime>::initiate_teleport()

--- a/runtime/shibuya/src/xcm_config.rs
+++ b/runtime/shibuya/src/xcm_config.rs
@@ -40,10 +40,11 @@ use parachains_common::{
 use polkadot_runtime_common::xcm_sender::NoPriceForMessageDelivery;
 use xcm::{latest::prelude::*, v5::ROCOCO_GENESIS_HASH};
 use xcm_builder::{
-    AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom, AllowUnpaidExecutionFrom,
-    ConvertedConcreteId, DescribeAllTerminal, DescribeFamily, EnsureXcmOrigin,
-    FrameTransactionalProcessor, FungibleAdapter, FungiblesAdapter, HashedDescription, IsConcrete,
-    NoChecking, ParentAsSuperuser, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
+    AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
+    AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom, ConvertedConcreteId,
+    DescribeAllTerminal, DescribeFamily, EnsureXcmOrigin, FrameTransactionalProcessor,
+    FungibleAdapter, FungiblesAdapter, HashedDescription, IsConcrete, NoChecking,
+    ParentAsSuperuser, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
     SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
     SovereignSignedViaLocation, TakeWeightCredit, TrailingSetTopicAsId, UsingComponents,
     WeightInfoBounds, WithComputedOrigin,
@@ -55,8 +56,8 @@ use orml_xcm_support::DisabledParachainFee;
 
 // Astar imports
 use astar_primitives::xcm::{
-    AbsoluteAndRelativeReserveProvider, AccountIdToMultiLocation, AllowTopLevelPaidExecutionFrom,
-    FixedRateOfForeignAsset, ReserveAssetFilter, XcmFungibleFeeHandler, MAX_ASSETS,
+    AbsoluteAndRelativeReserveProvider, AccountIdToMultiLocation, FixedRateOfForeignAsset,
+    ReserveAssetFilter, XcmFungibleFeeHandler, MAX_ASSETS,
 };
 
 parameter_types! {

--- a/runtime/shiden/src/weights/xcm/mod.rs
+++ b/runtime/shiden/src/weights/xcm/mod.rs
@@ -69,8 +69,8 @@ where
             .saturating_mul(assets.inner().into_iter().count() as u64)
     }
 
-    fn reserve_asset_deposited(_assets: &Assets) -> XCMWeight {
-        XcmFungibleWeight::<Runtime>::reserve_asset_deposited()
+    fn reserve_asset_deposited(assets: &Assets) -> XCMWeight {
+        assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::reserve_asset_deposited())
     }
     fn receive_teleported_asset(assets: &Assets) -> XCMWeight {
         assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::receive_teleported_asset())
@@ -133,14 +133,15 @@ where
         Weight::MAX
     }
     fn initiate_reserve_withdraw(
-        _assets: &AssetFilter,
+        assets: &AssetFilter,
         _reserve: &Location,
         _xcm: &Xcm<()>,
     ) -> XCMWeight {
-        // This is not correct. initiate reserve withdraw does not to that many db reads
-        // the only thing it does based on number of assets is a take from a local variable
-        //assets.weigh_multi_assets(XcmGeneric::<Runtime>::initiate_reserve_withdraw())
-        XcmFungibleWeight::<Runtime>::initiate_reserve_withdraw()
+        // The executor reanchors and re-encodes every matched asset, so this is linear in the
+        // number of assets taken out of holding.
+        // The base weight is a floor: a filter that matches nothing still builds and sends a message.
+        let base = XcmFungibleWeight::<Runtime>::initiate_reserve_withdraw();
+        assets.weigh_multi_assets_filter(base).max(base)
     }
     fn initiate_teleport(_assets: &AssetFilter, _dest: &Location, _xcm: &Xcm<()>) -> XCMWeight {
         XcmFungibleWeight::<Runtime>::initiate_teleport()

--- a/runtime/shiden/src/xcm_config.rs
+++ b/runtime/shiden/src/xcm_config.rs
@@ -40,10 +40,11 @@ use parachains_common::{
 use polkadot_runtime_common::xcm_sender::NoPriceForMessageDelivery;
 use xcm::latest::prelude::*;
 use xcm_builder::{
-    AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom, AllowUnpaidExecutionFrom,
-    ConvertedConcreteId, DescribeAllTerminal, DescribeFamily, EnsureXcmOrigin,
-    FrameTransactionalProcessor, FungibleAdapter, FungiblesAdapter, HashedDescription, IsConcrete,
-    NoChecking, ParentAsSuperuser, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
+    AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
+    AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom, ConvertedConcreteId,
+    DescribeAllTerminal, DescribeFamily, EnsureXcmOrigin, FrameTransactionalProcessor,
+    FungibleAdapter, FungiblesAdapter, HashedDescription, IsConcrete, NoChecking,
+    ParentAsSuperuser, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
     SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
     SovereignSignedViaLocation, TakeWeightCredit, TrailingSetTopicAsId, UsingComponents,
     WeightInfoBounds, WithComputedOrigin,
@@ -58,8 +59,8 @@ use orml_xcm_support::DisabledParachainFee;
 
 // Astar imports
 use astar_primitives::xcm::{
-    AbsoluteAndRelativeReserveProvider, AccountIdToMultiLocation, AllowTopLevelPaidExecutionFrom,
-    FixedRateOfForeignAsset, ReserveAssetFilter, XcmFungibleFeeHandler,
+    AbsoluteAndRelativeReserveProvider, AccountIdToMultiLocation, FixedRateOfForeignAsset,
+    ReserveAssetFilter, XcmFungibleFeeHandler,
 };
 
 parameter_types! {

--- a/tests/xcm-simulator/src/mocks/parachain.rs
+++ b/tests/xcm-simulator/src/mocks/parachain.rs
@@ -48,9 +48,9 @@ use parachains_common::xcm_config::ParentRelayOrSiblingParachains;
 use xcm::latest::prelude::{AssetId as XcmAssetId, *};
 use xcm_builder::{
     Account32Hash, AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
-    AllowUnpaidExecutionFrom, ConvertedConcreteId, EnsureXcmOrigin, FixedRateOfFungible,
-    FixedWeightBounds, FungibleAdapter, FungiblesAdapter, IsConcrete, NoChecking,
-    ParentAsSuperuser, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
+    AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom, ConvertedConcreteId, EnsureXcmOrigin,
+    FixedRateOfFungible, FixedWeightBounds, FungibleAdapter, FungiblesAdapter, IsConcrete,
+    NoChecking, ParentAsSuperuser, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
     SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
     SovereignSignedViaLocation, TakeWeightCredit, TrailingSetTopicAsId, WithComputedOrigin,
 };
@@ -62,9 +62,8 @@ use xcm_executor::{traits::JustTry, XcmExecutor};
 use astar_primitives::{
     dapp_staking::{AccountCheck, CycleConfiguration, SmartContract, StakingRewardHandler},
     xcm::{
-        AbsoluteAndRelativeReserveProvider, AllowTopLevelPaidExecutionFrom,
-        AssetLocationIdConverter, FixedRateOfForeignAsset, ReserveAssetFilter,
-        XcmFungibleFeeHandler,
+        AbsoluteAndRelativeReserveProvider, AssetLocationIdConverter, FixedRateOfForeignAsset,
+        ReserveAssetFilter, XcmFungibleFeeHandler,
     },
 };
 


### PR DESCRIPTION
# Pull Request Summary

This PR adjusts some XCM config elements without adding capability:
- Outdated forked primitive `AllowTopLevelPaidExecutionFrom` is removed and the upstream one is now used
- The foreign-asset trader only supports 1 asset for `buy_execution`
- `ReserveAssetDeposited` and `InitiateReserveWithdraw` are now weighed properly if multiple assets