### PR TITLE
chore: remove orml deps

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist.md
+++ b/.github/ISSUE_TEMPLATE/release_checklist.md
@@ -10,7 +10,7 @@ assignees: ''
 <!---
 All the preparation specific for this release, for example
 - [x] Test batch precompile in Astar & Shiden
-- [x] Test xtokens in Astar
+- [x] Test the XCM precompile in Astar
 -->
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,7 +744,6 @@ dependencies = [
  "impl-trait-for-tuples",
  "log",
  "once_cell",
- "orml-traits",
  "pallet-assets",
  "pallet-balances",
  "pallet-collective",
@@ -801,8 +800,6 @@ dependencies = [
  "moonbeam-rpc-primitives-debug",
  "moonbeam-rpc-primitives-txpool",
  "num_enum",
- "orml-xcm-support",
- "orml-xtokens",
  "pallet-assets",
  "pallet-aura",
  "pallet-authorship",
@@ -8604,77 +8601,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "orml-traits"
-version = "1.5.0"
-source = "git+https://github.com/AstarNetwork/open-runtime-module-library?branch=stable2512#99b8ce55b4f2d06673b8405f66bee967745aae7a"
-dependencies = [
- "frame-support",
- "impl-trait-for-tuples",
- "num-traits",
- "orml-utilities",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "staging-xcm",
-]
-
-[[package]]
-name = "orml-utilities"
-version = "1.5.0"
-source = "git+https://github.com/AstarNetwork/open-runtime-module-library?branch=stable2512#99b8ce55b4f2d06673b8405f66bee967745aae7a"
-dependencies = [
- "frame-support",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "orml-xcm-support"
-version = "1.5.0"
-source = "git+https://github.com/AstarNetwork/open-runtime-module-library?branch=stable2512#99b8ce55b4f2d06673b8405f66bee967745aae7a"
-dependencies = [
- "frame-support",
- "orml-traits",
- "parity-scale-codec",
- "sp-runtime",
- "sp-std",
- "staging-xcm",
- "staging-xcm-executor",
-]
-
-[[package]]
-name = "orml-xtokens"
-version = "1.5.0"
-source = "git+https://github.com/AstarNetwork/open-runtime-module-library?branch=stable2512#99b8ce55b4f2d06673b8405f66bee967745aae7a"
-dependencies = [
- "frame-support",
- "frame-system",
- "log",
- "orml-traits",
- "orml-xcm-support",
- "pallet-xcm",
- "parachains-common",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-io",
- "sp-runtime",
- "sp-std",
- "staging-xcm",
- "staging-xcm-executor",
-]
-
-[[package]]
 name = "pallet-asset-conversion"
 version = "27.0.0"
 source = "git+https://github.com/paritytech/polkadot-sdk?branch=stable2512#ba6a0d23259cdc3108f70997a6847e7bc5b28794"
@@ -9488,9 +9414,6 @@ dependencies = [
  "log",
  "num_enum",
  "once_cell",
- "orml-traits",
- "orml-xcm-support",
- "orml-xtokens",
  "pallet-assets",
  "pallet-balances",
  "pallet-evm",
@@ -15206,8 +15129,6 @@ dependencies = [
  "moonbeam-rpc-primitives-debug",
  "moonbeam-rpc-primitives-txpool",
  "num_enum",
- "orml-xcm-support",
- "orml-xtokens",
  "pallet-assets",
  "pallet-aura",
  "pallet-authorship",
@@ -15325,8 +15246,6 @@ dependencies = [
  "moonbeam-rpc-primitives-debug",
  "moonbeam-rpc-primitives-txpool",
  "num_enum",
- "orml-xcm-support",
- "orml-xtokens",
  "pallet-assets",
  "pallet-aura",
  "pallet-authorship",
@@ -19419,9 +19338,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "log",
- "orml-traits",
- "orml-xcm-support",
- "orml-xtokens",
  "pallet-assets",
  "pallet-balances",
  "pallet-contracts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -299,12 +299,6 @@ xcm-runtime-apis = { git = "https://github.com/paritytech/polkadot-sdk", branch 
 polkadot-cli = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2512" }
 polkadot-service = { git = "https://github.com/paritytech/polkadot-sdk", branch = "stable2512" }
 
-# ORML
-# (wasm)
-orml-xtokens = { git = "https://github.com/AstarNetwork/open-runtime-module-library", branch = "stable2512", default-features = false }
-orml-traits = { git = "https://github.com/AstarNetwork/open-runtime-module-library", branch = "stable2512", default-features = false }
-orml-xcm-support = { git = "https://github.com/AstarNetwork/open-runtime-module-library", branch = "stable2512", default-features = false }
-
 # Astar pallets & modules
 # (wasm)
 pallet-collator-selection = { path = "./pallets/collator-selection", default-features = false }

--- a/precompiles/xcm/Cargo.toml
+++ b/precompiles/xcm/Cargo.toml
@@ -33,9 +33,6 @@ fp-evm = { workspace = true }
 pallet-evm = { workspace = true }
 
 # Polkadot
-orml-traits = { workspace = true }
-orml-xcm-support = { workspace = true }
-orml-xtokens = { workspace = true }
 xcm = { workspace = true }
 xcm-executor = { workspace = true }
 
@@ -71,9 +68,6 @@ std = [
 	"sp-io/std",
 	"xcm/std",
 	"xcm-executor/std",
-	"orml-xtokens/std",
-	"orml-xcm-support/std",
-	"orml-traits/std",
 	"astar-primitives/std",
 	"log/std",
 	"num_enum/std",
@@ -85,7 +79,6 @@ runtime-benchmarks = [
 	"astar-primitives/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
-	"orml-xtokens/runtime-benchmarks",
 	"pallet-evm/runtime-benchmarks",
 	"pallet-evm-precompile-assets-erc20/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",

--- a/precompiles/xcm/XCM.sol
+++ b/precompiles/xcm/XCM.sol
@@ -1,7 +1,11 @@
 pragma solidity ^0.8.0;
 
 /**
- * @title XCM interface.
+ * @title XCM interface (v1).
+ *
+ * @dev Only `assets_withdraw(address[],uint256[],bytes32,bool,uint256,uint256)` is still
+ * operational. Every other method in this interface is DEPRECATED: the selector stays registered
+ * so the ABI is unchanged, but calling it always reverts.
  */
 interface XCM {
 
@@ -39,6 +43,8 @@ interface XCM {
      * How method check that assets list is valid:
      * - all assets resolved to multi-location (on runtime level)
      * - all assets has corresponded amount (lenght of assets list matched to amount list)
+     *
+     * @custom:deprecated ALWAYS REVERTS. Use the `bytes32` overload of `assets_withdraw`.
      */
     function assets_withdraw(
         address[] calldata asset_id,
@@ -57,6 +63,9 @@ interface XCM {
      * @param call - encoded call data (must be decodable by remote chain)
      * @param transact_weight - max weight that the encoded call is allowed to consume in the destination chain
      * @return bool confirmation whether the XCM message sent.
+     *
+     * @custom:deprecated ALWAYS REVERTS. It was already unreachable - the runtimes' `SendXcmOrigin`
+     * rejects signed origins, so this could only ever revert.
      */
     function remote_transact(
         uint256 parachain_id,
@@ -79,6 +88,8 @@ interface XCM {
      * How method check that assets list is valid:
      * - all assets resolved to multi-location (on runtime level)
      * - all assets has corresponded amount (lenght of assets list matched to amount list)
+     *
+     * @custom:deprecated ALWAYS REVERTS. Use the `bytes32` overload of `assets_withdraw`.
      */
     function assets_reserve_transfer(
         address[] calldata asset_id,
@@ -101,6 +112,8 @@ interface XCM {
      * How method check that assets list is valid:
      * - all assets resolved to multi-location (on runtime level)
      * - all assets has corresponded amount (lenght of assets list matched to amount list)
+     *
+     * @custom:deprecated ALWAYS REVERTS. Use the `bytes32` overload of `assets_withdraw`.
      */
     function assets_reserve_transfer(
         address[] calldata asset_id,
@@ -110,5 +123,5 @@ interface XCM {
         uint256   parachain_id,
         uint256   fee_index
     ) external returns (bool);
-    
+
 }

--- a/precompiles/xcm/XCM_v2.sol
+++ b/precompiles/xcm/XCM_v2.sol
@@ -3,7 +3,14 @@ pragma solidity ^0.8.0;
 
 
 /**
- * @title XCM interface.
+ * @title XCM interface (v2).
+ *
+ * @dev Both this file and `XCM.sol` document the SAME precompile, registered at `0x...5004` on
+ * Astar, Shiden and Shibuya alike - there is no per-network split.
+ *
+ * Only `transfer(address,uint256,(uint8,bytes[]),(uint64,uint64))` is still operational. Every
+ * other method in this interface is DEPRECATED: the selector stays registered so the ABI is
+ * unchanged, but calling it always reverts.
  */
 interface XCM {
     // A multilocation is defined by its number of parents and the encoded junctions (interior)
@@ -53,6 +60,7 @@ interface XCM {
     /// @param destination The Multilocation to which we want to send the tokens
     /// @param weight The weight we want to buy in the destination chain, to set the
     /// weightlimit to Unlimited, you should use the value 0 for ref_time
+    /// @custom:deprecated ALWAYS REVERTS. Use `transfer`; the destination charges fees from the transferred asset.
     function transfer_with_fee(
         address currencyAddress,
         uint256 amount,
@@ -70,6 +78,7 @@ interface XCM {
     /// @param destination The Multilocation to which we want to send the tokens
     /// @param weight The weight we want to buy in the destination chain, to set the
     /// weightlimit to Unlimited, you should use the value 0 for ref_time
+    /// @custom:deprecated ALWAYS REVERTS. Use `transfer` with the asset's XC20 address.
     function transfer_multiasset(
         Multilocation memory asset,
         uint256 amount,
@@ -87,6 +96,7 @@ interface XCM {
     /// @param destination The Multilocation to which we want to send the tokens
     /// @param weight The weight we want to buy in the destination chain, to set the
     /// weightlimit to Unlimited, you should use the value 0 for ref_time
+    /// @custom:deprecated ALWAYS REVERTS. Use `transfer` with the asset's XC20 address.
     function transfer_multiasset_with_fee(
         Multilocation memory asset,
         uint256 amount,
@@ -103,6 +113,7 @@ interface XCM {
     /// @param destination The Multilocation to which we want to send the tokens
     /// @param weight The weight we want to buy in the destination chain, to set the
     /// weightlimit to Unlimited, you should use the value 0 for ref_time
+    /// @custom:deprecated ALWAYS REVERTS. Use `assets_withdraw` from `XCM.sol` for multi-asset transfers.
     function transfer_multi_currencies(
         Currency[] memory currencies,
         uint32 feeItem,
@@ -118,6 +129,7 @@ interface XCM {
     /// @param destination The Multilocation to which we want to send the tokens
     /// @param weight The weight we want to buy in the destination chain, to set the
     /// weightlimit to Unlimited, you should use the value 0 for ref_time
+    /// @custom:deprecated ALWAYS REVERTS. Use `assets_withdraw` from `XCM.sol` for multi-asset transfers.
     function transfer_multi_assets(
         MultiAsset[] memory assets,
         uint32 feeItem,
@@ -128,7 +140,9 @@ interface XCM {
     /**
      * @param destination - Multilocation of destination chain where to send this call
      * @param xcm_call - encoded xcm call you want to send to destination
-     **/
+     *
+     * @custom:deprecated ALWAYS REVERTS. It was already unreachable - the runtimes' `SendXcmOrigin` rejects signed origins.
+     */
     function send_xcm(
         Multilocation memory destination,
         bytes memory xcm_call

--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -18,24 +18,25 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use astar_primitives::xcm::XCM_SIZE_LIMIT;
+use astar_primitives::xcm::{
+    resolve_transfer_type, split_location_into_chain_part_and_beneficiary, XCM_SIZE_LIMIT,
+};
 use fp_evm::PrecompileHandle;
 use frame_support::{
     dispatch::{GetDispatchInfo, PostDispatchInfo},
     pallet_prelude::Weight,
-    traits::{ConstU32, Get},
+    traits::ConstU32,
 };
 use sp_runtime::traits::{Dispatchable, MaybeEquivalence};
-type GetXcmSizeLimit = ConstU32<XCM_SIZE_LIMIT>;
 
 use pallet_evm::AddressMapping;
-use parity_scale_codec::DecodeLimit;
 use sp_core::{H160, H256, U256};
 
 use sp_std::marker::PhantomData;
 use sp_std::prelude::*;
 
-use xcm::{latest::prelude::*, VersionedAsset, VersionedAssets, VersionedLocation};
+use xcm::{latest::prelude::*, VersionedAssetId, VersionedAssets, VersionedLocation, VersionedXcm};
+use xcm_executor::traits::TransferType;
 
 use pallet_evm_precompile_assets_erc20::AddressToAssetId;
 use precompile_utils::prelude::*;
@@ -47,21 +48,19 @@ mod tests;
 /// Dummy H160 address representing native currency (e.g. ASTR or SDN)
 const NATIVE_ADDRESS: H160 = H160::zero();
 
-/// Default proof_size of 256KB
-const DEFAULT_PROOF_SIZE: u64 = 1024 * 256;
+/// Bound for the SCALE-encoded XCM blob accepted by the (deprecated) `send_xcm`.
+type GetXcmSizeLimit = ConstU32<XCM_SIZE_LIMIT>;
 
-pub type XBalanceOf<Runtime> = <Runtime as orml_xtokens::Config>::Balance;
+/// Max number of assets a single cross-chain transfer may carry.
+pub const MAX_ASSETS_FOR_TRANSFER: u32 = 2;
 
-pub struct GetMaxAssets<R>(PhantomData<R>);
+/// Bound for the `BoundedVec` arguments of the asset-list based methods.
+pub type GetMaxAssets = ConstU32<MAX_ASSETS_FOR_TRANSFER>;
 
-impl<R> Get<u32> for GetMaxAssets<R>
-where
-    R: orml_xtokens::Config,
-{
-    fn get() -> u32 {
-        <R as orml_xtokens::Config>::MaxAssetsForTransfer::get() as u32
-    }
-}
+/// Revert reason shared by every deprecated selector.
+const DEPRECATED: &str =
+    "deprecated: xtokens has been removed. Use assets_withdraw(address[],uint256[],bytes32,bool,uint256,uint256) \
+     or transfer(address,uint256,(uint8,bytes[]),(uint64,uint64))";
 
 /// A precompile that expose XCM related functions.
 pub struct XcmPrecompile<Runtime, C>(PhantomData<(Runtime, C)>);
@@ -72,84 +71,36 @@ impl<Runtime, C> XcmPrecompile<Runtime, C>
 where
     Runtime: pallet_evm::Config
         + pallet_xcm::Config
-        + orml_xtokens::Config
         + pallet_assets::Config
         + AddressToAssetId<<Runtime as pallet_assets::Config>::AssetId>,
     <<Runtime as frame_system::Config>::RuntimeCall as Dispatchable>::RuntimeOrigin:
         From<Option<Runtime::AccountId>>,
-    <Runtime as frame_system::Config>::AccountId: Into<[u8; 32]>,
     <Runtime as frame_system::Config>::RuntimeCall: From<pallet_xcm::Call<Runtime>>
-        + From<orml_xtokens::Call<Runtime>>
         + Dispatchable<PostInfo = PostDispatchInfo>
         + GetDispatchInfo,
-    XBalanceOf<Runtime>: TryFrom<U256> + Into<U256> + From<u128>,
-    <Runtime as orml_xtokens::Config>::CurrencyId:
-        From<<Runtime as pallet_assets::Config>::AssetId>,
     C: MaybeEquivalence<Location, <Runtime as pallet_assets::Config>::AssetId>,
     <Runtime as pallet_evm::Config>::AddressMapping: AddressMapping<Runtime::AccountId>,
 {
+    /// Reserve-transfer a list of XC20 assets to an `AccountId32` beneficiary on the relay chain
+    /// or on a sibling parachain.
     #[precompile::public("assets_withdraw(address[],uint256[],bytes32,bool,uint256,uint256)")]
     fn assets_withdraw_native_v1(
         handle: &mut impl PrecompileHandle,
-        assets: BoundedVec<Address, GetMaxAssets<Runtime>>,
-        amounts: BoundedVec<U256, GetMaxAssets<Runtime>>,
+        assets: BoundedVec<Address, GetMaxAssets>,
+        amounts: BoundedVec<U256, GetMaxAssets>,
         recipient_account_id: H256,
         is_relay: bool,
         parachain_id: U256,
         fee_index: U256,
     ) -> EvmResult<bool> {
-        let beneficiary: Junction = Junction::AccountId32 {
+        let beneficiary: Location = Junction::AccountId32 {
             network: None,
             id: recipient_account_id.into(),
         }
         .into();
-        Self::assets_withdraw_v1_internal(
-            handle,
-            assets.into(),
-            amounts.into(),
-            beneficiary,
-            is_relay,
-            parachain_id,
-            fee_index,
-        )
-    }
 
-    #[precompile::public("assets_withdraw(address[],uint256[],address,bool,uint256,uint256)")]
-    fn assets_withdraw_evm_v1(
-        handle: &mut impl PrecompileHandle,
-        assets: BoundedVec<Address, GetMaxAssets<Runtime>>,
-        amounts: BoundedVec<U256, GetMaxAssets<Runtime>>,
-        recipient_account_id: Address,
-        is_relay: bool,
-        parachain_id: U256,
-        fee_index: U256,
-    ) -> EvmResult<bool> {
-        let beneficiary: Junction = Junction::AccountKey20 {
-            network: None,
-            key: recipient_account_id.0.to_fixed_bytes(),
-        }
-        .into();
-        Self::assets_withdraw_v1_internal(
-            handle,
-            assets.into(),
-            amounts.into(),
-            beneficiary,
-            is_relay,
-            parachain_id,
-            fee_index,
-        )
-    }
-
-    fn assets_withdraw_v1_internal(
-        handle: &mut impl PrecompileHandle,
-        assets: Vec<Address>,
-        amounts: Vec<U256>,
-        beneficiary: Junction,
-        is_relay: bool,
-        parachain_id: U256,
-        fee_index: U256,
-    ) -> EvmResult<bool> {
-        // Read arguments and check it
+        // Read arguments and check them
+        let assets: Vec<Address> = assets.into();
         let assets = assets
             .iter()
             .cloned()
@@ -158,6 +109,7 @@ where
             })
             .collect::<Vec<Location>>();
 
+        let amounts: Vec<U256> = amounts.into();
         let amounts = amounts
             .into_iter()
             .map(|x| x.try_into())
@@ -175,198 +127,31 @@ where
             .try_into()
             .map_err(|_| revert("error converting parachain_id, maybe value too large"))?;
 
-        let fee_item: u32 = fee_index
+        let fee_asset_item: u32 = fee_index
             .try_into()
             .map_err(|_| revert("error converting fee_index, maybe value too large"))?;
 
-        let mut destination = if is_relay {
+        let destination = if is_relay {
             Location::parent()
         } else {
             Junctions::from(Junction::Parachain(parachain_id)).into_exterior(1)
         };
 
-        destination
-            .push_interior(beneficiary)
-            .map_err(|_| revert("error building destination multilocation"))?;
-
-        let assets = assets
-            .iter()
-            .cloned()
-            .zip(amounts.iter().cloned())
-            .map(Into::into)
-            .collect::<Vec<Asset>>();
-
-        Self::ensure_dot_transfer_policy(&assets, &destination)?;
-
-        log::trace!(target: "xcm-precompile:assets_withdraw", "Processed arguments: assets {:?}, destination: {:?}", assets, destination);
-
-        // Build call with origin.
-        let origin = Some(Runtime::AddressMapping::into_account_id(
-            handle.context().caller,
-        ))
-        .into();
-
-        let call = orml_xtokens::Call::<Runtime>::transfer_multiassets {
-            assets: Box::new(VersionedAssets::V5(assets.into())),
-            fee_item,
-            dest: Box::new(VersionedLocation::V5(destination)),
-            dest_weight_limit: WeightLimit::Unlimited,
-        };
-
-        // Dispatch a call.
-        RuntimeHelper::<Runtime>::try_dispatch(handle, origin, call, 0)?;
-        Ok(true)
-    }
-
-    #[precompile::public("remote_transact(uint256,bool,address,uint256,bytes,uint64)")]
-    fn remote_transact_v1(
-        handle: &mut impl PrecompileHandle,
-        para_id: U256,
-        is_relay: bool,
-        fee_asset_addr: Address,
-        fee_amount: U256,
-        remote_call: UnboundedBytes,
-        transact_weight: u64,
-    ) -> EvmResult<bool> {
-        // Raw call arguments
-        let para_id: u32 = para_id
-            .try_into()
-            .map_err(|_| revert("error converting para_id, maybe value too large"))?;
-
-        let fee_amount: u128 = fee_amount
-            .try_into()
-            .map_err(|_| revert("error converting fee_amount, maybe value too large"))?;
-
-        let remote_call: Vec<u8> = remote_call.into();
-
-        log::trace!(target: "xcm-precompile:remote_transact", "Raw arguments: para_id: {}, is_relay: {}, fee_asset_addr: {:?}, \
-         fee_amount: {:?}, remote_call: {:?}, transact_weight: {}",
-         para_id, is_relay, fee_asset_addr, fee_amount, remote_call, transact_weight);
-
-        // Process arguments
-        let dest = if is_relay {
-            Location::parent()
-        } else {
-            Junctions::from(Junction::Parachain(para_id)).into_exterior(1)
-        };
-
-        let fee_asset = {
-            let address: H160 = fee_asset_addr.into();
-
-            // Special case where zero address maps to native token by convention.
-            if address == NATIVE_ADDRESS {
-                Here.into()
-            } else {
-                let fee_asset_id = Runtime::address_to_asset_id(address)
-                    .ok_or(revert("Failed to resolve fee asset id from address"))?;
-                C::convert_back(&fee_asset_id).ok_or(revert(
-                    "Failed to resolve fee asset multilocation from local id",
-                ))?
-            }
-        };
-
-        let context = <Runtime as pallet_xcm::Config>::UniversalLocation::get();
-        let fee_multilocation: Asset = (fee_asset, fee_amount).into();
-        let fee_multilocation = fee_multilocation
-            .reanchored(&dest, &context)
-            .map_err(|_| revert("Failed to reanchor fee asset"))?;
-
-        // Prepare XCM
-        let xcm = Xcm(vec![
-            WithdrawAsset(fee_multilocation.clone().into()),
-            BuyExecution {
-                fees: fee_multilocation.clone().into(),
-                weight_limit: WeightLimit::Unlimited,
-            },
-            Transact {
-                origin_kind: OriginKind::SovereignAccount,
-                fallback_max_weight: Some(Weight::from_parts(transact_weight, DEFAULT_PROOF_SIZE)),
-                call: remote_call.into(),
-            },
-        ]);
-
-        log::trace!(target: "xcm-precompile:remote_transact", "Processed arguments: dest: {:?}, fee asset: {:?}, XCM: {:?}", dest, fee_multilocation, xcm);
-
-        // Build call with origin.
-        let origin = Some(Runtime::AddressMapping::into_account_id(
-            handle.context().caller,
-        ))
-        .into();
-        let call = pallet_xcm::Call::<Runtime>::send {
-            dest: Box::new(dest.into()),
-            message: Box::new(xcm::VersionedXcm::V5(xcm)),
-        };
-
-        // Dispatch a call.
-        RuntimeHelper::<Runtime>::try_dispatch(handle, origin, call, 0)?;
-
-        Ok(true)
-    }
-
-    fn assets_reserve_transfer_v1_internal(
-        handle: &mut impl PrecompileHandle,
-        assets: Vec<Address>,
-        amounts: Vec<U256>,
-        beneficiary: Junction,
-        is_relay: bool,
-        parachain_id: U256,
-        fee_item: U256,
-    ) -> EvmResult<bool> {
-        let assets: Vec<Location> = assets
-            .iter()
-            .cloned()
-            .filter_map(|address| {
-                let address: H160 = address.into();
-                // Special case where zero address maps to native token by convention.
-                if address == NATIVE_ADDRESS {
-                    Some(Here.into())
-                } else {
-                    Runtime::address_to_asset_id(address).and_then(|x| C::convert_back(&x))
-                }
-            })
-            .collect();
-
-        let amounts: Vec<u128> = amounts
+        // `Assets` sorts and deduplicates on construction, so `fee_asset_item` has to be resolved
+        // against the sorted list - same as `orml-xtokens` did.
+        let assets: Assets = assets
             .into_iter()
-            .map(|x| x.try_into())
-            .collect::<Result<Vec<u128>, _>>()
-            .map_err(|_| revert("error converting amounts, maybe value too large"))?;
-
-        // Check that assets list is valid:
-        // * all assets resolved to multi-location
-        // * all assets has corresponded amount
-        if assets.len() != amounts.len() || assets.is_empty() {
-            return Err(revert("Assets resolution failure."));
-        }
-
-        let parachain_id: u32 = parachain_id
-            .try_into()
-            .map_err(|_| revert("error converting parachain_id, maybe value too large"))?;
-
-        let fee_item: u32 = fee_item
-            .try_into()
-            .map_err(|_| revert("error converting fee_index, maybe value too large"))?;
-
-        // Prepare pallet-xcm call arguments
-        let mut destination = if is_relay {
-            Location::parent()
-        } else {
-            Junctions::from(Junction::Parachain(parachain_id)).into_exterior(1)
-        };
-
-        destination
-            .push_interior(beneficiary)
-            .map_err(|_| revert("error building destination multilocation"))?;
-
-        let assets = assets
-            .iter()
-            .cloned()
-            .zip(amounts.iter().cloned())
+            .zip(amounts)
             .map(Into::into)
-            .collect::<Vec<Asset>>();
+            .collect::<Vec<Asset>>()
+            .into();
 
-        Self::ensure_dot_transfer_policy(&assets, &destination)?;
-        log::trace!(target: "xcm-precompile:assets_reserve_transfer", "Processed arguments: assets {:?}, destination: {:?}", assets, destination);
+        Self::ensure_dot_transfer_policy(assets.inner(), &destination)?;
+
+        let (assets_transfer_type, fees_transfer_type, fee_asset_id) =
+            Self::resolve_transfer_types(&assets, fee_asset_item, &destination)?;
+
+        log::trace!(target: "xcm-precompile:assets_withdraw", "Processed arguments: assets {:?}, destination: {:?}, beneficiary: {:?}, transfer types: {:?}/{:?}", assets, destination, beneficiary, assets_transfer_type, fees_transfer_type);
 
         // Build call with origin.
         let origin = Some(Runtime::AddressMapping::into_account_id(
@@ -374,109 +159,26 @@ where
         ))
         .into();
 
-        let call = orml_xtokens::Call::<Runtime>::transfer_multiassets {
-            assets: Box::new(VersionedAssets::V5(assets.into())),
-            fee_item,
+        let call = pallet_xcm::Call::<Runtime>::transfer_assets_using_type_and_then {
             dest: Box::new(VersionedLocation::V5(destination)),
-            dest_weight_limit: WeightLimit::Unlimited,
+            assets: Box::new(VersionedAssets::V5(assets.clone())),
+            assets_transfer_type: Box::new(assets_transfer_type),
+            remote_fees_id: Box::new(VersionedAssetId::V5(fee_asset_id)),
+            fees_transfer_type: Box::new(fees_transfer_type),
+            custom_xcm_on_dest: Box::new(VersionedXcm::V5(Self::deposit_to_beneficiary(
+                assets.len() as u32,
+                beneficiary,
+            ))),
+            weight_limit: WeightLimit::Unlimited,
         };
 
         // Dispatch a call.
         RuntimeHelper::<Runtime>::try_dispatch(handle, origin, call, 0)?;
-
         Ok(true)
     }
 
-    #[precompile::public(
-        "assets_reserve_transfer(address[],uint256[],bytes32,bool,uint256,uint256)"
-    )]
-    fn assets_reserve_transfer_native_v1(
-        handle: &mut impl PrecompileHandle,
-        assets: BoundedVec<Address, GetMaxAssets<Runtime>>,
-        amounts: BoundedVec<U256, GetMaxAssets<Runtime>>,
-        recipient_account_id: H256,
-        is_relay: bool,
-        parachain_id: U256,
-        fee_index: U256,
-    ) -> EvmResult<bool> {
-        let beneficiary: Junction = Junction::AccountId32 {
-            network: None,
-            id: recipient_account_id.into(),
-        }
-        .into();
-        Self::assets_reserve_transfer_v1_internal(
-            handle,
-            assets.into(),
-            amounts.into(),
-            beneficiary,
-            is_relay,
-            parachain_id,
-            fee_index,
-        )
-    }
-
-    #[precompile::public(
-        "assets_reserve_transfer(address[],uint256[],address,bool,uint256,uint256)"
-    )]
-    fn assets_reserve_transfer_evm_v1(
-        handle: &mut impl PrecompileHandle,
-        assets: BoundedVec<Address, GetMaxAssets<Runtime>>,
-        amounts: BoundedVec<U256, GetMaxAssets<Runtime>>,
-        recipient_account_id: Address,
-        is_relay: bool,
-        parachain_id: U256,
-        fee_index: U256,
-    ) -> EvmResult<bool> {
-        let beneficiary: Junction = Junction::AccountKey20 {
-            network: None,
-            key: recipient_account_id.0.to_fixed_bytes(),
-        }
-        .into();
-        Self::assets_reserve_transfer_v1_internal(
-            handle,
-            assets.into(),
-            amounts.into(),
-            beneficiary,
-            is_relay,
-            parachain_id,
-            fee_index,
-        )
-    }
-
-    #[precompile::public("send_xcm((uint8,bytes[]),bytes)")]
-    fn send_xcm(
-        handle: &mut impl PrecompileHandle,
-        dest: Location,
-        xcm_call: BoundedBytes<GetXcmSizeLimit>,
-    ) -> EvmResult<bool> {
-        // Raw call arguments
-        let dest: Location = dest.into();
-        let xcm_call: Vec<u8> = xcm_call.into();
-
-        log::trace!(target:"xcm-precompile::send_xcm", "Raw arguments: dest: {:?}, xcm_call: {:?}", dest, xcm_call);
-
-        let xcm = xcm::VersionedXcm::<()>::decode_all_with_depth_limit(
-            xcm::MAX_XCM_DECODE_DEPTH,
-            &mut xcm_call.as_slice(),
-        )
-        .map_err(|_| revert("Failed to decode xcm instructions"))?;
-
-        // Build call with origin.
-        let origin = Some(Runtime::AddressMapping::into_account_id(
-            handle.context().caller,
-        ))
-        .into();
-        let call = pallet_xcm::Call::<Runtime>::send {
-            dest: Box::new(dest.into()),
-            message: Box::new(xcm),
-        };
-        log::trace!(target: "xcm-send_xcm", "Processed arguments:  XCM call: {:?}", call);
-        // Dispatch a call.
-        RuntimeHelper::<Runtime>::try_dispatch(handle, origin, call, 0)?;
-
-        Ok(true)
-    }
-
+    /// Transfer a single token - native currency (zero address) or an XC20 - to a combined
+    /// destination location that embeds the beneficiary.
     #[precompile::public("transfer(address,uint256,(uint8,bytes[]),(uint64,uint64))")]
     fn transfer(
         handle: &mut impl PrecompileHandle,
@@ -490,40 +192,49 @@ where
             .try_into()
             .map_err(|_| revert("error converting amount_of_tokens, maybe value too large"))?;
 
-        let dest_weight_limit = if weight.is_zero() {
+        let weight_limit = if weight.is_zero() {
             WeightLimit::Unlimited
         } else {
             WeightLimit::Limited(weight.get_weight())
         };
 
-        let call = {
-            if currency_address == Address::from(NATIVE_ADDRESS) {
-                log::trace!(target: "xcm-precompile::transfer", "Raw arguments: currency_address: {:?} (this is native token), amount_of_tokens: {:?}, destination: {:?}, \
-                weight: {:?}",
-                currency_address, amount_of_tokens, destination, weight );
+        // Special case where zero address maps to native token by convention.
+        let asset_location = if currency_address == Address::from(NATIVE_ADDRESS) {
+            Location::here()
+        } else {
+            let asset_id = Runtime::address_to_asset_id(currency_address.into())
+                .ok_or(revert("Failed to resolve asset id from address"))?;
+            C::convert_back(&asset_id).ok_or(revert(
+                "Failed to resolve asset multilocation from local id",
+            ))?
+        };
+        let asset: Asset = (asset_location, amount_of_tokens).into();
 
-                orml_xtokens::Call::<Runtime>::transfer_multiasset {
-                    asset: Box::new(VersionedAsset::V5(
-                        (Location::here(), amount_of_tokens).into(),
-                    )),
-                    dest: Box::new(VersionedLocation::V5(destination)),
-                    dest_weight_limit,
-                }
-            } else {
-                let asset_id = Runtime::address_to_asset_id(currency_address.into())
-                    .ok_or(revert("Failed to resolve fee asset id from address"))?;
+        let (dest, beneficiary) = split_location_into_chain_part_and_beneficiary(destination)
+            .ok_or(revert(
+                "error splitting destination into chain and beneficiary",
+            ))?;
 
-                log::trace!(target: "xcm-precompile::transfer", "Raw arguments: currency_address: {:?}, amount_of_tokens: {:?}, destination: {:?}, \
-                weight: {:?}, calculated asset_id: {:?}",
-                currency_address, amount_of_tokens, destination, weight, asset_id);
+        let assets: Assets = asset.into();
+        Self::ensure_dot_transfer_policy(assets.inner(), &dest)?;
 
-                orml_xtokens::Call::<Runtime>::transfer {
-                    currency_id: asset_id.into(),
-                    amount: amount_of_tokens.into(),
-                    dest: Box::new(VersionedLocation::V5(destination)),
-                    dest_weight_limit,
-                }
-            }
+        let (assets_transfer_type, fees_transfer_type, fee_asset_id) =
+            Self::resolve_transfer_types(&assets, 0, &dest)?;
+
+        log::trace!(target: "xcm-precompile::transfer", "Processed arguments: currency_address: {:?}, assets: {:?}, dest: {:?}, beneficiary: {:?}, weight_limit: {:?}, transfer type: {:?}",
+        currency_address, assets, dest, beneficiary, weight_limit, assets_transfer_type);
+
+        let call = pallet_xcm::Call::<Runtime>::transfer_assets_using_type_and_then {
+            dest: Box::new(VersionedLocation::V5(dest)),
+            assets: Box::new(VersionedAssets::V5(assets.clone())),
+            assets_transfer_type: Box::new(assets_transfer_type),
+            remote_fees_id: Box::new(VersionedAssetId::V5(fee_asset_id)),
+            fees_transfer_type: Box::new(fees_transfer_type),
+            custom_xcm_on_dest: Box::new(VersionedXcm::V5(Self::deposit_to_beneficiary(
+                assets.len() as u32,
+                beneficiary,
+            ))),
+            weight_limit,
         };
 
         let origin = Some(Runtime::AddressMapping::into_account_id(
@@ -537,6 +248,118 @@ where
         Ok(true)
     }
 
+    // ------------------------------------------------------------------------------------------
+    // Deprecated methods.
+    // ------------------------------------------------------------------------------------------
+
+    /// Deprecated. Use the `bytes32` overload of `assets_withdraw` instead.
+    #[precompile::public("assets_withdraw(address[],uint256[],address,bool,uint256,uint256)")]
+    fn assets_withdraw_evm_v1(
+        handle: &mut impl PrecompileHandle,
+        assets: BoundedVec<Address, GetMaxAssets>,
+        amounts: BoundedVec<U256, GetMaxAssets>,
+        recipient_account_id: Address,
+        is_relay: bool,
+        parachain_id: U256,
+        fee_index: U256,
+    ) -> EvmResult<bool> {
+        let _ = (
+            handle,
+            assets,
+            amounts,
+            recipient_account_id,
+            is_relay,
+            parachain_id,
+            fee_index,
+        );
+        Err(revert(DEPRECATED))
+    }
+
+    /// Deprecated. Was already unreachable: `SendXcmOrigin` rejects signed origins.
+    #[precompile::public("remote_transact(uint256,bool,address,uint256,bytes,uint64)")]
+    fn remote_transact_v1(
+        handle: &mut impl PrecompileHandle,
+        para_id: U256,
+        is_relay: bool,
+        fee_asset_addr: Address,
+        fee_amount: U256,
+        remote_call: UnboundedBytes,
+        transact_weight: u64,
+    ) -> EvmResult<bool> {
+        let _ = (
+            handle,
+            para_id,
+            is_relay,
+            fee_asset_addr,
+            fee_amount,
+            remote_call,
+            transact_weight,
+        );
+        Err(revert(DEPRECATED))
+    }
+
+    /// Deprecated. Use the `bytes32` overload of `assets_withdraw` instead.
+    #[precompile::public(
+        "assets_reserve_transfer(address[],uint256[],bytes32,bool,uint256,uint256)"
+    )]
+    fn assets_reserve_transfer_native_v1(
+        handle: &mut impl PrecompileHandle,
+        assets: BoundedVec<Address, GetMaxAssets>,
+        amounts: BoundedVec<U256, GetMaxAssets>,
+        recipient_account_id: H256,
+        is_relay: bool,
+        parachain_id: U256,
+        fee_index: U256,
+    ) -> EvmResult<bool> {
+        let _ = (
+            handle,
+            assets,
+            amounts,
+            recipient_account_id,
+            is_relay,
+            parachain_id,
+            fee_index,
+        );
+        Err(revert(DEPRECATED))
+    }
+
+    /// Deprecated. Use the `bytes32` overload of `assets_withdraw` instead.
+    #[precompile::public(
+        "assets_reserve_transfer(address[],uint256[],address,bool,uint256,uint256)"
+    )]
+    fn assets_reserve_transfer_evm_v1(
+        handle: &mut impl PrecompileHandle,
+        assets: BoundedVec<Address, GetMaxAssets>,
+        amounts: BoundedVec<U256, GetMaxAssets>,
+        recipient_account_id: Address,
+        is_relay: bool,
+        parachain_id: U256,
+        fee_index: U256,
+    ) -> EvmResult<bool> {
+        let _ = (
+            handle,
+            assets,
+            amounts,
+            recipient_account_id,
+            is_relay,
+            parachain_id,
+            fee_index,
+        );
+        Err(revert(DEPRECATED))
+    }
+
+    /// Deprecated. Was already unreachable: `SendXcmOrigin` rejects signed origins.
+    #[precompile::public("send_xcm((uint8,bytes[]),bytes)")]
+    fn send_xcm(
+        handle: &mut impl PrecompileHandle,
+        dest: Location,
+        xcm_call: BoundedBytes<GetXcmSizeLimit>,
+    ) -> EvmResult<bool> {
+        let _ = (handle, dest, xcm_call);
+        Err(revert(DEPRECATED))
+    }
+
+    /// Deprecated. Use `transfer` and let the destination charge fees from the transferred asset.
     #[precompile::public(
         "transfer_with_fee(address,uint256,uint256,(uint8,bytes[]),(uint64,uint64))"
     )]
@@ -548,61 +371,18 @@ where
         destination: Location,
         weight: WeightV2,
     ) -> EvmResult<bool> {
-        // Read call arguments
-        let amount_of_tokens: u128 = amount_of_tokens
-            .try_into()
-            .map_err(|_| revert("error converting amount_of_tokens, maybe value too large"))?;
-        let fee: u128 = fee.try_into().map_err(|_| revert("can't convert fee"))?;
-
-        let dest_weight_limit = if weight.is_zero() {
-            WeightLimit::Unlimited
-        } else {
-            WeightLimit::Limited(weight.get_weight())
-        };
-
-        let call = {
-            if currency_address == Address::from(NATIVE_ADDRESS) {
-                log::trace!(target: "xcm-precompile::transfer_with_fee", "Raw arguments: currency_address: {:?} (this is native token), amount_of_tokens: {:?}, destination: {:?}, \
-                weight: {:?}, fee {:?}",
-                currency_address, amount_of_tokens, destination, weight, fee );
-
-                orml_xtokens::Call::<Runtime>::transfer_multiasset_with_fee {
-                    asset: Box::new(VersionedAsset::V5(
-                        (Location::here(), amount_of_tokens).into(),
-                    )),
-                    fee: Box::new(VersionedAsset::V5((Location::here(), fee).into())),
-                    dest: Box::new(VersionedLocation::V5(destination)),
-                    dest_weight_limit,
-                }
-            } else {
-                let asset_id = Runtime::address_to_asset_id(currency_address.into())
-                    .ok_or(revert("Failed to resolve fee asset id from address"))?;
-
-                log::trace!(target: "xcm-precompile::transfer_with_fee", "Raw arguments: currency_address: {:?}, amount_of_tokens: {:?}, destination: {:?}, \
-                weight: {:?}, calculated asset_id: {:?}, fee: {:?}",
-                currency_address, amount_of_tokens, destination, weight, asset_id, fee);
-
-                orml_xtokens::Call::<Runtime>::transfer_with_fee {
-                    currency_id: asset_id.into(),
-                    amount: amount_of_tokens.into(),
-                    fee: fee.into(),
-                    dest: Box::new(VersionedLocation::V5(destination)),
-                    dest_weight_limit,
-                }
-            }
-        };
-
-        let origin = Some(Runtime::AddressMapping::into_account_id(
-            handle.context().caller,
-        ))
-        .into();
-
-        // Dispatch a call.
-        RuntimeHelper::<Runtime>::try_dispatch(handle, origin, call, 0)?;
-
-        Ok(true)
+        let _ = (
+            handle,
+            currency_address,
+            amount_of_tokens,
+            fee,
+            destination,
+            weight,
+        );
+        Err(revert(DEPRECATED))
     }
 
+    /// Deprecated. Use `transfer` with the asset's XC20 address.
     #[precompile::public(
         "transfer_multiasset((uint8,bytes[]),uint256,(uint8,bytes[]),(uint64,uint64))"
     )]
@@ -613,40 +393,17 @@ where
         destination: Location,
         weight: WeightV2,
     ) -> EvmResult<bool> {
-        // Read call arguments
-        let amount_of_tokens: u128 = amount_of_tokens
-            .try_into()
-            .map_err(|_| revert("error converting amount_of_tokens, maybe value too large"))?;
-
-        let dest_weight_limit = if weight.is_zero() {
-            WeightLimit::Unlimited
-        } else {
-            WeightLimit::Limited(weight.get_weight())
-        };
-
-        log::trace!(target: "xcm-precompile::transfer_multiasset", "Raw arguments: asset_location: {:?}, amount_of_tokens: {:?}, destination: {:?}, \
-        weight: {:?}",
-        asset_location, amount_of_tokens, destination, weight);
-
-        let call = orml_xtokens::Call::<Runtime>::transfer_multiasset {
-            asset: Box::new(VersionedAsset::V5(
-                (asset_location, amount_of_tokens).into(),
-            )),
-            dest: Box::new(VersionedLocation::V5(destination)),
-            dest_weight_limit,
-        };
-
-        let origin = Some(Runtime::AddressMapping::into_account_id(
-            handle.context().caller,
-        ))
-        .into();
-
-        // Dispatch a call.
-        RuntimeHelper::<Runtime>::try_dispatch(handle, origin, call, 0)?;
-
-        Ok(true)
+        let _ = (
+            handle,
+            asset_location,
+            amount_of_tokens,
+            destination,
+            weight,
+        );
+        Err(revert(DEPRECATED))
     }
 
+    /// Deprecated. Use `transfer` with the asset's XC20 address.
     #[precompile::public(
         "transfer_multiasset_with_fee((uint8,bytes[]),uint256,uint256,(uint8,bytes[]),(uint64,uint64))"
     )]
@@ -658,169 +415,109 @@ where
         destination: Location,
         weight: WeightV2,
     ) -> EvmResult<bool> {
-        // Read call arguments
-        let amount_of_tokens: u128 = amount_of_tokens
-            .try_into()
-            .map_err(|_| revert("error converting amount_of_tokens, maybe value too large"))?;
-        let fee: u128 = fee.try_into().map_err(|_| revert("can't convert fee"))?;
-
-        let dest_weight_limit = if weight.is_zero() {
-            WeightLimit::Unlimited
-        } else {
-            WeightLimit::Limited(weight.get_weight())
-        };
-
-        log::trace!(target: "xcm-precompile::transfer_multiasset_with_fee", "Raw arguments: asset_location: {:?}, amount_of_tokens: {:?}, fee{:?}, destination: {:?}, \
-        weight: {:?}",
-        asset_location, amount_of_tokens, fee, destination, weight);
-
-        let call = orml_xtokens::Call::<Runtime>::transfer_multiasset_with_fee {
-            asset: Box::new(VersionedAsset::V5(
-                (asset_location.clone(), amount_of_tokens).into(),
-            )),
-            fee: Box::new(VersionedAsset::V5((asset_location, fee).into())),
-            dest: Box::new(VersionedLocation::V5(destination)),
-            dest_weight_limit,
-        };
-
-        let origin = Some(Runtime::AddressMapping::into_account_id(
-            handle.context().caller,
-        ))
-        .into();
-
-        // Dispatch a call.
-        RuntimeHelper::<Runtime>::try_dispatch(handle, origin, call, 0)?;
-
-        Ok(true)
+        let _ = (
+            handle,
+            asset_location,
+            amount_of_tokens,
+            fee,
+            destination,
+            weight,
+        );
+        Err(revert(DEPRECATED))
     }
 
+    /// Deprecated. Use `assets_withdraw` for multi-asset transfers.
     #[precompile::public(
         "transfer_multi_currencies((address,uint256)[],uint32,(uint8,bytes[]),(uint64,uint64))"
     )]
     fn transfer_multi_currencies(
         handle: &mut impl PrecompileHandle,
-        currencies: BoundedVec<Currency, GetMaxAssets<Runtime>>,
+        currencies: BoundedVec<Currency, GetMaxAssets>,
         fee_item: u32,
         destination: Location,
         weight: WeightV2,
     ) -> EvmResult<bool> {
-        let currencies: Vec<_> = currencies.into();
-        let currencies = currencies
-            .into_iter()
-            .map(|currency| {
-                let currency_address: H160 = currency.get_address().into();
-                let amount = currency
-                    .get_amount()
-                    .try_into()
-                    .map_err(|_| revert("value too large: in currency"))?;
-
-                Ok((
-                    Runtime::address_to_asset_id(currency_address.into())
-                        .ok_or(revert("can't convert into currency id"))?
-                        .into(),
-                    amount,
-                ))
-            })
-            .collect::<EvmResult<_>>()?;
-        let dest_weight_limit = if weight.is_zero() {
-            WeightLimit::Unlimited
-        } else {
-            WeightLimit::Limited(weight.get_weight())
-        };
-
-        log::trace!(target: "xcm-precompile::transfer_multi_currencies", "Raw arguments: currencies: {:?}, fee_item{:?}, destination: {:?}, \
-        weight: {:?}",
-        currencies, fee_item, destination, weight);
-
-        let call = orml_xtokens::Call::<Runtime>::transfer_multicurrencies {
-            currencies,
-            fee_item,
-            dest: Box::new(VersionedLocation::V5(destination)),
-            dest_weight_limit,
-        };
-
-        let origin = Some(Runtime::AddressMapping::into_account_id(
-            handle.context().caller,
-        ))
-        .into();
-
-        // Dispatch a call.
-        RuntimeHelper::<Runtime>::try_dispatch(handle, origin, call, 0)?;
-
-        Ok(true)
+        let _ = (handle, currencies, fee_item, destination, weight);
+        Err(revert(DEPRECATED))
     }
 
+    /// Deprecated. Use `assets_withdraw` for multi-asset transfers.
     #[precompile::public(
         "transfer_multi_assets(((uint8,bytes[]),uint256)[],uint32,(uint8,bytes[]),(uint64,uint64))"
     )]
     fn transfer_multi_assets(
         handle: &mut impl PrecompileHandle,
-        assets: BoundedVec<EvmMultiAsset, GetMaxAssets<Runtime>>,
+        assets: BoundedVec<EvmMultiAsset, GetMaxAssets>,
         fee_item: u32,
         destination: Location,
         weight: WeightV2,
     ) -> EvmResult<bool> {
-        let assets: Vec<_> = assets.into();
+        let _ = (handle, assets, fee_item, destination, weight);
+        Err(revert(DEPRECATED))
+    }
 
-        let dest_weight_limit = if weight.is_zero() {
-            WeightLimit::Unlimited
-        } else {
-            WeightLimit::Limited(weight.get_weight())
+    /// Picks the reserve model for `assets` and, separately, for the fee asset at
+    /// `fee_asset_item`.
+    fn resolve_transfer_types(
+        assets: &Assets,
+        fee_asset_item: u32,
+        dest: &Location,
+    ) -> EvmResult<(TransferType, TransferType, AssetId)> {
+        let assets = assets.inner();
+        let fee_asset = assets
+            .get(fee_asset_item as usize)
+            .ok_or(revert("fee_index is out of bounds of the assets list"))?;
+
+        let resolve = |asset: &Asset| {
+            resolve_transfer_type::<<Runtime as pallet_xcm::Config>::XcmExecutor>(asset, dest)
+                .ok_or(revert("cannot determine the reserve location for asset"))
         };
 
-        log::trace!(target: "xcm-precompile::transfer_multi_assets", "Raw arguments: assets: {:?}, fee_item{:?}, destination: {:?}, \
-        weight: {:?}",
-        assets, fee_item, destination, weight);
+        let fees_transfer_type = resolve(fee_asset)?;
 
-        let multiasset_vec: EvmResult<Vec<Asset>> = assets
-            .into_iter()
-            .map(|evm_multiasset| {
-                let to_balance: u128 = evm_multiasset
-                    .get_amount()
-                    .try_into()
-                    .map_err(|_| revert("value too large in assets"))?;
-                Ok((evm_multiasset.get_location(), to_balance).into())
-            })
-            .collect();
+        let mut assets_transfer_type = None;
+        for (idx, asset) in assets.iter().enumerate() {
+            if idx == fee_asset_item as usize {
+                continue;
+            }
+            let transfer_type = resolve(asset)?;
+            match &assets_transfer_type {
+                Some(existing) if existing != &transfer_type => {
+                    return Err(revert("all non-fee assets must share the same reserve"))
+                }
+                Some(_) => {}
+                None => assets_transfer_type = Some(transfer_type),
+            }
+        }
 
-        // Since multiassets sorts them, we need to check whether the index is still correct,
-        // and error otherwise as there is not much we can do other than that
-        let multiassets = Assets::from_sorted_and_deduplicated(multiasset_vec?).map_err(|_| {
-            revert("In field Assets, Provided assets either not sorted nor deduplicated")
-        })?;
+        // A lone asset also acts as the fee asset.
+        let assets_transfer_type =
+            assets_transfer_type.unwrap_or_else(|| fees_transfer_type.clone());
 
-        let call = orml_xtokens::Call::<Runtime>::transfer_multiassets {
-            assets: Box::new(VersionedAssets::V5(multiassets)),
-            fee_item,
-            dest: Box::new(VersionedLocation::V5(destination)),
-            dest_weight_limit,
-        };
-
-        let origin = Some(Runtime::AddressMapping::into_account_id(
-            handle.context().caller,
+        Ok((
+            assets_transfer_type,
+            fees_transfer_type,
+            fee_asset.id.clone(),
         ))
-        .into();
+    }
 
-        // Dispatch a call.
-        RuntimeHelper::<Runtime>::try_dispatch(handle, origin, call, 0)?;
-
-        Ok(true)
+    /// The XCM executed on the destination chain: hand everything that survived the transfer to the
+    /// beneficiary.
+    fn deposit_to_beneficiary(assets_count: u32, beneficiary: Location) -> Xcm<()> {
+        Xcm(vec![DepositAsset {
+            assets: Wild(AllCounted(assets_count)),
+            beneficiary,
+        }])
     }
 
     /// Enforces DOT transfer routing policy.
     ///
     /// Currently prevents direct DOT transfers to the relay chain,
     /// requiring routing through AssetHub (parachain 1000).
-    fn ensure_dot_transfer_policy(assets: &[Asset], destination: &Location) -> EvmResult<()> {
-        let dest_chain = {
-            let mut d = destination.clone();
-            // Remove the final interior junction (the beneficiary AccountId32 / AccountKey20)
-            // to get just the chain root, e.g. (1, Here) or (1, Parachain(1000)).
-            d.interior.take_last();
-            d
-        };
-
-        if dest_chain != Location::parent() {
+    ///
+    /// `dest_chain` is the destination *chain* location - it must not carry the beneficiary.
+    fn ensure_dot_transfer_policy(assets: &[Asset], dest_chain: &Location) -> EvmResult<()> {
+        if dest_chain != &Location::parent() {
             return Ok(());
         }
 

--- a/precompiles/xcm/src/mock.rs
+++ b/precompiles/xcm/src/mock.rs
@@ -40,8 +40,6 @@ use sp_core::{ConstU32, DecodeWithMemTracking, H160};
 use sp_runtime::{traits::IdentityLookup, BuildStorage};
 use sp_std::cell::RefCell;
 
-use astar_primitives::xcm::AbsoluteAndRelativeReserveProvider;
-use orml_xcm_support::DisabledParachainFee;
 use xcm::prelude::XcmVersion;
 use xcm_builder::{
     test_utils::TransactAsset, AllowKnownQueryResponses, AllowSubscriptionsFrom,
@@ -53,7 +51,6 @@ pub type AccountId = TestAccount;
 pub type AssetId = u128;
 pub type Balance = u128;
 pub type Block = frame_system::mocking::MockBlock<Runtime>;
-pub type CurrencyId = u128;
 
 /// Multilocations for assetId
 const PARENT: Location = Location::parent();
@@ -164,32 +161,6 @@ impl AddressToAssetId<AssetId> for Runtime {
     }
 }
 
-pub struct CurrencyIdToMultiLocation;
-
-impl sp_runtime::traits::Convert<CurrencyId, Option<Location>> for CurrencyIdToMultiLocation {
-    fn convert(currency: CurrencyId) -> Option<Location> {
-        match currency {
-            1u128 => Some(PARENT),
-            2u128 => Some((*PARACHAIN).clone()),
-            3u128 => Some((*GENERAL_INDEX).clone()),
-            4u128 => Some((*LOCAL_ASSET).clone()),
-            _ => None,
-        }
-    }
-}
-
-/// Convert `AccountId` to `Location`.
-pub struct AccountIdToLocation;
-impl sp_runtime::traits::Convert<AccountId, Location> for AccountIdToLocation {
-    fn convert(account: AccountId) -> Location {
-        AccountId32 {
-            network: None,
-            id: account.into(),
-        }
-        .into()
-    }
-}
-
 parameter_types! {
     pub const BlockHashCount: u64 = 250;
     pub const SS58Prefix: u8 = 42;
@@ -282,22 +253,40 @@ impl pallet_assets::Config for Runtime {
     type AssetIdParameter = AssetId;
 }
 
+/// The mock's asset registry: maps local asset ids to the locations they are registered at.
+///
+/// - `1` - the relay token, `(1, Here)`. Its trusted reserve is Asset Hub, not the relay.
+/// - `2` - a sibling parachain's native token, `(1, Parachain(10))`.
+/// - `3` - an asset held by a sibling parachain, `(1, Parachain(10), GeneralIndex(20))`.
+/// - `4` - a local asset, `(0, GeneralIndex(20))`.
 pub struct AssetIdConverter<AssetId>(PhantomData<AssetId>);
 impl<AssetId> sp_runtime::traits::MaybeEquivalence<Location, AssetId> for AssetIdConverter<AssetId>
 where
     AssetId: Clone + Eq + From<u8>,
 {
     fn convert(a: &Location) -> Option<AssetId> {
-        if a.eq(&Location::parent()) {
+        if a == &PARENT {
             Some(AssetId::from(1u8))
+        } else if a == &*PARACHAIN {
+            Some(AssetId::from(2u8))
+        } else if a == &*GENERAL_INDEX {
+            Some(AssetId::from(3u8))
+        } else if a == &*LOCAL_ASSET {
+            Some(AssetId::from(4u8))
         } else {
             None
         }
     }
 
     fn convert_back(b: &AssetId) -> Option<Location> {
-        if b.eq(&AssetId::from(1u8)) {
-            Some(Location::parent())
+        if b == &AssetId::from(1u8) {
+            Some(PARENT)
+        } else if b == &AssetId::from(2u8) {
+            Some((*PARACHAIN).clone())
+        } else if b == &AssetId::from(3u8) {
+            Some((*GENERAL_INDEX).clone())
+        } else if b == &AssetId::from(4u8) {
+            Some((*LOCAL_ASSET).clone())
         } else {
             None
         }
@@ -381,7 +370,7 @@ impl xcm_executor::Config for XcmConfig {
     type XcmSender = StoringRouter;
     type AssetTransactor = LocalAssetTransactor;
     type OriginConverter = ();
-    type IsReserve = Everything;
+    type IsReserve = astar_primitives::xcm::ReserveAssetFilter;
     type IsTeleporter = ();
     type UniversalLocation = UniversalLocation;
     type Barrier = Barrier;
@@ -411,12 +400,6 @@ impl xcm_executor::Config for XcmConfig {
 
 parameter_types! {
     pub static AdvertisedXcmVersion: XcmVersion = 3;
-    pub const MaxAssetsForTransfer: usize = 2;
-    pub const SelfLocation: Location = Here.into_location();
-    pub SelfLocationAbsolute: Location = Location {
-        parents: 1,
-        interior: Parachain(123).into()
-    };
 }
 
 pub type LocalOriginToLocation = SignedToAccountId32<RuntimeOrigin, AccountId, AnyNetwork>;
@@ -486,25 +469,6 @@ impl pallet_xcm::Config for Runtime {
     type AuthorizedAliasConsideration = Disabled;
 }
 
-impl orml_xtokens::Config for Runtime {
-    type Balance = Balance;
-    type CurrencyId = AssetId;
-    type CurrencyIdConvert = CurrencyIdToMultiLocation;
-    type AccountIdToLocation = AccountIdToLocation;
-    type SelfLocation = SelfLocation;
-    type XcmExecutor = XcmExecutor<XcmConfig>;
-    type Weigher = FixedWeightBounds<BaseXcmWeight, RuntimeCall, MaxInstructions>;
-    type BaseXcmWeight = UnitWeightCost;
-    type UniversalLocation = UniversalLocation;
-    type MaxAssetsForTransfer = MaxAssetsForTransfer;
-    // Default impl. Refer to `orml-xtokens` docs for more details.
-    type MinXcmFee = DisabledParachainFee;
-    type LocationsFilter = Everything;
-    type ReserveProvider = AbsoluteAndRelativeReserveProvider<SelfLocationAbsolute>;
-    type RateLimiter = ();
-    type RateLimiterId = ();
-}
-
 // Configure a mock runtime to test the pallet.
 construct_runtime!(
     pub enum Runtime
@@ -515,7 +479,6 @@ construct_runtime!(
         Evm: pallet_evm,
         Timestamp: pallet_timestamp,
         XcmPallet: pallet_xcm,
-        Xtokens: orml_xtokens,
     }
 );
 
@@ -532,11 +495,4 @@ impl ExtBuilder {
         ext.execute_with(|| System::set_block_number(1));
         ext
     }
-}
-
-pub(crate) fn events() -> Vec<RuntimeEvent> {
-    System::events()
-        .into_iter()
-        .map(|r| r.event)
-        .collect::<Vec<_>>()
 }

--- a/precompiles/xcm/src/tests.rs
+++ b/precompiles/xcm/src/tests.rs
@@ -19,21 +19,64 @@
 use crate::mock::*;
 use crate::*;
 
-use orml_xtokens::Event as XtokensEvent;
+use astar_primitives::xcm::ASSET_HUB_PARA_ID;
 use parity_scale_codec::Encode;
 use precompile_utils::testing::*;
 use sp_core::{H160, H256};
-use sp_runtime::traits::Convert;
-use xcm::VersionedXcm;
 
 fn precompiles() -> TestPrecompileSet<Runtime> {
     PrecompilesValue::get()
 }
 
-mod xcm_old_interface_test {
+/// `AccountId32` beneficiary, as the precompile builds it from a raw `bytes32`.
+fn beneficiary_32(byte: u8) -> Location {
+    Location::new(
+        0,
+        [AccountId32 {
+            network: None,
+            id: [byte; 32],
+        }],
+    )
+}
+
+/// The single XCM the mock router recorded, panicking if there isn't exactly one.
+fn only_sent_xcm() -> (Location, Xcm<()>) {
+    let mut sent = take_sent_xcm();
+    assert_eq!(sent.len(), 1, "expected exactly one XCM to be sent");
+    sent.pop().expect("length checked above")
+}
+
+/// Asserts the message ends by depositing everything to `beneficiary`.
+fn assert_deposits_to(message: &Xcm<()>, beneficiary: &Location) {
+    let deposit = message
+        .0
+        .iter()
+        .rev()
+        .find_map(|instruction| match instruction {
+            DepositAsset {
+                assets,
+                beneficiary,
+            } => Some((assets, beneficiary)),
+            _ => None,
+        })
+        .expect("message must deposit the assets somewhere");
+
+    assert_eq!(
+        deposit.1, beneficiary,
+        "assets must be deposited to the requested beneficiary"
+    );
+    assert!(
+        matches!(deposit.0, Wild(AllCounted(_))),
+        "precompile always deposits every asset that survived the transfer, got {:?}",
+        deposit.0
+    );
+}
+
+mod assets_withdraw {
     use super::*;
+
     #[test]
-    fn wrong_assets_len_or_fee_index_reverts() {
+    fn wrong_assets_len_reverts() {
         ExtBuilder.build().execute_with(|| {
             precompiles()
                 .prepare_test(
@@ -50,24 +93,28 @@ mod xcm_old_interface_test {
                 )
                 .expect_no_logs()
                 .execute_reverts(|output| output == b"Assets resolution failure.");
+        });
+    }
 
+    #[test]
+    fn out_of_bounds_fee_index_reverts() {
+        ExtBuilder.build().execute_with(|| {
             precompiles()
                 .prepare_test(
                     TestAccount::Alice,
                     PRECOMPILE_ADDRESS,
                     PrecompileCall::assets_withdraw_native_v1 {
-                        assets: vec![Address::from(Runtime::asset_id_to_address(1u128))].into(),
+                        assets: vec![Address::from(Runtime::asset_id_to_address(2u128))].into(),
                         amounts: vec![42000u64.into()].into(),
                         recipient_account_id: H256::repeat_byte(0xF1),
                         is_relay: false,
-                        parachain_id: 1000.into(),
+                        parachain_id: 10.into(),
                         fee_index: 2.into(),
                     },
                 )
                 .expect_no_logs()
                 .execute_reverts(|output| {
-                    let error_string = String::from_utf8_lossy(output);
-                    error_string.contains("AssetIndexNonExistent")
+                    output == b"fee_index is out of bounds of the assets list"
                 });
         });
     }
@@ -94,7 +141,7 @@ mod xcm_old_interface_test {
                     output == b"error converting parachain_id, maybe value too large"
                 });
 
-            // more than 2 assets can not be sent
+            // more than `MAX_ASSETS_FOR_TRANSFER` assets can not be sent
             precompiles()
                 .prepare_test(
                     TestAccount::Alice,
@@ -127,9 +174,66 @@ mod xcm_old_interface_test {
     }
 
     #[test]
-    fn assets_withdraw_works() {
+    fn sibling_parachain_asset_back_to_its_reserve_works() {
         ExtBuilder.build().execute_with(|| {
-            // SS58
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::assets_withdraw_native_v1 {
+                        // asset 2 is registered at `(1, Parachain(10))`, so parachain 10 is its
+                        // reserve - a plain destination-reserve withdraw.
+                        assets: vec![Address::from(Runtime::asset_id_to_address(2u128))].into(),
+                        amounts: vec![42000u64.into()].into(),
+                        recipient_account_id: H256::repeat_byte(0xF1),
+                        is_relay: false,
+                        parachain_id: 10.into(),
+                        fee_index: 0.into(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_returns(true);
+
+            let (dest, message) = only_sent_xcm();
+            assert_eq!(dest, Location::new(1, [Parachain(10)]));
+            assert_deposits_to(&message, &beneficiary_32(0xF1));
+        });
+    }
+
+    #[test]
+    fn relay_token_is_routed_through_asset_hub() {
+        ExtBuilder.build().execute_with(|| {
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::assets_withdraw_native_v1 {
+                        // asset 1 is the relay token, registered at `(1, Here)`. Its reserve is
+                        // Asset Hub, so a transfer to parachain 10 must go through it.
+                        assets: vec![Address::from(Runtime::asset_id_to_address(1u128))].into(),
+                        amounts: vec![42000u64.into()].into(),
+                        recipient_account_id: H256::repeat_byte(0xF1),
+                        is_relay: false,
+                        parachain_id: 10.into(),
+                        fee_index: 0.into(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_returns(true);
+
+            let (dest, _message) = only_sent_xcm();
+            assert_eq!(
+                dest,
+                Location::new(1, [Parachain(ASSET_HUB_PARA_ID)]),
+                "relay token must be withdrawn via its Asset Hub reserve, not sent to the \
+                 destination directly"
+            );
+        });
+    }
+
+    #[test]
+    fn relay_token_to_asset_hub_works() {
+        ExtBuilder.build().execute_with(|| {
             precompiles()
                 .prepare_test(
                     TestAccount::Alice,
@@ -139,51 +243,21 @@ mod xcm_old_interface_test {
                         amounts: vec![42000u64.into()].into(),
                         recipient_account_id: H256::repeat_byte(0xF1),
                         is_relay: false,
-                        parachain_id: 1000.into(),
+                        parachain_id: ASSET_HUB_PARA_ID.into(),
                         fee_index: 0.into(),
                     },
                 )
                 .expect_no_logs()
                 .execute_returns(true);
 
-            // H160
-            precompiles()
-                .prepare_test(
-                    TestAccount::Alice,
-                    PRECOMPILE_ADDRESS,
-                    PrecompileCall::assets_withdraw_evm_v1 {
-                        assets: vec![Address::from(Runtime::asset_id_to_address(1u128))].into(),
-                        amounts: vec![42000u64.into()].into(),
-                        recipient_account_id: Address(H160::repeat_byte(0xDE)),
-                        is_relay: false,
-                        parachain_id: 0.into(),
-                        fee_index: 0.into(),
-                    },
-                )
-                .expect_no_logs()
-                .execute_returns(true);
-
-            // Checking for non-relay destination case
-            precompiles()
-                .prepare_test(
-                    TestAccount::Alice,
-                    PRECOMPILE_ADDRESS,
-                    PrecompileCall::assets_withdraw_evm_v1 {
-                        assets: vec![Address::from(Runtime::asset_id_to_address(1u128))].into(),
-                        amounts: vec![42000u64.into()].into(),
-                        recipient_account_id: Address(H160::repeat_byte(0xDE)),
-                        is_relay: false,
-                        parachain_id: 123.into(),
-                        fee_index: 0.into(),
-                    },
-                )
-                .expect_no_logs()
-                .execute_returns(true);
+            let (dest, message) = only_sent_xcm();
+            assert_eq!(dest, Location::new(1, [Parachain(ASSET_HUB_PARA_ID)]));
+            assert_deposits_to(&message, &beneficiary_32(0xF1));
         });
     }
 
     #[test]
-    fn assets_withdraw_dot_to_relay_reverts() {
+    fn dot_to_relay_reverts() {
         ExtBuilder.build().execute_with(|| {
             precompiles()
                 .prepare_test(
@@ -205,281 +279,60 @@ mod xcm_old_interface_test {
         });
     }
 
+    /// The asset's own chain is neither the origin nor the destination, so it has to act as a
+    /// remote reserve.
     #[test]
-    fn remote_transact_works() {
+    fn asset_of_a_third_chain_uses_a_remote_reserve() {
         ExtBuilder.build().execute_with(|| {
-            // SS58
             precompiles()
                 .prepare_test(
                     TestAccount::Alice,
                     PRECOMPILE_ADDRESS,
-                    PrecompileCall::remote_transact_v1 {
-                        para_id: 0.into(),
-                        is_relay: true,
-                        fee_asset_addr: Address::from(Runtime::asset_id_to_address(1_u128)),
-                        fee_amount: 367.into(),
-                        remote_call: vec![0xff_u8, 0xaa, 0x77, 0x00].into(),
-                        transact_weight: 3_000_000_000u64.into(),
-                    },
-                )
-                .expect_no_logs()
-                .execute_returns(true);
-
-            let binding = take_sent_xcm();
-            let (_location, Xcm(instructions)) = binding.get(0).expect("XCM should be sent");
-
-            // Ensure that origin is immediately descended to eliminate sovereign parachain origin.
-            assert!(matches!(instructions.as_slice(), [DescendOrigin(..), ..]));
-        });
-    }
-
-    #[test]
-    fn reserve_transfer_assets_works() {
-        ExtBuilder.build().execute_with(|| {
-            // SS58
-            precompiles()
-                .prepare_test(
-                    TestAccount::Alice,
-                    PRECOMPILE_ADDRESS,
-                    PrecompileCall::assets_reserve_transfer_native_v1 {
-                        assets: vec![Address::from(Runtime::asset_id_to_address(1u128))].into(),
-                        amounts: vec![U256::from(42000u64)].into(),
+                    PrecompileCall::assets_withdraw_native_v1 {
+                        // asset 3 lives at `(1, Parachain(10), GeneralIndex(20))`; parachain 10 is
+                        // its only reserve, and it is not reachable from parachain 20.
+                        assets: vec![Address::from(Runtime::asset_id_to_address(3u128))].into(),
+                        amounts: vec![42000u64.into()].into(),
                         recipient_account_id: H256::repeat_byte(0xF1),
                         is_relay: false,
-                        parachain_id: 1000.into(),
+                        parachain_id: 20.into(),
                         fee_index: 0.into(),
                     },
                 )
                 .expect_no_logs()
                 .execute_returns(true);
 
-            // H160
-            precompiles()
-                .prepare_test(
-                    TestAccount::Alice,
-                    PRECOMPILE_ADDRESS,
-                    PrecompileCall::assets_reserve_transfer_evm_v1 {
-                        assets: vec![Address::from(Runtime::asset_id_to_address(1u128))].into(),
-                        amounts: vec![U256::from(42000u64)].into(),
-                        recipient_account_id: Address::from(H160::repeat_byte(0xDE)),
-                        is_relay: false,
-                        parachain_id: 1000.into(),
-                        fee_index: 0.into(),
-                    },
-                )
-                .expect_no_logs()
-                .execute_returns(true);
-
-            for (location, Xcm(instructions)) in take_sent_xcm() {
-                assert_eq!(
-                    location,
-                    Location {
-                        parents: 1,
-                        interior: Parachain(1000).into()
-                    }
-                );
-
-                let non_native_asset = Asset {
-                    fun: Fungible(42000),
-                    id: xcm::v5::AssetId::from(Location {
-                        parents: 1,
-                        interior: Here,
-                    }),
-                };
-                assert!(matches!(
-                    instructions.as_slice(),
-                    [
-                        WithdrawAsset(assets),
-                        ClearOrigin,
-                        BuyExecution {
-                            fees,
-                            ..
-                        },
-                        DepositAsset {
-                            beneficiary: Location {
-                                parents: 0,
-                                interior: Junctions::X1(_),
-                            },
-                            ..
-                        },
-                        SetTopic(..)
-                    ]
-
-                    if fees.contains(&non_native_asset) && assets.contains(&non_native_asset)
-                ));
-            }
+            let (dest, _) = only_sent_xcm();
+            assert_eq!(
+                dest,
+                Location::new(1, [Parachain(10)]),
+                "asset must be withdrawn via its own chain acting as remote reserve"
+            );
         });
-    }
-
-    #[test]
-    fn reserve_transfer_currency_works() {
-        ExtBuilder.build().execute_with(|| {
-            precompiles()
-                .prepare_test(
-                    TestAccount::Alice,
-                    PRECOMPILE_ADDRESS,
-                    PrecompileCall::assets_reserve_transfer_native_v1 {
-                        assets: vec![Address::from(H160::zero())].into(),
-                        amounts: vec![U256::from(42000u64)].into(),
-                        recipient_account_id: H256::repeat_byte(0xF1),
-                        is_relay: true,
-                        parachain_id: 0.into(),
-                        fee_index: 0.into(),
-                    },
-                )
-                .expect_no_logs()
-                .execute_returns(true);
-
-            precompiles()
-                .prepare_test(
-                    TestAccount::Alice,
-                    PRECOMPILE_ADDRESS,
-                    PrecompileCall::assets_reserve_transfer_evm_v1 {
-                        assets: vec![Address::from(H160::zero())].into(),
-                        amounts: vec![U256::from(42000u64)].into(),
-                        recipient_account_id: Address::from(H160::repeat_byte(0xDE)),
-                        is_relay: true,
-                        parachain_id: 0.into(),
-                        fee_index: 0.into(),
-                    },
-                )
-                .expect_no_logs()
-                .execute_returns(true);
-
-            for (location, Xcm(instructions)) in take_sent_xcm() {
-                // xtokens now routes native-token-to-relay-chain transfers through Asset Hub
-                assert_eq!(
-                    location,
-                    Location {
-                        parents: 1,
-                        interior: Parachain(1000).into()
-                    }
-                );
-
-                // from AssetHub, parachain 123's native token is at parents=1, Parachain(123)
-                let native_asset = Asset {
-                    fun: Fungible(42000),
-                    id: xcm::v5::AssetId::from(Location {
-                        parents: 1,
-                        interior: Parachain(123).into(),
-                    }),
-                };
-
-                assert!(matches!(
-                    instructions.as_slice(),
-                    [
-                        ReserveAssetDeposited(assets),
-                        ClearOrigin,
-                        BuyExecution {
-                            fees,
-                            ..
-                        },
-                        DepositAsset {
-                            beneficiary: Location {
-                                parents: 0,
-                                interior: Junctions::X1(_),
-                            },
-                            ..
-                        },
-                        SetTopic(..)
-                    ]
-                    if fees.contains(&native_asset) && assets.contains(&native_asset)
-                ));
-            }
-        });
-    }
-
-    #[test]
-    fn test_send_clear_origin() {
-        ExtBuilder.build().execute_with(|| {
-            let dest: Location = Location {
-                parents: 1,
-                interior: AccountId32 {
-                    network: None,
-                    id: H256::repeat_byte(0xF1).into(),
-                }
-                .into(),
-            };
-            let xcm_to_send = VersionedXcm::<()>::V5(Xcm(vec![ClearOrigin])).encode();
-            precompiles()
-                .prepare_test(
-                    TestAccount::Alice,
-                    PRECOMPILE_ADDRESS,
-                    PrecompileCall::send_xcm {
-                        dest,
-                        xcm_call: xcm_to_send.as_slice().into(),
-                    },
-                )
-                // Fixed: TestWeightInfo
-                .expect_cost(100000000)
-                .expect_no_logs()
-                .execute_returns(true);
-
-            let sent_messages = take_sent_xcm();
-            let (_, sent_message) = sent_messages.first().unwrap();
-            // Lets make sure the message is as expected
-            assert!(sent_message.0.contains(&ClearOrigin));
-        })
     }
 }
 
-mod xcm_new_interface_test {
+mod transfer {
     use super::*;
+
+    fn weight() -> WeightV2 {
+        WeightV2::from(3_000_000_000u64, 1024)
+    }
+
     #[test]
-    fn xtokens_transfer_works() {
-        let weight = WeightV2::from(3_000_000_000u64, 1024);
-
+    fn sibling_parachain_asset_works() {
         ExtBuilder.build().execute_with(|| {
-            let parent_destination = Location {
-                parents: 1,
-                interior: Junctions::from(Junction::AccountId32 {
-                    network: None,
-                    id: [1u8; 32],
-                }),
-            };
-
-            let sibling_parachain_location = Location {
-                parents: 1,
-                interior: Junctions::from([
-                    Junction::Parachain(10),
-                    Junction::AccountId32 {
+            let destination = Location::new(
+                1,
+                [
+                    Parachain(10),
+                    AccountId32 {
                         network: None,
                         id: [1u8; 32],
                     },
-                ]),
-            };
+                ],
+            );
 
-            // sending relay token back to relay chain
-            precompiles()
-                .prepare_test(
-                    TestAccount::Alice,
-                    PRECOMPILE_ADDRESS,
-                    PrecompileCall::transfer {
-                        currency_address: Address::from(Runtime::asset_id_to_address(1u128)),
-                        amount_of_tokens: 42000u64.into(),
-                        destination: parent_destination.clone(),
-                        weight: weight.clone(),
-                    },
-                )
-                .expect_no_logs()
-                .execute_returns(true);
-
-            let expected_asset: Asset = Asset {
-                id: AssetId(CurrencyIdToMultiLocation::convert(1).unwrap()),
-                fun: Fungibility::Fungible(42000),
-            };
-
-            let expected: crate::mock::RuntimeEvent =
-                mock::RuntimeEvent::Xtokens(XtokensEvent::TransferredAssets {
-                    sender: TestAccount::Alice.into(),
-                    assets: vec![expected_asset.clone()].into(),
-                    fee: expected_asset,
-                    dest: parent_destination,
-                })
-                .into();
-            assert!(events().contains(&expected));
-
-            // sending parachain token back to parachain
             precompiles()
                 .prepare_test(
                     TestAccount::Alice,
@@ -487,43 +340,37 @@ mod xcm_new_interface_test {
                     PrecompileCall::transfer {
                         currency_address: Address::from(Runtime::asset_id_to_address(2u128)),
                         amount_of_tokens: 42000u64.into(),
-                        destination: sibling_parachain_location.clone(),
-                        weight,
+                        destination,
+                        weight: weight(),
                     },
                 )
                 .expect_no_logs()
                 .execute_returns(true);
 
-            let expected_asset: Asset = Asset {
-                id: AssetId(CurrencyIdToMultiLocation::convert(2).unwrap()),
-                fun: Fungibility::Fungible(42000),
-            };
-
-            let expected: crate::mock::RuntimeEvent =
-                mock::RuntimeEvent::Xtokens(XtokensEvent::TransferredAssets {
-                    sender: TestAccount::Alice.into(),
-                    assets: vec![expected_asset.clone()].into(),
-                    fee: expected_asset,
-                    dest: sibling_parachain_location,
-                })
-                .into();
-            assert!(events().contains(&expected));
+            let (dest, message) = only_sent_xcm();
+            assert_eq!(
+                dest,
+                Location::new(1, [Parachain(10)]),
+                "the beneficiary junction must be stripped from the destination"
+            );
+            assert_deposits_to(&message, &beneficiary_32(1));
         });
     }
 
     #[test]
-    fn xtokens_transfer_works_for_native_asset() {
-        let weight = WeightV2::from(3_000_000_000u64, 1024);
-        let parent_destination = Location {
-            parents: 1,
-            interior: Junctions::from(Junction::AccountId32 {
-                network: None,
-                id: [1u8; 32],
-            }),
-        };
-
+    fn native_asset_works() {
         ExtBuilder.build().execute_with(|| {
-            // sending native token to relay
+            let destination = Location::new(
+                1,
+                [
+                    Parachain(10),
+                    AccountId32 {
+                        network: None,
+                        id: [1u8; 32],
+                    },
+                ],
+            );
+
             precompiles()
                 .prepare_test(
                     TestAccount::Alice,
@@ -531,466 +378,312 @@ mod xcm_new_interface_test {
                     PrecompileCall::transfer {
                         currency_address: Address::from(NATIVE_ADDRESS),
                         amount_of_tokens: 42000u64.into(),
-                        destination: parent_destination.clone(),
-                        weight: weight.clone(),
+                        destination,
+                        weight: weight(),
                     },
                 )
                 .expect_no_logs()
                 .execute_returns(true);
 
-            let expected_asset: Asset = Asset {
-                id: AssetId(Here.into()),
-                fun: Fungibility::Fungible(42000),
-            };
-
-            let expected: crate::mock::RuntimeEvent =
-                mock::RuntimeEvent::Xtokens(XtokensEvent::TransferredAssets {
-                    sender: TestAccount::Alice.into(),
-                    assets: vec![expected_asset.clone()].into(),
-                    fee: expected_asset,
-                    dest: parent_destination,
-                })
-                .into();
-            assert!(events().contains(&expected));
+            let (dest, message) = only_sent_xcm();
+            assert_eq!(dest, Location::new(1, [Parachain(10)]));
+            assert_deposits_to(&message, &beneficiary_32(1));
         });
     }
 
     #[test]
-    fn xtokens_transfer_with_fee_works() {
-        let weight = WeightV2::from(3_000_000_000u64, 1024);
+    fn relay_token_to_asset_hub_works() {
         ExtBuilder.build().execute_with(|| {
-            let parent_destination = Location {
-                parents: 1,
-                interior: Junctions::from(Junction::AccountId32 {
-                    network: None,
-                    id: [1u8; 32],
-                }),
-            };
-
-            // sending relay token back to relay chain
-            precompiles()
-                .prepare_test(
-                    TestAccount::Alice,
-                    PRECOMPILE_ADDRESS,
-                    PrecompileCall::transfer_with_fee {
-                        currency_address: Address::from(Runtime::asset_id_to_address(1u128)),
-                        amount_of_tokens: 42000u64.into(),
-                        fee: 50.into(),
-                        destination: parent_destination.clone(),
-                        weight,
-                    },
-                )
-                .expect_no_logs()
-                .execute_returns(true);
-
-            let expected_asset: Asset = Asset {
-                id: AssetId(CurrencyIdToMultiLocation::convert(1).unwrap()),
-                fun: Fungibility::Fungible(42000),
-            };
-            let expected_fee: Asset = Asset {
-                id: AssetId(CurrencyIdToMultiLocation::convert(1).unwrap()),
-                fun: Fungibility::Fungible(50),
-            };
-
-            let expected: crate::mock::RuntimeEvent =
-                mock::RuntimeEvent::Xtokens(XtokensEvent::TransferredAssets {
-                    sender: TestAccount::Alice.into(),
-                    assets: vec![expected_asset.clone(), expected_fee.clone()].into(),
-                    fee: expected_fee,
-                    dest: parent_destination,
-                })
-                .into();
-            assert!(events().contains(&expected));
-        });
-    }
-
-    #[test]
-    fn xtokens_transfer_with_fee_works_for_native_asset() {
-        let weight = WeightV2::from(3_000_000_000u64, 1024);
-        let parent_destination = Location {
-            parents: 1,
-            interior: Junctions::from(Junction::AccountId32 {
-                network: None,
-                id: [1u8; 32],
-            }),
-        };
-
-        ExtBuilder.build().execute_with(|| {
-            // sending native token to relay
-            precompiles()
-                .prepare_test(
-                    TestAccount::Alice,
-                    PRECOMPILE_ADDRESS,
-                    PrecompileCall::transfer_with_fee {
-                        currency_address: Address::from(NATIVE_ADDRESS),
-                        amount_of_tokens: 42000u64.into(),
-                        fee: 50.into(),
-                        destination: parent_destination.clone(),
-                        weight,
-                    },
-                )
-                .expect_no_logs()
-                .execute_returns(true);
-
-            let expected_asset: Asset = Asset {
-                id: AssetId(Here.into()),
-                fun: Fungibility::Fungible(42000),
-            };
-            let expected_fee: Asset = Asset {
-                id: AssetId(Here.into()),
-                fun: Fungibility::Fungible(50),
-            };
-            let expected: crate::mock::RuntimeEvent =
-                mock::RuntimeEvent::Xtokens(XtokensEvent::TransferredAssets {
-                    sender: TestAccount::Alice.into(),
-                    assets: vec![expected_asset.clone(), expected_fee.clone()].into(),
-                    fee: expected_fee,
-                    dest: parent_destination,
-                })
-                .into();
-            assert!(events().contains(&expected));
-        });
-    }
-
-    #[test]
-    fn transfer_multiasset_works() {
-        let weight = WeightV2::from(3_000_000_000u64, 1024);
-        ExtBuilder.build().execute_with(|| {
-            let relay_token_location = Location {
-                parents: 1,
-                interior: Junctions::Here,
-            };
-            let relay_destination = Location {
-                parents: 1,
-                interior: Junctions::from(Junction::AccountId32 {
-                    network: None,
-                    id: [1u8; 32],
-                }),
-            };
-            let para_destination = Location {
-                parents: 1,
-                interior: Junctions::from([
-                    Junction::Parachain(10),
-                    Junction::AccountId32 {
+            let destination = Location::new(
+                1,
+                [
+                    Parachain(ASSET_HUB_PARA_ID),
+                    AccountId32 {
                         network: None,
                         id: [1u8; 32],
                     },
-                ]),
-            };
-            let native_token_location: Location = (Here).into();
-
-            let amount = 4200u64;
-            // relay token to relay
-            precompiles()
-                .prepare_test(
-                    TestAccount::Alice,
-                    PRECOMPILE_ADDRESS,
-                    PrecompileCall::transfer_multiasset {
-                        asset_location: relay_token_location.clone(),
-                        amount_of_tokens: amount.into(),
-                        destination: relay_destination.clone(),
-                        weight: weight.clone(),
-                    },
-                )
-                .expect_no_logs()
-                .execute_returns(true);
-
-            let expected_asset: Asset = Asset {
-                id: AssetId(relay_token_location.clone()),
-                fun: Fungibility::Fungible(amount.into()),
-            };
-            let expected: crate::mock::RuntimeEvent =
-                mock::RuntimeEvent::Xtokens(XtokensEvent::TransferredAssets {
-                    sender: TestAccount::Alice.into(),
-                    assets: vec![expected_asset.clone()].into(),
-                    fee: expected_asset,
-                    dest: relay_destination,
-                })
-                .into();
-
-            // Assert that the events vector contains the one expected
-            assert!(events().contains(&expected));
-
-            // relay to para
-            precompiles()
-                .prepare_test(
-                    TestAccount::Alice,
-                    PRECOMPILE_ADDRESS,
-                    PrecompileCall::transfer_multiasset {
-                        asset_location: relay_token_location.clone(),
-                        amount_of_tokens: amount.into(),
-                        destination: para_destination.clone(),
-                        weight: weight.clone(),
-                    },
-                )
-                .expect_no_logs()
-                .execute_returns(true);
-
-            let expected_asset: Asset = Asset {
-                id: AssetId(relay_token_location),
-                fun: Fungibility::Fungible(amount.into()),
-            };
-            let expected: crate::mock::RuntimeEvent =
-                mock::RuntimeEvent::Xtokens(XtokensEvent::TransferredAssets {
-                    sender: TestAccount::Alice.into(),
-                    assets: vec![expected_asset.clone()].into(),
-                    fee: expected_asset,
-                    dest: para_destination.clone(),
-                })
-                .into();
-
-            // Assert that the events vector contains the one expected
-            assert!(events().contains(&expected));
-
-            // native token to para
+                ],
+            );
 
             precompiles()
                 .prepare_test(
                     TestAccount::Alice,
                     PRECOMPILE_ADDRESS,
-                    PrecompileCall::transfer_multiasset {
-                        asset_location: native_token_location.clone(), // zero address by convention
-                        amount_of_tokens: amount.into(),
-                        destination: para_destination.clone(),
-                        weight: weight.clone(),
-                    },
-                )
-                .expect_no_logs()
-                .execute_returns(true);
-
-            let expected_asset: Asset = Asset {
-                id: AssetId(native_token_location),
-                fun: Fungibility::Fungible(amount.into()),
-            };
-            let expected: crate::mock::RuntimeEvent =
-                mock::RuntimeEvent::Xtokens(XtokensEvent::TransferredAssets {
-                    sender: TestAccount::Alice.into(),
-                    assets: vec![expected_asset.clone()].into(),
-                    fee: expected_asset,
-                    dest: para_destination,
-                })
-                .into();
-
-            // Assert that the events vector contains the one expected
-            assert!(events().contains(&expected));
-        });
-    }
-
-    #[test]
-    fn transfer_multi_currencies_works() {
-        let destination = Location::new(
-            1,
-            Junctions::from([Junction::AccountId32 {
-                network: None,
-                id: [1u8; 32],
-            }]),
-        );
-
-        let weight = WeightV2::from(3_000_000_000u64, 1024);
-
-        //  NOTE: Currently only support `ToReserve` with relay-chain asset as fee. other case
-        // like `NonReserve` or `SelfReserve` with relay-chain fee is not support.
-        let currencies = vec![
-            (
-                Address::from(Runtime::asset_id_to_address(2u128)),
-                U256::from(500),
-            )
-                .into(),
-            (
-                Address::from(Runtime::asset_id_to_address(3u128)),
-                U256::from(500),
-            )
-                .into(),
-        ]
-        .into();
-
-        ExtBuilder.build().execute_with(|| {
-            precompiles()
-                .prepare_test(
-                    TestAccount::Alice,
-                    PRECOMPILE_ADDRESS,
-                    PrecompileCall::transfer_multi_currencies {
-                        currencies,
-                        fee_item: 0u32,
-                        destination: destination.clone(),
-                        weight,
-                    },
-                )
-                .expect_no_logs()
-                .execute_returns(true);
-
-            let expected_asset_1: Asset = Asset {
-                id: AssetId(CurrencyIdToMultiLocation::convert(2u128).unwrap()),
-                fun: Fungibility::Fungible(500),
-            };
-            let expected_asset_2: Asset = Asset {
-                id: AssetId(CurrencyIdToMultiLocation::convert(3u128).unwrap()),
-                fun: Fungibility::Fungible(500),
-            };
-
-            let expected: crate::mock::RuntimeEvent =
-                mock::RuntimeEvent::Xtokens(XtokensEvent::TransferredAssets {
-                    sender: TestAccount::Alice.into(),
-                    assets: vec![expected_asset_1.clone(), expected_asset_2].into(),
-                    fee: expected_asset_1,
-                    dest: destination,
-                })
-                .into();
-            assert!(events().contains(&expected));
-        });
-    }
-
-    #[test]
-    fn transfer_multi_currencies_cannot_insert_more_than_max() {
-        let destination = Location::new(
-            1,
-            Junctions::from([Junction::AccountId32 {
-                network: None,
-                id: [1u8; 32],
-            }]),
-        );
-        let weight = WeightV2::from(3_000_000_000u64, 1024);
-        // we only allow upto 2 currencies to be transfered
-        let currencies = vec![
-            (
-                Address::from(Runtime::asset_id_to_address(2u128)),
-                U256::from(500),
-            )
-                .into(),
-            (
-                Address::from(Runtime::asset_id_to_address(3u128)),
-                U256::from(500),
-            )
-                .into(),
-            (
-                Address::from(Runtime::asset_id_to_address(4u128)),
-                U256::from(500),
-            )
-                .into(),
-        ]
-        .into();
-
-        ExtBuilder.build().execute_with(|| {
-            precompiles()
-                .prepare_test(
-                    TestAccount::Alice,
-                    PRECOMPILE_ADDRESS,
-                    PrecompileCall::transfer_multi_currencies {
-                        currencies,
-                        fee_item: 0u32,
+                    PrecompileCall::transfer {
+                        currency_address: Address::from(Runtime::asset_id_to_address(1u128)),
+                        amount_of_tokens: 42000u64.into(),
                         destination,
-                        weight,
+                        weight: weight(),
                     },
                 )
                 .expect_no_logs()
-                .execute_reverts(|output| output == b"currencies: Value is too large for length");
+                .execute_returns(true);
+
+            let (dest, message) = only_sent_xcm();
+            assert_eq!(dest, Location::new(1, [Parachain(ASSET_HUB_PARA_ID)]));
+            assert_deposits_to(&message, &beneficiary_32(1));
         });
     }
 
     #[test]
-    fn transfer_multiassets_works() {
-        let destination = Location::new(
-            1,
-            Junctions::from([
-                Junction::Parachain(2),
-                Junction::AccountId32 {
+    fn relay_token_to_relay_reverts() {
+        ExtBuilder.build().execute_with(|| {
+            let destination = Location::new(
+                1,
+                [AccountId32 {
                     network: None,
                     id: [1u8; 32],
-                },
-            ]),
-        );
-        let weight = WeightV2::from(3_000_000_000u64, 1024);
+                }],
+            );
 
-        let asset_1_location = Location::new(
-            1,
-            Junctions::from([Junction::Parachain(2), Junction::GeneralIndex(0u128)]),
-        );
-        let asset_2_location =
-            Location::new(1, Junctions::from([Parachain(2), GeneralIndex(1u128)]));
-
-        let assets = vec![
-            (asset_1_location.clone(), U256::from(500)).into(),
-            (asset_2_location.clone(), U256::from(500)).into(),
-        ]
-        .into();
-
-        let multiassets = Assets::from_sorted_and_deduplicated(vec![
-            (asset_1_location.clone(), 500).into(),
-            (asset_2_location, 500).into(),
-        ])
-        .unwrap();
-
-        ExtBuilder.build().execute_with(|| {
             precompiles()
                 .prepare_test(
                     TestAccount::Alice,
                     PRECOMPILE_ADDRESS,
-                    PrecompileCall::transfer_multi_assets {
-                        assets,
-                        fee_item: 0u32,
-                        destination: destination.clone(),
-                        weight,
+                    PrecompileCall::transfer {
+                        currency_address: Address::from(Runtime::asset_id_to_address(1u128)),
+                        amount_of_tokens: 42000u64.into(),
+                        destination,
+                        weight: weight(),
                     },
                 )
                 .expect_no_logs()
-                .execute_returns(true);
-
-            let expected: crate::mock::RuntimeEvent =
-                mock::RuntimeEvent::Xtokens(XtokensEvent::TransferredAssets {
-                    sender: TestAccount::Alice.into(),
-                    assets: multiassets,
-                    fee: (asset_1_location, 500).into(),
-                    dest: destination,
-                })
-                .into();
-            assert!(events().contains(&expected));
+                .execute_reverts(|output| {
+                    output == b"DOT cannot be sent directly to the relay. Route via AssetHub (parachain 1000)."
+                });
         });
     }
 
     #[test]
-    fn transfer_multiassets_cannot_insert_more_than_max() {
-        // We have definaed MaxAssetsForTransfer = 2,
-        // so any number greater than MaxAssetsForTransfer will result in error
-        let destination = Location::new(
+    fn unknown_currency_address_reverts() {
+        ExtBuilder.build().execute_with(|| {
+            let destination = Location::new(
+                1,
+                [
+                    Parachain(10),
+                    AccountId32 {
+                        network: None,
+                        id: [1u8; 32],
+                    },
+                ],
+            );
+
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::transfer {
+                        currency_address: Address::from(H160::repeat_byte(0xF1)),
+                        amount_of_tokens: 42000u64.into(),
+                        destination,
+                        weight: weight(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_reverts(|output| output == b"Failed to resolve asset id from address");
+        });
+    }
+
+    #[test]
+    fn destination_without_chain_part_reverts() {
+        ExtBuilder.build().execute_with(|| {
+            // No parent and no chain junction - there is no chain to send this to.
+            let destination = Location::new(
+                0,
+                [AccountId32 {
+                    network: None,
+                    id: [1u8; 32],
+                }],
+            );
+
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::transfer {
+                        currency_address: Address::from(NATIVE_ADDRESS),
+                        amount_of_tokens: 42000u64.into(),
+                        destination,
+                        weight: weight(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_reverts(|output| {
+                    output == b"error splitting destination into chain and beneficiary"
+                });
+        });
+    }
+}
+
+/// The ten selectors that were backed by `orml-xtokens` and saw no traffic on any network.
+///
+/// They stay registered so the precompile's ABI is unchanged, but every one of them must revert
+/// with the shared deprecation notice rather than silently doing something unexpected.
+mod deprecated {
+    use super::*;
+
+    fn weight() -> WeightV2 {
+        WeightV2::from(3_000_000_000u64, 1024)
+    }
+
+    fn parachain_destination() -> Location {
+        Location::new(
             1,
-            Junctions::from([
-                Parachain(2),
+            [
+                Parachain(10),
                 AccountId32 {
                     network: None,
                     id: [1u8; 32],
                 },
-            ]),
+            ],
+        )
+    }
+
+    fn assert_deprecated(call: PrecompileCall) {
+        precompiles()
+            .prepare_test(TestAccount::Alice, PRECOMPILE_ADDRESS, call)
+            .expect_no_logs()
+            .execute_reverts(|output| {
+                String::from_utf8_lossy(output).contains("deprecated: xtokens has been removed")
+            });
+
+        assert!(
+            take_sent_xcm().is_empty(),
+            "a deprecated method must not send any XCM"
         );
-        let weight = WeightV2::from(3_000_000_000u64, 1024);
+    }
 
-        let asset_1_location =
-            Location::new(1, Junctions::from([Parachain(2), GeneralIndex(0u128)]));
-        let asset_2_location =
-            Location::new(1, Junctions::from([Parachain(2), GeneralIndex(1u128)]));
-        let asset_3_location =
-            Location::new(1, Junctions::from([Parachain(2), GeneralIndex(3u128)]));
-
-        let assets = vec![
-            (asset_1_location.clone(), U256::from(500)).into(),
-            (asset_2_location.clone(), U256::from(500)).into(),
-            (asset_3_location.clone(), U256::from(500)).into(),
-        ]
-        .into();
-
+    #[test]
+    fn assets_withdraw_evm_v1_reverts() {
         ExtBuilder.build().execute_with(|| {
-            precompiles()
-                .prepare_test(
-                    TestAccount::Alice,
-                    PRECOMPILE_ADDRESS,
-                    PrecompileCall::transfer_multi_assets {
-                        assets,
-                        fee_item: 0u32,
-                        destination,
-                        weight,
-                    },
+            assert_deprecated(PrecompileCall::assets_withdraw_evm_v1 {
+                assets: vec![Address::from(Runtime::asset_id_to_address(2u128))].into(),
+                amounts: vec![42000u64.into()].into(),
+                recipient_account_id: Address(H160::repeat_byte(0xDE)),
+                is_relay: false,
+                parachain_id: 10.into(),
+                fee_index: 0.into(),
+            });
+        });
+    }
+
+    #[test]
+    fn remote_transact_v1_reverts() {
+        ExtBuilder.build().execute_with(|| {
+            assert_deprecated(PrecompileCall::remote_transact_v1 {
+                para_id: 0.into(),
+                is_relay: true,
+                fee_asset_addr: Address::from(Runtime::asset_id_to_address(1u128)),
+                fee_amount: 367.into(),
+                remote_call: vec![0xff_u8, 0xaa, 0x77, 0x00].into(),
+                transact_weight: 3_000_000_000u64,
+            });
+        });
+    }
+
+    #[test]
+    fn assets_reserve_transfer_native_v1_reverts() {
+        ExtBuilder.build().execute_with(|| {
+            assert_deprecated(PrecompileCall::assets_reserve_transfer_native_v1 {
+                assets: vec![Address::from(Runtime::asset_id_to_address(2u128))].into(),
+                amounts: vec![42000u64.into()].into(),
+                recipient_account_id: H256::repeat_byte(0xF1),
+                is_relay: false,
+                parachain_id: 10.into(),
+                fee_index: 0.into(),
+            });
+        });
+    }
+
+    #[test]
+    fn assets_reserve_transfer_evm_v1_reverts() {
+        ExtBuilder.build().execute_with(|| {
+            assert_deprecated(PrecompileCall::assets_reserve_transfer_evm_v1 {
+                assets: vec![Address::from(Runtime::asset_id_to_address(2u128))].into(),
+                amounts: vec![42000u64.into()].into(),
+                recipient_account_id: Address(H160::repeat_byte(0xDE)),
+                is_relay: false,
+                parachain_id: 10.into(),
+                fee_index: 0.into(),
+            });
+        });
+    }
+
+    #[test]
+    fn send_xcm_reverts() {
+        ExtBuilder.build().execute_with(|| {
+            let message: Xcm<()> = Xcm(vec![ClearOrigin]);
+            assert_deprecated(PrecompileCall::send_xcm {
+                dest: Location::parent(),
+                xcm_call: xcm::VersionedXcm::V5(message).encode().into(),
+            });
+        });
+    }
+
+    #[test]
+    fn transfer_with_fee_reverts() {
+        ExtBuilder.build().execute_with(|| {
+            assert_deprecated(PrecompileCall::transfer_with_fee {
+                currency_address: Address::from(Runtime::asset_id_to_address(2u128)),
+                amount_of_tokens: 42000u64.into(),
+                fee: 100u64.into(),
+                destination: parachain_destination(),
+                weight: weight(),
+            });
+        });
+    }
+
+    #[test]
+    fn transfer_multiasset_reverts() {
+        ExtBuilder.build().execute_with(|| {
+            assert_deprecated(PrecompileCall::transfer_multiasset {
+                asset_location: Location::new(1, [Parachain(10)]),
+                amount_of_tokens: 42000u64.into(),
+                destination: parachain_destination(),
+                weight: weight(),
+            });
+        });
+    }
+
+    #[test]
+    fn transfer_multiasset_with_fee_reverts() {
+        ExtBuilder.build().execute_with(|| {
+            assert_deprecated(PrecompileCall::transfer_multiasset_with_fee {
+                asset_location: Location::new(1, [Parachain(10)]),
+                amount_of_tokens: 42000u64.into(),
+                fee: 100u64.into(),
+                destination: parachain_destination(),
+                weight: weight(),
+            });
+        });
+    }
+
+    #[test]
+    fn transfer_multi_currencies_reverts() {
+        ExtBuilder.build().execute_with(|| {
+            assert_deprecated(PrecompileCall::transfer_multi_currencies {
+                currencies: vec![(
+                    Address::from(Runtime::asset_id_to_address(2u128)),
+                    42000.into(),
                 )
-                .expect_no_logs()
-                .execute_reverts(|output| output == b"assets: Value is too large for length");
+                    .into()]
+                .into(),
+                fee_item: 0u32,
+                destination: parachain_destination(),
+                weight: weight(),
+            });
+        });
+    }
+
+    #[test]
+    fn transfer_multi_assets_reverts() {
+        ExtBuilder.build().execute_with(|| {
+            assert_deprecated(PrecompileCall::transfer_multi_assets {
+                assets: vec![(Location::new(1, [Parachain(10)]), 42000.into()).into()].into(),
+                fee_item: 0u32,
+                destination: parachain_destination(),
+                weight: weight(),
+            });
         });
     }
 }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -42,7 +42,6 @@ xcm-builder = { workspace = true }
 xcm-executor = { workspace = true }
 
 # ORML dependencies
-orml-traits = { workspace = true }
 
 pallet-contracts = { workspace = true }
 
@@ -78,7 +77,6 @@ std = [
 	"xcm/std",
 	"xcm-builder/std",
 	"xcm-executor/std",
-	"orml-traits/std",
 	"pallet-xc-asset-config/std",
 	"fp-evm/std",
 	"pallet-assets/std",

--- a/primitives/src/xcm/mod.rs
+++ b/primitives/src/xcm/mod.rs
@@ -26,26 +26,24 @@
 //! - `FixedRateOfForeignAsset` - weight trader for execution payment in foreign asset
 //! - `ReserveAssetFilter` - used to check whether asset/origin are a valid reserve location
 //! - `XcmFungibleFeeHandler` - used to handle XCM fee execution fees
+//! - `split_location_into_chain_part_and_beneficiary` - splits a combined `Location` into
+//!   the destination chain part and the beneficiary part, as required by `pallet_xcm`
+//! - `resolve_transfer_type` - picks the reserve model `pallet_xcm` should use for a transfer
 //!
 //! Please refer to implementation below for more info.
 //!
-
-use crate::AccountId;
 
 use frame_support::{
     traits::{tokens::fungibles, ContainsPair, Get},
     weights::constants::WEIGHT_REF_TIME_PER_SECOND,
 };
-use sp_runtime::traits::{Bounded, Convert, MaybeEquivalence, Zero};
+use sp_runtime::traits::{Bounded, MaybeEquivalence, Zero};
 use sp_std::marker::PhantomData;
 
 // Polkadot imports
 use xcm::latest::{prelude::*, Weight};
 use xcm_builder::TakeRevenue;
-use xcm_executor::traits::{MatchesFungibles, WeightTrader};
-
-// ORML imports
-use orml_traits::location::Reserve;
+use xcm_executor::traits::{MatchesFungibles, TransferType, WeightTrader, XcmAssetTransfers};
 
 use pallet_xc_asset_config::{ExecutionPaymentRate, XcAssetLocation};
 
@@ -258,47 +256,68 @@ impl<
     }
 }
 
-/// Convert `AccountId` to `Location`.
-pub struct AccountIdToMultiLocation;
-impl Convert<AccountId, Location> for AccountIdToMultiLocation {
-    fn convert(account: AccountId) -> Location {
-        AccountId32 {
-            network: None,
-            id: account.into(),
+/// Splits a combined `Location` into its chain part and its beneficiary part.
+///
+/// Junctions are popped off the tail until a chain identifier (`Parachain`/`GlobalConsensus`)
+/// is reached; whatever was popped becomes the beneficiary, relative to the chain part.
+///
+/// A location with no chain identifier is only valid when it has exactly one parent, in which
+/// case the chain part is the relay chain. Returns `None` for anything else.
+pub fn split_location_into_chain_part_and_beneficiary(
+    mut location: Location,
+) -> Option<(Location, Location)> {
+    let mut beneficiary_junctions = Junctions::Here;
+
+    while let Some(junction) = location.last() {
+        if matches!(
+            junction,
+            Junction::Parachain(_) | Junction::GlobalConsensus(_)
+        ) {
+            return Some((location, beneficiary_junctions.into_location()));
         }
-        .into()
+
+        let (prefix, maybe_last) = location.split_last_interior();
+        location = prefix;
+        if let Some(junction) = maybe_last {
+            beneficiary_junctions.push_front(junction).ok()?;
+        }
+    }
+
+    // No chain identifier found: only the relay chain qualifies.
+    if location.parent_count() == 1 {
+        Some((Location::parent(), beneficiary_junctions.into_location()))
+    } else {
+        None
     }
 }
 
-/// `Asset` reserve location provider.
-/// Converts self absolute location to relative location.
-pub struct AbsoluteAndRelativeReserveProvider<AbsoluteLocation>(PhantomData<AbsoluteLocation>);
-impl<AbsoluteLocation: Get<Location>> Reserve
-    for AbsoluteAndRelativeReserveProvider<AbsoluteLocation>
-{
-    fn reserve(asset: &Asset) -> Option<Location> {
-        // Local/native assets (parents==0, no Parachain junction) → Here.
-        // Parent relay chain, sibling or child parachains → their chain prefix.
-        let reserve_location = {
-            let AssetId(location) = &asset.id;
-            match (location.parents, location.first_interior()) {
-                (1, Some(Parachain(id))) => Some(Location::new(1, [Parachain(*id)])),
-                (1, _) => Some(Location::parent()),
-                (0, Some(Parachain(id))) => Some(Location::new(0, [Parachain(*id)])),
-                (0, _) => Some(Location::here()), // local asset, no chain prefix
-                _ => None,
-            }
-        }?;
-
-        if reserve_location == AbsoluteLocation::get() {
-            return Some(Location::here());
-        }
-
-        let is_relay_token = reserve_location.contains_parents_only(1);
-        if is_relay_token {
-            return Some(Location::new(1, [Parachain(ASSET_HUB_PARA_ID)]));
-        }
-
-        Some(reserve_location)
+/// Resolves which reserve model `pallet_xcm` should use to move `asset` to `dest`.
+///
+/// Defers to the XCM executor's own determination, which is driven by the runtime's
+/// [`ReserveAssetFilter`] and teleport filter - the same logic `pallet_xcm::transfer_assets` runs
+/// internally. One case the executor cannot resolve on its own: the relay-native token (`DOT`,
+/// `KSM`, ...) is identified by the bare parent location, but its trusted reserve is Asset Hub
+/// rather than the relay chain. For any destination other than Asset Hub itself the executor gives
+/// up, so we name Asset Hub as a remote reserve explicitly.
+///
+/// This mirrors the routing that `orml-xtokens` derived from its `AbsoluteAndRelativeReserveProvider`,
+/// so EVM callers see the same behaviour after the pallet's removal.
+///
+/// Returns `None` when no reserve can be determined - the caller should reject the transfer.
+pub fn resolve_transfer_type<XcmExecutor: XcmAssetTransfers>(
+    asset: &Asset,
+    dest: &Location,
+) -> Option<TransferType> {
+    if let Ok(transfer_type) = XcmExecutor::determine_for(asset, dest) {
+        return Some(transfer_type);
     }
+
+    let AssetId(location) = &asset.id;
+    if location == &Location::parent() {
+        return Some(TransferType::RemoteReserve(
+            Location::new(1, [Parachain(ASSET_HUB_PARA_ID)]).into(),
+        ));
+    }
+
+    None
 }

--- a/primitives/src/xcm/tests.rs
+++ b/primitives/src/xcm/tests.rs
@@ -458,3 +458,159 @@ fn reserve_asset_filter_accepts_asset_hub_as_reserve() {
 
     assert!(ReserveAssetFilter::contains(&multi_asset, &origin));
 }
+
+#[test]
+fn split_location_sibling_parachain_with_account_id_32() {
+    let location = Location::new(
+        1,
+        [
+            Parachain(1000),
+            AccountId32 {
+                network: None,
+                id: [1u8; 32],
+            },
+        ],
+    );
+
+    let (chain, beneficiary) = split_location_into_chain_part_and_beneficiary(location)
+        .expect("Parachain junction must be recognized as the chain part.");
+
+    assert_eq!(chain, Location::new(1, [Parachain(1000)]));
+    assert_eq!(
+        beneficiary,
+        Location::new(
+            0,
+            [AccountId32 {
+                network: None,
+                id: [1u8; 32]
+            }]
+        )
+    );
+}
+
+#[test]
+fn split_location_sibling_parachain_with_account_key_20() {
+    let location = Location::new(
+        1,
+        [
+            Parachain(2000),
+            AccountKey20 {
+                network: None,
+                key: [2u8; 20],
+            },
+        ],
+    );
+
+    let (chain, beneficiary) = split_location_into_chain_part_and_beneficiary(location)
+        .expect("Parachain junction must be recognized as the chain part.");
+
+    assert_eq!(chain, Location::new(1, [Parachain(2000)]));
+    assert_eq!(
+        beneficiary,
+        Location::new(
+            0,
+            [AccountKey20 {
+                network: None,
+                key: [2u8; 20]
+            }]
+        )
+    );
+}
+
+#[test]
+fn split_location_relay_chain_beneficiary() {
+    let location = Location::new(
+        1,
+        [AccountId32 {
+            network: None,
+            id: [3u8; 32],
+        }],
+    );
+
+    let (chain, beneficiary) = split_location_into_chain_part_and_beneficiary(location)
+        .expect("Single parent without chain junction must resolve to the relay chain.");
+
+    assert_eq!(chain, Location::parent());
+    assert_eq!(
+        beneficiary,
+        Location::new(
+            0,
+            [AccountId32 {
+                network: None,
+                id: [3u8; 32]
+            }]
+        )
+    );
+}
+
+#[test]
+fn split_location_keeps_beneficiary_junction_order() {
+    let location = Location::new(
+        1,
+        [
+            Parachain(1000),
+            PalletInstance(50),
+            GeneralIndex(1984),
+            AccountId32 {
+                network: None,
+                id: [4u8; 32],
+            },
+        ],
+    );
+
+    let (chain, beneficiary) = split_location_into_chain_part_and_beneficiary(location)
+        .expect("Parachain junction must be recognized as the chain part.");
+
+    assert_eq!(chain, Location::new(1, [Parachain(1000)]));
+    assert_eq!(
+        beneficiary,
+        Location::new(
+            0,
+            [
+                PalletInstance(50),
+                GeneralIndex(1984),
+                AccountId32 {
+                    network: None,
+                    id: [4u8; 32]
+                }
+            ]
+        )
+    );
+}
+
+#[test]
+fn split_location_chain_part_only_gives_empty_beneficiary() {
+    let (chain, beneficiary) =
+        split_location_into_chain_part_and_beneficiary(Location::new(1, [Parachain(1000)]))
+            .expect("A bare chain location is a valid input.");
+
+    assert_eq!(chain, Location::new(1, [Parachain(1000)]));
+    assert_eq!(beneficiary, Location::here());
+}
+
+#[test]
+fn split_location_without_chain_identifier_reverts() {
+    // Local location - no parent, no chain junction.
+    assert!(
+        split_location_into_chain_part_and_beneficiary(Location::new(
+            0,
+            [AccountId32 {
+                network: None,
+                id: [5u8; 32]
+            }]
+        ))
+        .is_none()
+    );
+
+    // Two parents but no chain junction - cannot be resolved.
+    assert!(
+        split_location_into_chain_part_and_beneficiary(Location::new(
+            2,
+            [AccountId32 {
+                network: None,
+                id: [5u8; 32]
+            }]
+        ))
+        .is_none()
+    );
+}

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -105,9 +105,6 @@ xcm-builder = { workspace = true }
 xcm-executor = { workspace = true }
 xcm-runtime-apis = { workspace = true }
 
-# orml dependencies
-orml-xcm-support = { workspace = true }
-orml-xtokens = { workspace = true }
 
 # benchmarking
 array-bytes = { workspace = true }
@@ -176,8 +173,6 @@ std = [
 	"moonbeam-rpc-primitives-debug/std",
 	"moonbeam-rpc-primitives-txpool/std",
 	"num_enum/std",
-	"orml-xcm-support/std",
-	"orml-xtokens/std",
 	"pallet-assets/std",
 	"pallet-aura/std",
 	"pallet-authorship/std",
@@ -269,7 +264,6 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system-benchmarking/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
-	"orml-xtokens/runtime-benchmarks",
 	"pallet-assets/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",
 	"pallet-safe-mode/runtime-benchmarks",
@@ -329,7 +323,6 @@ try-runtime = [
 	"frame-system/try-runtime",
 	"frame-try-runtime/try-runtime",
 	"log",
-	"orml-xtokens/try-runtime",
 	"pallet-assets/try-runtime",
 	"pallet-aura/try-runtime",
 	"pallet-safe-mode/try-runtime",

--- a/runtime/astar/Cargo.toml
+++ b/runtime/astar/Cargo.toml
@@ -105,7 +105,6 @@ xcm-builder = { workspace = true }
 xcm-executor = { workspace = true }
 xcm-runtime-apis = { workspace = true }
 
-
 # benchmarking
 array-bytes = { workspace = true }
 frame-benchmarking = { workspace = true, optional = true }

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -1644,6 +1644,7 @@ mod runtime {
     pub type CumulusXcm = cumulus_pallet_xcm;
     #[runtime::pallet_index(54)]
     pub type XcAssetConfig = pallet_xc_asset_config;
+    // skip 55 - orml_xtokens previously
     #[runtime::pallet_index(56)]
     pub type MessageQueue = pallet_message_queue;
 
@@ -1740,9 +1741,7 @@ pub type Executive = frame_executive::Executive<
 pub type Migrations = (Unreleased, Permanent);
 
 /// Unreleased migrations. Add new ones here:
-pub type Unreleased = (
-    frame_support::migrations::RemovePallet<XTokensPalletName, RocksDbWeight>,
-);
+pub type Unreleased = (frame_support::migrations::RemovePallet<XTokensPalletName, RocksDbWeight>,);
 
 parameter_types! {
     pub const XTokensPalletName: &'static str = "XTokens";

--- a/runtime/astar/src/lib.rs
+++ b/runtime/astar/src/lib.rs
@@ -1644,8 +1644,6 @@ mod runtime {
     pub type CumulusXcm = cumulus_pallet_xcm;
     #[runtime::pallet_index(54)]
     pub type XcAssetConfig = pallet_xc_asset_config;
-    #[runtime::pallet_index(55)]
-    pub type XTokens = orml_xtokens;
     #[runtime::pallet_index(56)]
     pub type MessageQueue = pallet_message_queue;
 
@@ -1742,7 +1740,13 @@ pub type Executive = frame_executive::Executive<
 pub type Migrations = (Unreleased, Permanent);
 
 /// Unreleased migrations. Add new ones here:
-pub type Unreleased = ();
+pub type Unreleased = (
+    frame_support::migrations::RemovePallet<XTokensPalletName, RocksDbWeight>,
+);
+
+parameter_types! {
+    pub const XTokensPalletName: &'static str = "XTokens";
+}
 
 /// Migrations/checks that do not need to be versioned and can run on every upgrade.
 pub type Permanent = (pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,);

--- a/runtime/astar/src/precompiles.rs
+++ b/runtime/astar/src/precompiles.rs
@@ -61,8 +61,6 @@ impl Contains<RuntimeCall> for WhitelistedCalls {
             }
             RuntimeCall::DappStaking(_) => true,
             RuntimeCall::Assets(pallet_assets::Call::transfer { .. }) => true,
-            RuntimeCall::XTokens(orml_xtokens::Call::transfer_multiasset_with_fee { .. }) => true,
-            RuntimeCall::XTokens(orml_xtokens::Call::transfer_multiasset { .. }) => true,
             // Governance related calls
             RuntimeCall::Democracy(_)
             | RuntimeCall::Treasury(_)

--- a/runtime/astar/src/xcm_config.rs
+++ b/runtime/astar/src/xcm_config.rs
@@ -353,12 +353,3 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
     type PriceForSiblingDelivery = NoPriceForMessageDelivery<ParaId>;
     type WeightInfo = cumulus_pallet_xcmp_queue::weights::SubstrateWeight<Runtime>;
 }
-
-/// Convert `AssetId` to optional `Location`. The impl is a wrapper
-/// on `ShidenAssetLocationIdConverter`.
-pub struct AssetIdConvert;
-impl Convert<AssetId, Option<Location>> for AssetIdConvert {
-    fn convert(asset_id: AssetId) -> Option<Location> {
-        AstarAssetLocationIdConverter::convert_back(&asset_id)
-    }
-}

--- a/runtime/astar/src/xcm_config.rs
+++ b/runtime/astar/src/xcm_config.rs
@@ -46,21 +46,15 @@ use xcm_builder::{
     ParentAsSuperuser, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
     SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
     SovereignSignedViaLocation, TakeWeightCredit, TrailingSetTopicAsId, UsingComponents,
-    WeightInfoBounds, WithComputedOrigin,
+    WeightInfoBounds, WithComputedOrigin, WithUniqueTopic,
 };
 use xcm_executor::{
     traits::{JustTry, WithOriginFilter},
     XcmExecutor,
 };
 
-// ORML imports
-use orml_xcm_support::DisabledParachainFee;
-
 // Astar imports
-use astar_primitives::xcm::{
-    AbsoluteAndRelativeReserveProvider, AccountIdToMultiLocation, FixedRateOfForeignAsset,
-    ReserveAssetFilter, XcmFungibleFeeHandler,
-};
+use astar_primitives::xcm::{FixedRateOfForeignAsset, ReserveAssetFilter, XcmFungibleFeeHandler};
 
 parameter_types! {
     pub RelayNetwork: Option<NetworkId> = Some(NetworkId::Polkadot);
@@ -302,12 +296,12 @@ pub type LocalOriginToLocation = SignedToAccountId32<RuntimeOrigin, AccountId, R
 
 /// The means for routing XCM messages which are not for local execution into the right message
 /// queues.
-pub type XcmRouter = (
+pub type XcmRouter = WithUniqueTopic<(
     // Two routers - use UMP to communicate with the relay chain:
     cumulus_primitives_utility::ParentAsUmp<ParachainSystem, PolkadotXcm, ()>,
     // ..and XCMP to communicate with the sibling chains.
     XcmpQueue,
-);
+)>;
 
 pub type Weigher =
     WeightInfoBounds<weights::xcm::XcmWeight<Runtime, RuntimeCall>, RuntimeCall, MaxInstructions>;
@@ -360,18 +354,6 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
     type WeightInfo = cumulus_pallet_xcmp_queue::weights::SubstrateWeight<Runtime>;
 }
 
-parameter_types! {
-    /// The absolute location in perspective of the whole network.
-    pub AstarLocationAbsolute: Location = Location {
-        parents: 1,
-        interior: Parachain(ParachainInfo::parachain_id().into()).into()
-
-    };
-    /// Max asset types for one cross-chain transfer. `2` covers all current use cases.
-    /// Can be updated with extra test cases in the future if needed.
-    pub const MaxAssetsForTransfer: usize = 2;
-}
-
 /// Convert `AssetId` to optional `Location`. The impl is a wrapper
 /// on `ShidenAssetLocationIdConverter`.
 pub struct AssetIdConvert;
@@ -379,23 +361,4 @@ impl Convert<AssetId, Option<Location>> for AssetIdConvert {
     fn convert(asset_id: AssetId) -> Option<Location> {
         AstarAssetLocationIdConverter::convert_back(&asset_id)
     }
-}
-
-impl orml_xtokens::Config for Runtime {
-    type Balance = Balance;
-    type CurrencyId = AssetId;
-    type CurrencyIdConvert = AssetIdConvert;
-    type AccountIdToLocation = AccountIdToMultiLocation;
-    type SelfLocation = AstarLocation;
-    type XcmExecutor = XcmExecutor<XcmConfig>;
-    type Weigher = Weigher;
-    type BaseXcmWeight = UnitWeightCost;
-    type UniversalLocation = UniversalLocation;
-    type MaxAssetsForTransfer = MaxAssetsForTransfer;
-    // Default impl. Refer to `orml-xtokens` docs for more details.
-    type MinXcmFee = DisabledParachainFee;
-    type LocationsFilter = Everything;
-    type ReserveProvider = AbsoluteAndRelativeReserveProvider<AstarLocationAbsolute>;
-    type RateLimiter = ();
-    type RateLimiterId = ();
 }

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -105,7 +105,6 @@ xcm-builder = { workspace = true }
 xcm-executor = { workspace = true }
 xcm-runtime-apis = { workspace = true }
 
-
 # Astar pallets
 astar-primitives = { workspace = true }
 astar-xcm-benchmarks = { workspace = true, optional = true }

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -105,9 +105,6 @@ xcm-builder = { workspace = true }
 xcm-executor = { workspace = true }
 xcm-runtime-apis = { workspace = true }
 
-# orml dependencies
-orml-xcm-support = { workspace = true }
-orml-xtokens = { workspace = true }
 
 # Astar pallets
 astar-primitives = { workspace = true }
@@ -176,8 +173,6 @@ std = [
 	"moonbeam-rpc-primitives-debug/std",
 	"moonbeam-rpc-primitives-txpool/std",
 	"num_enum/std",
-	"orml-xcm-support/std",
-	"orml-xtokens/std",
 	"pallet-assets/std",
 	"pallet-aura/std",
 	"pallet-authorship/std",
@@ -273,7 +268,6 @@ runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"frame-system-benchmarking/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
-	"orml-xtokens/runtime-benchmarks",
 	"pallet-assets/runtime-benchmarks",
 	"pallet-balances/runtime-benchmarks",
 	"pallet-collator-selection/runtime-benchmarks",
@@ -333,7 +327,6 @@ try-runtime = [
 	"frame-system/try-runtime",
 	"frame-try-runtime/try-runtime",
 	"log",
-	"orml-xtokens/try-runtime",
 	"pallet-assets/try-runtime",
 	"pallet-aura/try-runtime",
 	"pallet-authorship/try-runtime",

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -1639,8 +1639,6 @@ mod runtime {
     // skip 53 - cumulus_pallet_dmp_queue previously
     #[runtime::pallet_index(54)]
     pub type XcAssetConfig = pallet_xc_asset_config;
-    #[runtime::pallet_index(55)]
-    pub type XTokens = orml_xtokens;
     #[runtime::pallet_index(56)]
     pub type MessageQueue = pallet_message_queue;
 
@@ -1739,7 +1737,13 @@ pub type Executive = frame_executive::Executive<
 pub type Migrations = (Unreleased, Permanent);
 
 /// Unreleased migrations. Add new ones here:
-pub type Unreleased = ();
+pub type Unreleased = (
+    frame_support::migrations::RemovePallet<XTokensPalletName, RocksDbWeight>,
+);
+
+parameter_types! {
+    pub const XTokensPalletName: &'static str = "XTokens";
+}
 
 /// Migrations/checks that do not need to be versioned and can run on every upgrade.
 pub type Permanent = (pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,);

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -1639,6 +1639,7 @@ mod runtime {
     // skip 53 - cumulus_pallet_dmp_queue previously
     #[runtime::pallet_index(54)]
     pub type XcAssetConfig = pallet_xc_asset_config;
+    // skip 55 - orml_xtokens previously
     #[runtime::pallet_index(56)]
     pub type MessageQueue = pallet_message_queue;
 
@@ -1737,9 +1738,7 @@ pub type Executive = frame_executive::Executive<
 pub type Migrations = (Unreleased, Permanent);
 
 /// Unreleased migrations. Add new ones here:
-pub type Unreleased = (
-    frame_support::migrations::RemovePallet<XTokensPalletName, RocksDbWeight>,
-);
+pub type Unreleased = (frame_support::migrations::RemovePallet<XTokensPalletName, RocksDbWeight>,);
 
 parameter_types! {
     pub const XTokensPalletName: &'static str = "XTokens";

--- a/runtime/shibuya/src/precompiles.rs
+++ b/runtime/shibuya/src/precompiles.rs
@@ -61,8 +61,6 @@ impl Contains<RuntimeCall> for WhitelistedCalls {
             }
             RuntimeCall::DappStaking(_) => true,
             RuntimeCall::Assets(pallet_assets::Call::transfer { .. }) => true,
-            RuntimeCall::XTokens(orml_xtokens::Call::transfer_multiasset_with_fee { .. }) => true,
-            RuntimeCall::XTokens(orml_xtokens::Call::transfer_multiasset { .. }) => true,
             // Governance related calls
             RuntimeCall::Democracy(_)
             | RuntimeCall::Treasury(_)

--- a/runtime/shibuya/src/xcm_config.rs
+++ b/runtime/shibuya/src/xcm_config.rs
@@ -279,12 +279,3 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
     type PriceForSiblingDelivery = NoPriceForMessageDelivery<ParaId>;
     type WeightInfo = cumulus_pallet_xcmp_queue::weights::SubstrateWeight<Runtime>;
 }
-
-/// Convert `AssetId` to optional `Location`. The impl is a wrapper
-/// on `ShibuyaAssetLocationIdConverter`.
-pub struct AssetIdConvert;
-impl Convert<AssetId, Option<Location>> for AssetIdConvert {
-    fn convert(asset_id: AssetId) -> Option<Location> {
-        ShibuyaAssetLocationIdConverter::convert_back(&asset_id)
-    }
-}

--- a/runtime/shibuya/src/xcm_config.rs
+++ b/runtime/shibuya/src/xcm_config.rs
@@ -47,17 +47,13 @@ use xcm_builder::{
     ParentAsSuperuser, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
     SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
     SovereignSignedViaLocation, TakeWeightCredit, TrailingSetTopicAsId, UsingComponents,
-    WeightInfoBounds, WithComputedOrigin,
+    WeightInfoBounds, WithComputedOrigin, WithUniqueTopic,
 };
 use xcm_executor::{traits::JustTry, XcmExecutor};
 
-// ORML imports
-use orml_xcm_support::DisabledParachainFee;
-
 // Astar imports
 use astar_primitives::xcm::{
-    AbsoluteAndRelativeReserveProvider, AccountIdToMultiLocation, FixedRateOfForeignAsset,
-    ReserveAssetFilter, XcmFungibleFeeHandler, MAX_ASSETS,
+    FixedRateOfForeignAsset, ReserveAssetFilter, XcmFungibleFeeHandler, MAX_ASSETS,
 };
 
 parameter_types! {
@@ -230,12 +226,12 @@ pub type LocalOriginToLocation = SignedToAccountId32<RuntimeOrigin, AccountId, R
 
 /// The means for routing XCM messages which are not for local execution into the right message
 /// queues.
-pub type XcmRouter = (
+pub type XcmRouter = WithUniqueTopic<(
     // Two routers - use UMP to communicate with the relay chain:
     cumulus_primitives_utility::ParentAsUmp<ParachainSystem, PolkadotXcm, ()>,
     // ..and XCMP to communicate with the sibling chains.
     XcmpQueue,
-);
+)>;
 
 impl pallet_xcm::Config for Runtime {
     const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
@@ -284,18 +280,6 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
     type WeightInfo = cumulus_pallet_xcmp_queue::weights::SubstrateWeight<Runtime>;
 }
 
-parameter_types! {
-    /// The absolute location in perspective of the whole network.
-    pub ShibuyaLocationAbsolute: Location = Location {
-        parents: 1,
-        interior: Parachain(ParachainInfo::parachain_id().into()).into()
-
-    };
-    /// Max asset types for one cross-chain transfer. `2` covers all current use cases.
-    /// Can be updated with extra test cases in the future if needed.
-    pub const MaxAssetsForTransfer: usize = 2;
-}
-
 /// Convert `AssetId` to optional `Location`. The impl is a wrapper
 /// on `ShibuyaAssetLocationIdConverter`.
 pub struct AssetIdConvert;
@@ -303,23 +287,4 @@ impl Convert<AssetId, Option<Location>> for AssetIdConvert {
     fn convert(asset_id: AssetId) -> Option<Location> {
         ShibuyaAssetLocationIdConverter::convert_back(&asset_id)
     }
-}
-
-impl orml_xtokens::Config for Runtime {
-    type Balance = Balance;
-    type CurrencyId = AssetId;
-    type CurrencyIdConvert = AssetIdConvert;
-    type AccountIdToLocation = AccountIdToMultiLocation;
-    type SelfLocation = ShibuyaLocation;
-    type XcmExecutor = XcmExecutor<XcmConfig>;
-    type Weigher = Weigher;
-    type BaseXcmWeight = UnitWeightCost;
-    type UniversalLocation = UniversalLocation;
-    type MaxAssetsForTransfer = MaxAssetsForTransfer;
-    // Default impl. Refer to `orml-xtokens` docs for more details.
-    type MinXcmFee = DisabledParachainFee;
-    type LocationsFilter = Everything;
-    type ReserveProvider = AbsoluteAndRelativeReserveProvider<ShibuyaLocationAbsolute>;
-    type RateLimiter = ();
-    type RateLimiterId = ();
 }

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -100,7 +100,6 @@ xcm-builder = { workspace = true }
 xcm-executor = { workspace = true }
 xcm-runtime-apis = { workspace = true }
 
-
 # benchmarking
 array-bytes = { workspace = true }
 frame-benchmarking = { workspace = true, optional = true }

--- a/runtime/shiden/Cargo.toml
+++ b/runtime/shiden/Cargo.toml
@@ -100,9 +100,6 @@ xcm-builder = { workspace = true }
 xcm-executor = { workspace = true }
 xcm-runtime-apis = { workspace = true }
 
-# orml dependencies
-orml-xcm-support = { workspace = true }
-orml-xtokens = { workspace = true }
 
 # benchmarking
 array-bytes = { workspace = true }
@@ -231,8 +228,6 @@ std = [
 	"xcm-executor/std",
 	"pallet-xc-asset-config/std",
 	"substrate-wasm-builder",
-	"orml-xtokens/std",
-	"orml-xcm-support/std",
 	"astar-primitives/std",
 	"pallet-message-queue/std",
 	"parachains-common/std",
@@ -274,7 +269,6 @@ runtime-benchmarks = [
 	"cumulus-pallet-parachain-system/runtime-benchmarks",
 	"cumulus-pallet-xcmp-queue/runtime-benchmarks",
 	"frame-benchmarking/runtime-benchmarks",
-	"orml-xtokens/runtime-benchmarks",
 	"pallet-contracts/runtime-benchmarks",
 	"pallet-evm/runtime-benchmarks",
 	"pallet-evm-precompile-assets-erc20/runtime-benchmarks",
@@ -336,7 +330,6 @@ try-runtime = [
 	"parachain-info/try-runtime",
 	"pallet-dynamic-evm-base-fee/try-runtime",
 	"pallet-evm/try-runtime",
-	"orml-xtokens/try-runtime",
 	"pallet-message-queue/try-runtime",
 	"astar-xcm-benchmarks?/try-runtime",
 	"polkadot-runtime-common/try-runtime",

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -1239,6 +1239,7 @@ mod runtime {
     // skip 53 - cumulus_pallet_dmp_queue previously
     #[runtime::pallet_index(54)]
     pub type XcAssetConfig = pallet_xc_asset_config;
+    // skip 55 - orml_xtokens previously
     #[runtime::pallet_index(56)]
     pub type MessageQueue = pallet_message_queue;
 
@@ -1312,9 +1313,7 @@ parameter_types! {
 pub type Migrations = (Unreleased, Permanent);
 
 /// Unreleased migrations. Add new ones here:
-pub type Unreleased = (
-    frame_support::migrations::RemovePallet<XTokensPalletName, RocksDbWeight>,
-);
+pub type Unreleased = (frame_support::migrations::RemovePallet<XTokensPalletName, RocksDbWeight>,);
 
 parameter_types! {
     pub const XTokensPalletName: &'static str = "XTokens";

--- a/runtime/shiden/src/lib.rs
+++ b/runtime/shiden/src/lib.rs
@@ -1239,8 +1239,6 @@ mod runtime {
     // skip 53 - cumulus_pallet_dmp_queue previously
     #[runtime::pallet_index(54)]
     pub type XcAssetConfig = pallet_xc_asset_config;
-    #[runtime::pallet_index(55)]
-    pub type XTokens = orml_xtokens;
     #[runtime::pallet_index(56)]
     pub type MessageQueue = pallet_message_queue;
 
@@ -1314,7 +1312,13 @@ parameter_types! {
 pub type Migrations = (Unreleased, Permanent);
 
 /// Unreleased migrations. Add new ones here:
-pub type Unreleased = ();
+pub type Unreleased = (
+    frame_support::migrations::RemovePallet<XTokensPalletName, RocksDbWeight>,
+);
+
+parameter_types! {
+    pub const XTokensPalletName: &'static str = "XTokens";
+}
 
 /// Migrations/checks that do not need to be versioned and can run on every upgrade.
 pub type Permanent = (pallet_xcm::migration::MigrateToLatestXcmVersion<Runtime>,);

--- a/runtime/shiden/src/precompiles.rs
+++ b/runtime/shiden/src/precompiles.rs
@@ -61,8 +61,6 @@ impl Contains<RuntimeCall> for WhitelistedCalls {
             }
             RuntimeCall::DappStaking(_) => true,
             RuntimeCall::Assets(pallet_assets::Call::transfer { .. }) => true,
-            RuntimeCall::XTokens(orml_xtokens::Call::transfer_multiasset_with_fee { .. }) => true,
-            RuntimeCall::XTokens(orml_xtokens::Call::transfer_multiasset { .. }) => true,
             _ => false,
         }
     }

--- a/runtime/shiden/src/xcm_config.rs
+++ b/runtime/shiden/src/xcm_config.rs
@@ -355,12 +355,3 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
     type PriceForSiblingDelivery = NoPriceForMessageDelivery<ParaId>;
     type WeightInfo = cumulus_pallet_xcmp_queue::weights::SubstrateWeight<Runtime>;
 }
-
-/// Convert `AssetId` to optional `Location`. The impl is a wrapper
-/// on `ShidenAssetLocationIdConverter`.
-pub struct AssetIdConvert;
-impl Convert<AssetId, Option<Location>> for AssetIdConvert {
-    fn convert(asset_id: AssetId) -> Option<Location> {
-        ShidenAssetLocationIdConverter::convert_back(&asset_id)
-    }
-}

--- a/runtime/shiden/src/xcm_config.rs
+++ b/runtime/shiden/src/xcm_config.rs
@@ -47,21 +47,15 @@ use xcm_builder::{
     ParentAsSuperuser, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
     SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
     SovereignSignedViaLocation, TakeWeightCredit, TrailingSetTopicAsId, UsingComponents,
-    WeightInfoBounds, WithComputedOrigin,
+    WeightInfoBounds, WithComputedOrigin, WithUniqueTopic,
 };
 use xcm_executor::{
     traits::{JustTry, WithOriginFilter},
     XcmExecutor,
 };
 
-// ORML imports
-use orml_xcm_support::DisabledParachainFee;
-
 // Astar imports
-use astar_primitives::xcm::{
-    AbsoluteAndRelativeReserveProvider, AccountIdToMultiLocation, FixedRateOfForeignAsset,
-    ReserveAssetFilter, XcmFungibleFeeHandler,
-};
+use astar_primitives::xcm::{FixedRateOfForeignAsset, ReserveAssetFilter, XcmFungibleFeeHandler};
 
 parameter_types! {
     pub RelayNetwork: Option<NetworkId> = Some(NetworkId::Kusama);
@@ -304,12 +298,12 @@ pub type LocalOriginToLocation = SignedToAccountId32<RuntimeOrigin, AccountId, R
 
 /// The means for routing XCM messages which are not for local execution into the right message
 /// queues.
-pub type XcmRouter = (
+pub type XcmRouter = WithUniqueTopic<(
     // Two routers - use UMP to communicate with the relay chain:
     cumulus_primitives_utility::ParentAsUmp<ParachainSystem, PolkadotXcm, ()>,
     // ..and XCMP to communicate with the sibling chains.
     XcmpQueue,
-);
+)>;
 
 pub type Weigher =
     WeightInfoBounds<weights::xcm::XcmWeight<Runtime, RuntimeCall>, RuntimeCall, MaxInstructions>;
@@ -362,18 +356,6 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
     type WeightInfo = cumulus_pallet_xcmp_queue::weights::SubstrateWeight<Runtime>;
 }
 
-parameter_types! {
-    /// The absolute location in perspective of the whole network.
-    pub ShidenLocationAbsolute: Location = Location {
-        parents: 1,
-        interior: Parachain(ParachainInfo::parachain_id().into()).into()
-
-    };
-    /// Max asset types for one cross-chain transfer. `2` covers all current use cases.
-    /// Can be updated with extra test cases in the future if needed.
-    pub const MaxAssetsForTransfer: usize = 2;
-}
-
 /// Convert `AssetId` to optional `Location`. The impl is a wrapper
 /// on `ShidenAssetLocationIdConverter`.
 pub struct AssetIdConvert;
@@ -381,23 +363,4 @@ impl Convert<AssetId, Option<Location>> for AssetIdConvert {
     fn convert(asset_id: AssetId) -> Option<Location> {
         ShidenAssetLocationIdConverter::convert_back(&asset_id)
     }
-}
-
-impl orml_xtokens::Config for Runtime {
-    type Balance = Balance;
-    type CurrencyId = AssetId;
-    type CurrencyIdConvert = AssetIdConvert;
-    type AccountIdToLocation = AccountIdToMultiLocation;
-    type SelfLocation = ShidenLocation;
-    type XcmExecutor = XcmExecutor<XcmConfig>;
-    type Weigher = Weigher;
-    type BaseXcmWeight = UnitWeightCost;
-    type UniversalLocation = UniversalLocation;
-    type MaxAssetsForTransfer = MaxAssetsForTransfer;
-    // Default impl. Refer to `orml-xtokens` docs for more details.
-    type MinXcmFee = DisabledParachainFee;
-    type LocationsFilter = Everything;
-    type ReserveProvider = AbsoluteAndRelativeReserveProvider<ShidenLocationAbsolute>;
-    type RateLimiter = ();
-    type RateLimiterId = ();
 }

--- a/tests/integration/src/dispatch_precompile_filter.rs
+++ b/tests/integration/src/dispatch_precompile_filter.rs
@@ -108,47 +108,6 @@ fn filter_rejects_non_whitelisted_calls() {
     })
 }
 
-/// The dispatch precompile used to whitelist two `XTokens` calls, which gave EVM callers a second
-/// route to cross-chain transfers, bypassing the XCM precompile. `XTokens` is gone; make sure the
-/// hole was not simply moved to `pallet_xcm`.
-#[test]
-fn filter_rejects_xcm_calls() {
-    ExtBuilder::default().build().execute_with(|| {
-        let dest = Box::new(VersionedLocation::V5(Location::parent()));
-        let beneficiary = Box::new(VersionedLocation::V5(Location::here()));
-        let assets = Box::new(VersionedAssets::V5((Location::here(), 100u128).into()));
-
-        let transfer_assets = RuntimeCall::PolkadotXcm(pallet_xcm::Call::transfer_assets {
-            dest: dest.clone(),
-            beneficiary,
-            assets: assets.clone(),
-            fee_asset_item: 0,
-            weight_limit: WeightLimit::Unlimited,
-        });
-        assert!(!WhitelistedCalls::contains(&transfer_assets));
-
-        let reserve_transfer =
-            RuntimeCall::PolkadotXcm(pallet_xcm::Call::limited_reserve_transfer_assets {
-                dest: dest.clone(),
-                beneficiary: Box::new(VersionedLocation::V5(Location::here())),
-                assets,
-                fee_asset_item: 0,
-                weight_limit: WeightLimit::Unlimited,
-            });
-        assert!(!WhitelistedCalls::contains(&reserve_transfer));
-
-        let send = RuntimeCall::PolkadotXcm(pallet_xcm::Call::send {
-            dest,
-            message: Box::new(VersionedXcm::V5(Xcm(vec![]))),
-        });
-        assert!(!WhitelistedCalls::contains(&send));
-
-        // ...and not through a utility batch either.
-        let batched = RuntimeCall::Utility(UtilityCall::batch { calls: vec![send] });
-        assert!(!WhitelistedCalls::contains(&batched));
-    })
-}
-
 #[test]
 fn filter_accepts_whitelisted_batch_all_calls() {
     ExtBuilder::default().build().execute_with(|| {

--- a/tests/integration/src/dispatch_precompile_filter.rs
+++ b/tests/integration/src/dispatch_precompile_filter.rs
@@ -26,6 +26,10 @@ use frame_support::{
 };
 use pallet_evm_precompile_dispatch::DispatchValidateT;
 use parity_scale_codec::Compact;
+use xcm::{
+    v5::{Location, WeightLimit, Xcm},
+    VersionedAssets, VersionedLocation, VersionedXcm,
+};
 
 /// Whitelisted Calls are defined in the runtime
 #[test]
@@ -101,6 +105,47 @@ fn filter_rejects_non_whitelisted_calls() {
         let thaw_asset_call =
             RuntimeCall::Assets(pallet_assets::Call::thaw_asset { id: Compact(0) });
         assert!(!WhitelistedCalls::contains(&thaw_asset_call));
+    })
+}
+
+/// The dispatch precompile used to whitelist two `XTokens` calls, which gave EVM callers a second
+/// route to cross-chain transfers, bypassing the XCM precompile. `XTokens` is gone; make sure the
+/// hole was not simply moved to `pallet_xcm`.
+#[test]
+fn filter_rejects_xcm_calls() {
+    ExtBuilder::default().build().execute_with(|| {
+        let dest = Box::new(VersionedLocation::V5(Location::parent()));
+        let beneficiary = Box::new(VersionedLocation::V5(Location::here()));
+        let assets = Box::new(VersionedAssets::V5((Location::here(), 100u128).into()));
+
+        let transfer_assets = RuntimeCall::PolkadotXcm(pallet_xcm::Call::transfer_assets {
+            dest: dest.clone(),
+            beneficiary,
+            assets: assets.clone(),
+            fee_asset_item: 0,
+            weight_limit: WeightLimit::Unlimited,
+        });
+        assert!(!WhitelistedCalls::contains(&transfer_assets));
+
+        let reserve_transfer =
+            RuntimeCall::PolkadotXcm(pallet_xcm::Call::limited_reserve_transfer_assets {
+                dest: dest.clone(),
+                beneficiary: Box::new(VersionedLocation::V5(Location::here())),
+                assets,
+                fee_asset_item: 0,
+                weight_limit: WeightLimit::Unlimited,
+            });
+        assert!(!WhitelistedCalls::contains(&reserve_transfer));
+
+        let send = RuntimeCall::PolkadotXcm(pallet_xcm::Call::send {
+            dest,
+            message: Box::new(VersionedXcm::V5(Xcm(vec![]))),
+        });
+        assert!(!WhitelistedCalls::contains(&send));
+
+        // ...and not through a utility batch either.
+        let batched = RuntimeCall::Utility(UtilityCall::batch { calls: vec![send] });
+        assert!(!WhitelistedCalls::contains(&batched));
     })
 }
 

--- a/tests/xcm-simulator/Cargo.toml
+++ b/tests/xcm-simulator/Cargo.toml
@@ -56,9 +56,6 @@ xcm-executor = { workspace = true }
 xcm-simulator = { workspace = true }
 
 # ORML
-orml-traits = { workspace = true }
-orml-xcm-support = { workspace = true }
-orml-xtokens = { workspace = true }
 
 [features]
 default = ["std"]
@@ -82,9 +79,6 @@ std = [
 	"pallet-proxy/std",
 	"pallet-utility/std",
 	"pallet-message-queue/std",
-	"orml-xtokens/std",
-	"orml-traits/std",
-	"orml-xcm-support/std",
 	"pallet-dapp-staking/std",
 	"parachains-common/std",
 ]
@@ -99,7 +93,6 @@ runtime-benchmarks = [
 	"xcm-executor/runtime-benchmarks",
 	"polkadot-runtime-parachains/runtime-benchmarks",
 	"polkadot-parachain/runtime-benchmarks",
-	"orml-xtokens/runtime-benchmarks",
 	"astar-primitives/runtime-benchmarks",
 	"pallet-message-queue/runtime-benchmarks",
 	"pallet-dapp-staking/runtime-benchmarks",

--- a/tests/xcm-simulator/src/mocks/mod.rs
+++ b/tests/xcm-simulator/src/mocks/mod.rs
@@ -20,11 +20,16 @@ pub(crate) mod msg_queue;
 pub(crate) mod parachain;
 pub(crate) mod relay_chain;
 
+use astar_primitives::xcm::{
+    resolve_transfer_type, split_location_into_chain_part_and_beneficiary,
+};
 use frame_support::traits::{IsType, OnFinalize, OnInitialize};
 use sp_runtime::traits::{Bounded, StaticLookup};
 use sp_runtime::{BuildStorage, DispatchResult};
 use xcm::latest::prelude::*;
+use xcm::VersionedXcm;
 use xcm_executor::traits::ConvertLocation;
+use xcm_executor::XcmExecutor;
 use xcm_simulator::{decl_test_network, decl_test_parachain, decl_test_relay_chain, TestExt};
 
 pub const ALICE: sp_runtime::AccountId32 = sp_runtime::AccountId32::new([0xFAu8; 32]);
@@ -87,7 +92,54 @@ pub type RelayChainPalletXcm = pallet_xcm::Pallet<relay_chain::Runtime>;
 pub type ParachainPalletXcm = pallet_xcm::Pallet<parachain::Runtime>;
 pub type ParachainAssets = pallet_assets::Pallet<parachain::Runtime>;
 pub type ParachainBalances = pallet_balances::Pallet<parachain::Runtime>;
-pub type ParachainXtokens = orml_xtokens::Pallet<parachain::Runtime>;
+
+/// Reserve-transfers a single `asset` to a `destination` that embeds the beneficiary, the way the
+/// XCM precompile does.
+pub fn para_transfer_currency(
+    origin: parachain::RuntimeOrigin,
+    asset_id: parachain::AssetId,
+    amount: parachain::Balance,
+    destination: Location,
+    weight_limit: WeightLimit,
+) -> DispatchResult {
+    let location =
+        <parachain::ShidenAssetLocationIdConverter as sp_runtime::traits::MaybeEquivalence<
+            Location,
+            parachain::AssetId,
+        >>::convert_back(&asset_id)
+        .expect("asset id must be registered");
+
+    para_transfer_asset(origin, (location, amount).into(), destination, weight_limit)
+}
+
+pub fn para_transfer_asset(
+    origin: parachain::RuntimeOrigin,
+    asset: Asset,
+    destination: Location,
+    weight_limit: WeightLimit,
+) -> DispatchResult {
+    let (dest, beneficiary) = split_location_into_chain_part_and_beneficiary(destination)
+        .expect("destination must carry a chain part");
+
+    let transfer_type = resolve_transfer_type::<XcmExecutor<parachain::XcmConfig>>(&asset, &dest)
+        .expect("no reserve could be determined for asset");
+
+    let fees_id = asset.id.clone();
+
+    ParachainPalletXcm::transfer_assets_using_type_and_then(
+        origin,
+        Box::new(dest.into()),
+        Box::new(Assets::from(asset).into()),
+        Box::new(transfer_type.clone()),
+        Box::new(fees_id.into()),
+        Box::new(transfer_type),
+        Box::new(VersionedXcm::from(Xcm(vec![DepositAsset {
+            assets: Wild(AllCounted(1)),
+            beneficiary,
+        }]))),
+        weight_limit,
+    )
+}
 
 pub fn parent_account_id() -> parachain::AccountId {
     let location = (Parent,);

--- a/tests/xcm-simulator/src/mocks/parachain.rs
+++ b/tests/xcm-simulator/src/mocks/parachain.rs
@@ -38,7 +38,7 @@ use frame_system::{
 };
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use sp_runtime::{
-    traits::{AccountIdConversion, Convert, IdentityLookup, MaybeEquivalence},
+    traits::{AccountIdConversion, Convert, IdentityLookup},
     AccountId32, Perbill, RuntimeDebug,
 };
 use sp_std::prelude::*;
@@ -53,17 +53,17 @@ use xcm_builder::{
     NoChecking, ParentAsSuperuser, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
     SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
     SovereignSignedViaLocation, TakeWeightCredit, TrailingSetTopicAsId, WithComputedOrigin,
+    WithUniqueTopic,
 };
 
-use orml_xcm_support::DisabledParachainFee;
 use sp_core::DecodeWithMemTracking;
 use xcm_executor::{traits::JustTry, XcmExecutor};
 
 use astar_primitives::{
     dapp_staking::{AccountCheck, CycleConfiguration, SmartContract, StakingRewardHandler},
     xcm::{
-        AbsoluteAndRelativeReserveProvider, AssetLocationIdConverter, FixedRateOfForeignAsset,
-        ReserveAssetFilter, XcmFungibleFeeHandler,
+        AssetLocationIdConverter, FixedRateOfForeignAsset, ReserveAssetFilter,
+        XcmFungibleFeeHandler,
     },
 };
 
@@ -406,7 +406,7 @@ parameter_types! {
     pub NativePerSecond: (XcmAssetId, u128, u128) = (AssetId(ShidenLocation::get()), 1_000_000_000_000, 1024 * 1024);
 }
 
-pub type XcmRouter = super::ParachainXcmRouter<MsgQueue>;
+pub type XcmRouter = WithUniqueTopic<super::ParachainXcmRouter<MsgQueue>>;
 
 pub struct ParentOrParentsPlurality;
 impl Contains<Location> for ParentOrParentsPlurality {
@@ -514,57 +514,6 @@ impl pallet_xcm::Config for Runtime {
     type RemoteLockConsumerIdentifier = ();
     type AdminOrigin = EnsureRoot<AccountId>;
     type AuthorizedAliasConsideration = Disabled;
-}
-
-/// Convert `AccountId` to `Location`.
-pub struct AccountIdToLocation;
-impl Convert<AccountId, Location> for AccountIdToLocation {
-    fn convert(account: AccountId) -> Location {
-        Junction::AccountId32 {
-            network: None,
-            id: account.into(),
-        }
-        .into()
-    }
-}
-
-parameter_types! {
-    /// The absolute location in perspective of the whole network.
-    pub ShidenLocationAbsolute: Location = Location {
-        parents: 1,
-        interior: Parachain(MsgQueue::parachain_id().into()).into()
-    };
-    /// Max asset types for one cross-chain transfer. `2` covers all current use cases.
-    /// Can be updated with extra test cases in the future if needed.
-    pub const MaxAssetsForTransfer: usize = 2;
-}
-
-/// Convert `AssetId` to optional `Location`. The impl is a wrapper
-/// on `ShidenAssetLocationIdConverter`.
-pub struct AssetIdConvert;
-impl Convert<AssetId, Option<Location>> for AssetIdConvert {
-    fn convert(asset_id: AssetId) -> Option<Location> {
-        ShidenAssetLocationIdConverter::convert_back(&asset_id)
-    }
-}
-
-impl orml_xtokens::Config for Runtime {
-    type Balance = Balance;
-    type CurrencyId = AssetId;
-    type CurrencyIdConvert = AssetIdConvert;
-    type AccountIdToLocation = AccountIdToLocation;
-    type SelfLocation = ShidenLocation;
-    type XcmExecutor = XcmExecutor<XcmConfig>;
-    type Weigher = Weigher;
-    type BaseXcmWeight = UnitWeightCost;
-    type UniversalLocation = UniversalLocation;
-    type MaxAssetsForTransfer = MaxAssetsForTransfer;
-    // Default impl. Refer to `orml-xtokens` docs for more details.
-    type MinXcmFee = DisabledParachainFee;
-    type LocationsFilter = Everything;
-    type ReserveProvider = AbsoluteAndRelativeReserveProvider<ShidenLocationAbsolute>;
-    type RateLimiter = ();
-    type RateLimiterId = ();
 }
 
 pub struct DummyCycleConfiguration;
@@ -675,6 +624,5 @@ construct_runtime!(
         Randomness: pallet_insecure_randomness_collective_flip,
         Timestamp: pallet_timestamp,
         Contracts: pallet_contracts,
-        Xtokens: orml_xtokens,
     }
 );

--- a/tests/xcm-simulator/src/tests/fungible_assets.rs
+++ b/tests/xcm-simulator/src/tests/fungible_assets.rs
@@ -22,7 +22,7 @@ use xcm::prelude::*;
 use xcm_simulator::TestExt;
 
 #[test]
-fn para_to_para_reserve_transfer_and_back_via_xtokens() {
+fn para_to_para_reserve_transfer_and_back_by_asset_location() {
     MockNet::reset();
 
     let sibling_asset_id = 123 as u128;
@@ -56,11 +56,11 @@ fn para_to_para_reserve_transfer_and_back_via_xtokens() {
             ]
             .into(),
         };
-        assert_ok!(ParachainXtokens::transfer_multiasset(
+        assert_ok!(para_transfer_asset(
             parachain::RuntimeOrigin::signed(ALICE),
-            Box::new((Here, withdraw_amount).into()),
-            Box::new(destination.into()),
-            Unlimited
+            (Here, withdraw_amount).into(),
+            destination,
+            Unlimited,
         ));
 
         // Parachain 2 sovereign account should have it's balance increased, while Alice balance should be decreased.
@@ -101,11 +101,11 @@ fn para_to_para_reserve_transfer_and_back_via_xtokens() {
             .into(),
         };
 
-        assert_ok!(ParachainXtokens::transfer_multiasset(
+        assert_ok!(para_transfer_asset(
             parachain::RuntimeOrigin::signed(ALICE),
-            Box::new((para_a_multiloc, remaining).into()),
-            Box::new(destination.into()),
-            Unlimited
+            (para_a_multiloc, remaining).into(),
+            destination,
+            Unlimited,
         ));
     });
 
@@ -154,10 +154,10 @@ fn para_to_para_reserve_transfer_and_back() {
     // Next step is to send some of parachain A native asset to parachain B.
     let withdraw_amount = 567;
     ParaA::execute_with(|| {
-        assert_ok!(ParachainXtokens::transfer_multiasset(
+        assert_ok!(para_transfer_asset(
             parachain::RuntimeOrigin::signed(ALICE),
-            Box::new((Here, withdraw_amount).into()),
-            Box::new((Parent, Parachain(2), alice).into()),
+            (Here, withdraw_amount).into(),
+            (Parent, Parachain(2), alice).into(),
             Unlimited,
         ));
 
@@ -187,11 +187,11 @@ fn para_to_para_reserve_transfer_and_back() {
 
     // send assets back to ParaA
     ParaB::execute_with(|| {
-        assert_ok!(ParachainXtokens::transfer(
+        assert_ok!(para_transfer_currency(
             parachain::RuntimeOrigin::signed(ALICE),
             sibling_asset_id,
             remaining,
-            Box::new((Parent, Parachain(1), alice,).into()),
+            (Parent, Parachain(1), alice,).into(),
             Unlimited
         ));
     });
@@ -274,11 +274,11 @@ fn para_to_para_reserve_transfer_and_back_with_extra_native() {
 
     let send_amount = 123;
     ParaA::execute_with(|| {
-        assert_ok!(ParachainXtokens::transfer(
+        assert_ok!(para_transfer_currency(
             parachain::RuntimeOrigin::signed(ALICE.into()),
             local_asset_id,
             send_amount,
-            Box::new((Parent, Parachain(2), alice).into()),
+            (Parent, Parachain(2), alice).into(),
             Unlimited
         ));
     });
@@ -307,18 +307,18 @@ fn para_to_para_reserve_transfer_and_back_with_extra_native() {
 
     // Sending back Local Asset to Para A with some native asset of Para B
     ParaB::execute_with(|| {
-        assert_ok!(ParachainXtokens::transfer(
+        assert_ok!(para_transfer_currency(
             parachain::RuntimeOrigin::signed(ALICE.into()),
             local_asset_id,
             send_amount,
-            Box::new((Parent, Parachain(1), alice.clone()).into()),
+            (Parent, Parachain(1), alice.clone()).into(),
             Unlimited
         ));
-        assert_ok!(ParachainXtokens::transfer_multiasset(
+        assert_ok!(para_transfer_asset(
             parachain::RuntimeOrigin::signed(ALICE.into()),
-            Box::new((Here, send_amount).into()),
-            Box::new((Parent, Parachain(1), alice.clone()).into()),
-            Unlimited
+            (Here, send_amount).into(),
+            (Parent, Parachain(1), alice.clone()).into(),
+            Unlimited,
         ));
     });
 
@@ -382,21 +382,19 @@ fn para_to_para_reserve_transfer_local_asset() {
 
     let send_amount = 123;
     ParaA::execute_with(|| {
-        assert_ok!(ParachainXtokens::transfer(
+        assert_ok!(para_transfer_currency(
             parachain::RuntimeOrigin::signed(ALICE.into()),
             asset_id,
             send_amount,
-            Box::new(
-                (
-                    Parent,
-                    Parachain(2),
-                    AccountId32 {
-                        network: None,
-                        id: ALICE.into()
-                    }
-                )
-                    .into()
-            ),
+            (
+                Parent,
+                Parachain(2),
+                AccountId32 {
+                    network: None,
+                    id: ALICE.into()
+                }
+            )
+                .into(),
             Unlimited
         ));
     });
@@ -515,13 +513,13 @@ fn receive_relay_asset_from_relay_and_send_them_back() {
         asset_hub_alice_balance_before = parachain::Assets::balance(relay_asset_id, ALICE);
     });
 
-    // Send back to Asset Hub using xtokens
+    // Send back to Asset Hub
     ParaA::execute_with(|| {
-        assert_ok!(ParachainXtokens::transfer(
+        assert_ok!(para_transfer_currency(
             parachain::RuntimeOrigin::signed(ALICE),
             relay_asset_id,
             para_a_alice_expected_balance,
-            Box::new((Parent, Parachain(1000), alice).into()),
+            (Parent, Parachain(1000), alice).into(),
             Unlimited
         ));
     });
@@ -657,17 +655,17 @@ fn send_relay_asset_to_para_b_with_extra_native() {
 
     // send relay asset with some Para A native to ParaB
     ParaA::execute_with(|| {
-        assert_ok!(ParachainXtokens::transfer(
+        assert_ok!(para_transfer_currency(
             parachain::RuntimeOrigin::signed(ALICE.into()),
             relay_asset_id,
             withdraw_amount,
-            Box::new((Parent, Parachain(2), alice).into()),
+            (Parent, Parachain(2), alice).into(),
             Unlimited,
         ));
-        assert_ok!(ParachainXtokens::transfer_multiasset(
+        assert_ok!(para_transfer_asset(
             parachain::RuntimeOrigin::signed(ALICE.into()),
-            Box::new((Here, withdraw_amount).into()),
-            Box::new((Parent, Parachain(2), alice).into()),
+            (Here, withdraw_amount).into(),
+            (Parent, Parachain(2), alice).into(),
             Unlimited,
         ));
     });
@@ -1054,11 +1052,12 @@ fn transfer_relay_token_reserve_from_para_c_to_para_a() {
 
     // Parachain A should receive the tokens, and some portion of it is used for XCM execution fees
     ParaA::execute_with(|| {
-        let four_instructions_execution_cost =
-            (parachain::UnitWeightCost::get() * 4).ref_time() as u128;
+        // Four instructions above, plus the `SetTopic` the router appends.
+        let five_instructions_execution_cost =
+            (parachain::UnitWeightCost::get() * 5).ref_time() as u128;
         assert_eq!(
             parachain::Assets::balance(relay_asset_id, ALICE),
-            to_para_a_amount - four_instructions_execution_cost
+            to_para_a_amount - five_instructions_execution_cost
         );
     });
 }
@@ -1157,11 +1156,11 @@ fn transfer_relay_token_reserve_from_para_a_to_para_b_should_use_asset_hub_as_re
 
     // send relay asset from Para A to Para B should work
     ParaA::execute_with(|| {
-        assert_ok!(ParachainXtokens::transfer(
+        assert_ok!(para_transfer_currency(
             parachain::RuntimeOrigin::signed(ALICE.into()),
             relay_asset_id,
             withdraw_amount,
-            Box::new((Parent, Parachain(2), alice).into()),
+            (Parent, Parachain(2), alice).into(),
             Unlimited,
         ));
     });


### PR DESCRIPTION
# Pull Request Summary

## Motivation

Removing `orml-xtokens` drops all three open-runtime-module-library crates, closes the dispatch-precompile (`0x…0401`) route into xtokens, and leaves `ReserveAssetFilter` as the single source of truth for reserve resolution instead of a second hardcoded table.

## Migration

The Portal must move `xTokens.transferMultiasset / transferMultiassetWithFee` to `polkadotXcm.transferAssetsUsingTypeAndThen`; the 10 unused precompile selectors stay registered but now revert with a notice naming their replacement.

## Check list**

- [X] added or updated unit tests
- [ ] updated Astar official documentation
