### PR TITLE
feat(xcm-precompile): reimplement xtokens calls on `pallet_xcm`

### DIFF
--- a/precompiles/xcm/XCM.sol
+++ b/precompiles/xcm/XCM.sol
@@ -68,7 +68,8 @@ interface XCM {
      *
      * @dev Sibling parachains only: passing `is_relay = true` reverts. The relay-bound queue is
      * proven in full by every block, so it stays reachable by `Root` alone. `call` is capped at
-     * 64 KiB, inside the limit the XCMP transport enforces.
+     * 64 KiB, inside the limit the XCMP transport enforces. `transact_weight` sets the call's
+     * ref_time only; its proof size is fixed at 256 KiB, and XCM v5 destinations ignore both.
      */
     function remote_transact(
         uint256 parachain_id,

--- a/precompiles/xcm/XCM.sol
+++ b/precompiles/xcm/XCM.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.0;
 /**
  * @title XCM interface (v1).
  *
- * @dev Only `assets_withdraw(address[],uint256[],bytes32,bool,uint256,uint256)` is still
- * operational. Every other method in this interface is DEPRECATED: the selector stays registered
- * so the ABI is unchanged, but calling it always reverts.
+ * @dev Every method in this interface is operational. `assets_withdraw` and
+ * `assets_reserve_transfer` differ in one respect only: the latter reads the zero address as the
+ * native token.
  */
 interface XCM {
 
@@ -44,7 +44,9 @@ interface XCM {
      * - all assets resolved to multi-location (on runtime level)
      * - all assets has corresponded amount (lenght of assets list matched to amount list)
      *
-     * @custom:deprecated ALWAYS REVERTS. Use the `bytes32` overload of `assets_withdraw`.
+     * @dev The beneficiary is an `AccountKey20` on the destination. Substrate-native chains
+     * generally cannot resolve one - prefer the `bytes32` overload unless the destination accepts
+     * it.
      */
     function assets_withdraw(
         address[] calldata asset_id,
@@ -58,14 +60,14 @@ interface XCM {
     /**
      * @param parachain_id - destination parachain Id (ignored if is_relay is true)
      * @param is_relay - if true, destination is relay_chain, if false it is parachain (see previous argument)
-     * @param payment_asset_id - ETH address of the local asset derivate used to pay for execution in the destination chain
+     * @param payment_asset_id - ETH address of the local asset derivate used to pay for execution in the destination chain, or the zero address for the native token
      * @param payment_amount - amount of payment asset to use for execution payment - should cover cost of XCM instructions + Transact call weight.
      * @param call - encoded call data (must be decodable by remote chain)
      * @param transact_weight - max weight that the encoded call is allowed to consume in the destination chain
      * @return bool confirmation whether the XCM message sent.
      *
-     * @custom:deprecated ALWAYS REVERTS. It was already unreachable - the runtimes' `SendXcmOrigin`
-     * rejects signed origins, so this could only ever revert.
+     * @dev Sibling parachains only: passing `is_relay = true` reverts. The relay-bound queue is
+     * proven in full by every block, so it stays reachable by `Root` alone.
      */
     function remote_transact(
         uint256 parachain_id,
@@ -77,7 +79,7 @@ interface XCM {
     ) external returns (bool);
 
     /**
-     * @param asset_id - list of XC20 asset addresses
+     * @param asset_id - list of XC20 asset addresses, or the zero address for the native token
      * @param asset_amount - list of transfer amounts (must match with asset addresses above)
      * @param recipient_account_id - SS58 public key of the destination account
      * @param is_relay - set `true` for using relay chain as destination
@@ -89,7 +91,7 @@ interface XCM {
      * - all assets resolved to multi-location (on runtime level)
      * - all assets has corresponded amount (lenght of assets list matched to amount list)
      *
-     * @custom:deprecated ALWAYS REVERTS. Use the `bytes32` overload of `assets_withdraw`.
+     * @dev As `assets_withdraw`, except the zero address is read as the native token.
      */
     function assets_reserve_transfer(
         address[] calldata asset_id,
@@ -113,7 +115,7 @@ interface XCM {
      * - all assets resolved to multi-location (on runtime level)
      * - all assets has corresponded amount (lenght of assets list matched to amount list)
      *
-     * @custom:deprecated ALWAYS REVERTS. Use the `bytes32` overload of `assets_withdraw`.
+     * @dev As `assets_reserve_transfer` above, with an `AccountKey20` beneficiary.
      */
     function assets_reserve_transfer(
         address[] calldata asset_id,

--- a/precompiles/xcm/XCM.sol
+++ b/precompiles/xcm/XCM.sol
@@ -67,7 +67,8 @@ interface XCM {
      * @return bool confirmation whether the XCM message sent.
      *
      * @dev Sibling parachains only: passing `is_relay = true` reverts. The relay-bound queue is
-     * proven in full by every block, so it stays reachable by `Root` alone.
+     * proven in full by every block, so it stays reachable by `Root` alone. `call` is capped at
+     * 64 KiB, inside the limit the XCMP transport enforces.
      */
     function remote_transact(
         uint256 parachain_id,

--- a/precompiles/xcm/XCM_v2.sol
+++ b/precompiles/xcm/XCM_v2.sol
@@ -60,9 +60,7 @@ interface XCM {
     /// @param destination The Multilocation to which we want to send the tokens
     /// @param weight The weight we want to buy in the destination chain, to set the
     /// weightlimit to Unlimited, you should use the value 0 for ref_time
-    /// @custom:deprecated ALWAYS REVERTS. pallet-xcm merges equal asset ids, so a separate fee amount
-    /// of the same asset cannot be expressed. Use `transfer` and let the destination charge fees from
-    /// the transferred asset.
+    /// @dev Equivalent to `transfer` with `amount + fee`.
     function transfer_with_fee(
         address currencyAddress,
         uint256 amount,
@@ -98,8 +96,7 @@ interface XCM {
     /// @param destination The Multilocation to which we want to send the tokens
     /// @param weight The weight we want to buy in the destination chain, to set the
     /// weightlimit to Unlimited, you should use the value 0 for ref_time
-    /// @custom:deprecated ALWAYS REVERTS. pallet-xcm merges equal asset ids, so a separate fee amount
-    /// of the same asset cannot be expressed. Use `transfer_multiasset`.
+    /// @dev Equivalent to `transfer_multiasset` with `amount + fee`. See `transfer_with_fee`.
     function transfer_multiasset_with_fee(
         Multilocation memory asset,
         uint256 amount,
@@ -116,7 +113,8 @@ interface XCM {
     /// @param destination The Multilocation to which we want to send the tokens
     /// @param weight The weight we want to buy in the destination chain, to set the
     /// weightlimit to Unlimited, you should use the value 0 for ref_time
-    /// @dev `fee_item` names the asset in the list that pays for execution on the destination.
+    /// @dev `fee_item` names the asset in the list that pays for execution on the destination,
+    /// indexed in the order the currencies are passed in.
     function transfer_multi_currencies(
         Currency[] memory currencies,
         uint32 feeItem,

--- a/precompiles/xcm/XCM_v2.sol
+++ b/precompiles/xcm/XCM_v2.sol
@@ -60,7 +60,9 @@ interface XCM {
     /// @param destination The Multilocation to which we want to send the tokens
     /// @param weight The weight we want to buy in the destination chain, to set the
     /// weightlimit to Unlimited, you should use the value 0 for ref_time
-    /// @custom:deprecated ALWAYS REVERTS. Use `transfer`; the destination charges fees from the transferred asset.
+    /// @custom:deprecated ALWAYS REVERTS. pallet-xcm merges equal asset ids, so a separate fee amount
+    /// of the same asset cannot be expressed. Use `transfer` and let the destination charge fees from
+    /// the transferred asset.
     function transfer_with_fee(
         address currencyAddress,
         uint256 amount,
@@ -78,7 +80,7 @@ interface XCM {
     /// @param destination The Multilocation to which we want to send the tokens
     /// @param weight The weight we want to buy in the destination chain, to set the
     /// weightlimit to Unlimited, you should use the value 0 for ref_time
-    /// @custom:deprecated ALWAYS REVERTS. Use `transfer` with the asset's XC20 address.
+    /// @dev As `transfer`, with the asset named by its location instead of its XC20 address.
     function transfer_multiasset(
         Multilocation memory asset,
         uint256 amount,
@@ -96,7 +98,8 @@ interface XCM {
     /// @param destination The Multilocation to which we want to send the tokens
     /// @param weight The weight we want to buy in the destination chain, to set the
     /// weightlimit to Unlimited, you should use the value 0 for ref_time
-    /// @custom:deprecated ALWAYS REVERTS. Use `transfer` with the asset's XC20 address.
+    /// @custom:deprecated ALWAYS REVERTS. pallet-xcm merges equal asset ids, so a separate fee amount
+    /// of the same asset cannot be expressed. Use `transfer_multiasset`.
     function transfer_multiasset_with_fee(
         Multilocation memory asset,
         uint256 amount,
@@ -113,7 +116,7 @@ interface XCM {
     /// @param destination The Multilocation to which we want to send the tokens
     /// @param weight The weight we want to buy in the destination chain, to set the
     /// weightlimit to Unlimited, you should use the value 0 for ref_time
-    /// @custom:deprecated ALWAYS REVERTS. Use `assets_withdraw` from `XCM.sol` for multi-asset transfers.
+    /// @dev `fee_item` names the asset in the list that pays for execution on the destination.
     function transfer_multi_currencies(
         Currency[] memory currencies,
         uint32 feeItem,
@@ -129,7 +132,7 @@ interface XCM {
     /// @param destination The Multilocation to which we want to send the tokens
     /// @param weight The weight we want to buy in the destination chain, to set the
     /// weightlimit to Unlimited, you should use the value 0 for ref_time
-    /// @custom:deprecated ALWAYS REVERTS. Use `assets_withdraw` from `XCM.sol` for multi-asset transfers.
+    /// @dev The list must already be sorted and deduplicated, since `fee_item` indexes it.
     function transfer_multi_assets(
         MultiAsset[] memory assets,
         uint32 feeItem,
@@ -141,7 +144,8 @@ interface XCM {
      * @param destination - Multilocation of destination chain where to send this call
      * @param xcm_call - encoded xcm call you want to send to destination
      *
-     * @custom:deprecated ALWAYS REVERTS. It was already unreachable - the runtimes' `SendXcmOrigin` rejects signed origins.
+     * @custom:deprecated ALWAYS REVERTS. An arbitrary XCM to an arbitrary destination requires
+     * `Root`. Use `remote_transact` from `XCM.sol` for a sibling `Transact`.
      */
     function send_xcm(
         Multilocation memory destination,

--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -59,19 +59,19 @@ pub const MAX_ASSETS_FOR_TRANSFER: u32 = 2;
 /// Bound for the `BoundedVec` arguments of the asset-list based methods.
 pub type GetMaxAssets = ConstU32<MAX_ASSETS_FOR_TRANSFER>;
 
-/// Proof size allowance for the `Transact` weight `remote_transact` sends.
-const DEFAULT_PROOF_SIZE: u64 = 1024 * 256;
+/// Proof size the `Transact` weight carries when the destination cannot speak XCM v5.
+const DEFAULT_PROOF_SIZE: u64 = 64 * 1024;
+
+/// Bound for the `Transact` call blob `remote_transact` forwards.
+pub const REMOTE_CALL_SIZE_LIMIT: u32 = 64 * 1024;
+
+/// Bound for the `remote_call` argument of `remote_transact`.
+pub type GetRemoteCallSizeLimit = ConstU32<REMOTE_CALL_SIZE_LIMIT>;
 
 /// Revert reason for `send_xcm`.
 const SEND_XCM_UNSUPPORTED: &str =
     "send_xcm is not supported: sending an arbitrary XCM requires Root. \
      Use remote_transact(uint256,bool,address,uint256,bytes,uint64) for a sibling Transact.";
-
-/// Revert reason for the two `*_with_fee` selectors.
-const SEPARATE_FEE_UNSUPPORTED: &str =
-    "a separate fee amount of the same asset is not supported: pallet-xcm merges equal asset ids. \
-     Use transfer(address,uint256,(uint8,bytes[]),(uint64,uint64)) and let the destination charge \
-     fees from the transferred asset.";
 
 /// A precompile that expose XCM related functions.
 pub struct XcmPrecompile<Runtime, C>(PhantomData<(Runtime, C)>);
@@ -96,7 +96,7 @@ where
     // ------------------------------------------------------------------------------------------
     // Asset transfers. Every selector below funnels into `do_transfer`, which dispatches
     // `pallet_xcm::transfer_assets_using_type_and_then` - the reserve is derived per asset rather
-    // than chosen by the caller, as `orml-xtokens` used to do.
+    // than chosen by the caller.
     // ------------------------------------------------------------------------------------------
 
     /// Transfer XC20 assets to an `AccountId32` beneficiary on the relay chain or a sibling.
@@ -255,7 +255,7 @@ where
         weight: WeightV2,
     ) -> EvmResult<bool> {
         let currencies: Vec<Currency> = currencies.into();
-        let assets = currencies
+        let unsorted = currencies
             .into_iter()
             .map(|currency| {
                 Ok((
@@ -267,7 +267,10 @@ where
             })
             .collect::<EvmResult<Vec<Asset>>>()?;
 
-        Self::transfer_to_combined_destination(handle, assets.into(), fee_item, destination, weight)
+        let assets: Assets = unsorted.clone().into();
+        let fee_item = Self::fee_index_after_sort(&unsorted, &assets, fee_item)?;
+
+        Self::transfer_to_combined_destination(handle, assets, fee_item, destination, weight)
     }
 
     /// As `transfer_multi_currencies`, with the assets named by their locations.
@@ -296,6 +299,48 @@ where
         Self::transfer_to_combined_destination(handle, assets, fee_item, destination, weight)
     }
 
+    /// As `transfer`, with the destination's fee named separately.
+    #[precompile::public(
+        "transfer_with_fee(address,uint256,uint256,(uint8,bytes[]),(uint64,uint64))"
+    )]
+    fn transfer_with_fee(
+        handle: &mut impl PrecompileHandle,
+        currency_address: Address,
+        amount_of_tokens: U256,
+        fee: U256,
+        destination: Location,
+        weight: WeightV2,
+    ) -> EvmResult<bool> {
+        Self::transfer(
+            handle,
+            currency_address,
+            Self::total_with_fee(amount_of_tokens, fee)?,
+            destination,
+            weight,
+        )
+    }
+
+    /// As `transfer_with_fee`, with the asset named by its location.
+    #[precompile::public(
+        "transfer_multiasset_with_fee((uint8,bytes[]),uint256,uint256,(uint8,bytes[]),(uint64,uint64))"
+    )]
+    fn transfer_multiasset_with_fee(
+        handle: &mut impl PrecompileHandle,
+        asset_location: Location,
+        amount_of_tokens: U256,
+        fee: U256,
+        destination: Location,
+        weight: WeightV2,
+    ) -> EvmResult<bool> {
+        Self::transfer_multiasset(
+            handle,
+            asset_location,
+            Self::total_with_fee(amount_of_tokens, fee)?,
+            destination,
+            weight,
+        )
+    }
+
     // ------------------------------------------------------------------------------------------
     // Remote execution.
     // ------------------------------------------------------------------------------------------
@@ -312,7 +357,7 @@ where
         is_relay: bool,
         fee_asset_addr: Address,
         fee_amount: U256,
-        remote_call: UnboundedBytes,
+        remote_call: BoundedBytes<GetRemoteCallSizeLimit>,
         transact_weight: u64,
     ) -> EvmResult<bool> {
         if is_relay {
@@ -322,6 +367,8 @@ where
         }
 
         let dest = Self::chain_part(false, para_id)?;
+        let remote_call: Vec<u8> = remote_call.into();
+        let remote_call_len = remote_call.len() as u64;
 
         let fee_asset_addr: H160 = fee_asset_addr.into();
         // Special case where zero address maps to native token by convention.
@@ -350,20 +397,28 @@ where
             Transact {
                 origin_kind: OriginKind::SovereignAccount,
                 fallback_max_weight: Some(Weight::from_parts(transact_weight, DEFAULT_PROOF_SIZE)),
-                call: Vec::<u8>::from(remote_call).into(),
+                call: remote_call.into(),
             },
         ]);
 
         // The interior `pallet_xcm::send` derived for a signed origin: `SignedToAccountId32` with
-        // the network this chain lives in, which `UniversalLocation` already carries.
+        // the network this chain lives in, which `UniversalLocation` already carries. Refuse to
+        // guess it - `network: None` is a different location to the destination, so it would
+        // silently move every caller's derived sovereign account there.
+        let network = context.global_consensus().map_err(|_| {
+            revert(
+                "UniversalLocation carries no global consensus: cannot derive the caller's origin",
+            )
+        })?;
         let interior = Junction::AccountId32 {
-            network: context.global_consensus().ok(),
+            network: Some(network),
             id: Runtime::AddressMapping::into_account_id(handle.context().caller).into(),
         };
 
         log::trace!(target: "xcm-precompile:remote_transact", "dest: {:?}, interior: {:?}, message: {:?}", dest, interior, message);
 
-        let weight = <Runtime as pallet_xcm::Config>::WeightInfo::send();
+        let weight = <Runtime as pallet_xcm::Config>::WeightInfo::send()
+            .saturating_add(Weight::from_parts(0, remote_call_len));
         RuntimeHelper::<Runtime>::record_external_cost(handle, weight, 0)?;
         handle.record_cost(
             <Runtime as pallet_evm::Config>::GasWeightMapping::weight_to_gas(weight),
@@ -391,50 +446,6 @@ where
     ) -> EvmResult<bool> {
         let _ = (handle, dest, xcm_call);
         Err(revert(SEND_XCM_UNSUPPORTED))
-    }
-
-    #[precompile::public(
-        "transfer_with_fee(address,uint256,uint256,(uint8,bytes[]),(uint64,uint64))"
-    )]
-    fn transfer_with_fee(
-        handle: &mut impl PrecompileHandle,
-        currency_address: Address,
-        amount_of_tokens: U256,
-        fee: U256,
-        destination: Location,
-        weight: WeightV2,
-    ) -> EvmResult<bool> {
-        let _ = (
-            handle,
-            currency_address,
-            amount_of_tokens,
-            fee,
-            destination,
-            weight,
-        );
-        Err(revert(SEPARATE_FEE_UNSUPPORTED))
-    }
-
-    #[precompile::public(
-        "transfer_multiasset_with_fee((uint8,bytes[]),uint256,uint256,(uint8,bytes[]),(uint64,uint64))"
-    )]
-    fn transfer_multiasset_with_fee(
-        handle: &mut impl PrecompileHandle,
-        asset_location: Location,
-        amount_of_tokens: U256,
-        fee: U256,
-        destination: Location,
-        weight: WeightV2,
-    ) -> EvmResult<bool> {
-        let _ = (
-            handle,
-            asset_location,
-            amount_of_tokens,
-            fee,
-            destination,
-            weight,
-        );
-        Err(revert(SEPARATE_FEE_UNSUPPORTED))
     }
 
     // ------------------------------------------------------------------------------------------
@@ -509,13 +520,21 @@ where
                 "error splitting destination into chain and beneficiary",
             ))?;
 
-        let weight_limit = if weight.is_zero() {
-            WeightLimit::Unlimited
-        } else {
-            WeightLimit::Limited(weight.get_weight())
-        };
+        // Without one the destination deposits to itself and the assets are trapped there.
+        if beneficiary == Location::here() {
+            return Err(revert(
+                "destination carries no beneficiary: append the recipient junction to it",
+            ));
+        }
 
-        Self::do_transfer(handle, assets, fee_index, dest, beneficiary, weight_limit)
+        Self::do_transfer(
+            handle,
+            assets,
+            fee_index,
+            dest,
+            beneficiary,
+            Self::weight_limit(&weight)?,
+        )
     }
 
     /// Resolve the reserves and hand the transfer to pallet-xcm.
@@ -603,9 +622,61 @@ where
     }
 
     fn amount(amount: U256) -> EvmResult<u128> {
-        amount
+        let amount: u128 = amount
             .try_into()
-            .map_err(|_| revert("error converting amount, maybe value too large"))
+            .map_err(|_| revert("error converting amount, maybe value too large"))?;
+
+        if amount == 0 {
+            return Err(revert("amount must be greater than zero"));
+        }
+
+        Ok(amount)
+    }
+
+    fn total_with_fee(amount_of_tokens: U256, fee: U256) -> EvmResult<U256> {
+        amount_of_tokens
+            .checked_add(fee)
+            .ok_or(revert("error adding fee to amount, maybe value too large"))
+    }
+
+    /// The `WeightLimit` a caller's `(ref_time, proof_size)` pair asks for.
+    ///
+    /// `(0, 0)` is the documented spelling of `Unlimited`. Neither mixed form is reinterpreted:
+    /// `(0, n)` would silently drop the caller's proof-size limit, and `(n, 0)` is weighed as
+    /// overweight by every destination, which strands the assets there instead of here.
+    fn weight_limit(weight: &WeightV2) -> EvmResult<WeightLimit> {
+        match (weight.ref_time, weight.proof_size) {
+            (0, 0) => Ok(WeightLimit::Unlimited),
+            (0, _) => Err(revert(
+                "weight.ref_time is zero but weight.proof_size is not: pass (0, 0) for an \
+                 unlimited weight limit",
+            )),
+            (_, 0) => Err(revert(
+                "weight.proof_size is zero: every destination weighs a message with a non-zero \
+                 proof size, so the transfer would be rejected there as overweight",
+            )),
+            (ref_time, proof_size) => Ok(WeightLimit::Limited(Weight::from_parts(
+                ref_time, proof_size,
+            ))),
+        }
+    }
+
+    /// `fee_item` indexes the list in the order the caller wrote it, but `Assets` sorts and merges
+    /// what it is built from. Map the caller's index onto the sorted list rather than letting it
+    /// slide onto a neighbouring asset.
+    fn fee_index_after_sort(unsorted: &[Asset], sorted: &Assets, fee_item: u32) -> EvmResult<u32> {
+        let fee_asset_id = unsorted
+            .get(fee_item as usize)
+            .ok_or(revert("fee_index is out of bounds of the assets list"))?
+            .id
+            .clone();
+
+        sorted
+            .inner()
+            .iter()
+            .position(|asset| asset.id == fee_asset_id)
+            .map(|index| index as u32)
+            .ok_or(revert("fee_index is out of bounds of the assets list"))
     }
 
     /// `AccountId32` beneficiary, as the `bytes32` overloads take it.
@@ -723,10 +794,6 @@ impl WeightV2 {
 
     pub fn get_weight(&self) -> Weight {
         Weight::from_parts(self.ref_time, self.proof_size)
-    }
-
-    pub fn is_zero(&self) -> bool {
-        self.ref_time == 0u64
     }
 }
 

--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -59,8 +59,8 @@ pub const MAX_ASSETS_FOR_TRANSFER: u32 = 2;
 /// Bound for the `BoundedVec` arguments of the asset-list based methods.
 pub type GetMaxAssets = ConstU32<MAX_ASSETS_FOR_TRANSFER>;
 
-/// Proof size the `Transact` weight carries when the destination cannot speak XCM v5.
-const DEFAULT_PROOF_SIZE: u64 = 64 * 1024;
+/// Default proof_size of 256KB
+const DEFAULT_PROOF_SIZE: u64 = 1024 * 256;
 
 /// Bound for the `Transact` call blob `remote_transact` forwards.
 pub const REMOTE_CALL_SIZE_LIMIT: u32 = 64 * 1024;

--- a/precompiles/xcm/src/lib.rs
+++ b/precompiles/xcm/src/lib.rs
@@ -19,17 +19,18 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use astar_primitives::xcm::{
-    resolve_transfer_type, split_location_into_chain_part_and_beneficiary, XCM_SIZE_LIMIT,
+    resolve_transfer_type, split_location_into_chain_part_and_beneficiary, ASSET_HUB_PARA_ID,
+    XCM_SIZE_LIMIT,
 };
 use fp_evm::PrecompileHandle;
 use frame_support::{
     dispatch::{GetDispatchInfo, PostDispatchInfo},
     pallet_prelude::Weight,
-    traits::ConstU32,
+    traits::{ConstU32, Get},
 };
 use sp_runtime::traits::{Dispatchable, MaybeEquivalence};
 
-use pallet_evm::AddressMapping;
+use pallet_evm::{AddressMapping, GasWeightMapping};
 use sp_core::{H160, H256, U256};
 
 use sp_std::marker::PhantomData;
@@ -39,6 +40,7 @@ use xcm::{latest::prelude::*, VersionedAssetId, VersionedAssets, VersionedLocati
 use xcm_executor::traits::TransferType;
 
 use pallet_evm_precompile_assets_erc20::AddressToAssetId;
+use pallet_xcm::WeightInfo as PalletXcmWeightInfo;
 use precompile_utils::prelude::*;
 #[cfg(test)]
 mod mock;
@@ -57,10 +59,19 @@ pub const MAX_ASSETS_FOR_TRANSFER: u32 = 2;
 /// Bound for the `BoundedVec` arguments of the asset-list based methods.
 pub type GetMaxAssets = ConstU32<MAX_ASSETS_FOR_TRANSFER>;
 
-/// Revert reason shared by every deprecated selector.
-const DEPRECATED: &str =
-    "deprecated: xtokens has been removed. Use assets_withdraw(address[],uint256[],bytes32,bool,uint256,uint256) \
-     or transfer(address,uint256,(uint8,bytes[]),(uint64,uint64))";
+/// Proof size allowance for the `Transact` weight `remote_transact` sends.
+const DEFAULT_PROOF_SIZE: u64 = 1024 * 256;
+
+/// Revert reason for `send_xcm`.
+const SEND_XCM_UNSUPPORTED: &str =
+    "send_xcm is not supported: sending an arbitrary XCM requires Root. \
+     Use remote_transact(uint256,bool,address,uint256,bytes,uint64) for a sibling Transact.";
+
+/// Revert reason for the two `*_with_fee` selectors.
+const SEPARATE_FEE_UNSUPPORTED: &str =
+    "a separate fee amount of the same asset is not supported: pallet-xcm merges equal asset ids. \
+     Use transfer(address,uint256,(uint8,bytes[]),(uint64,uint64)) and let the destination charge \
+     fees from the transferred asset.";
 
 /// A precompile that expose XCM related functions.
 pub struct XcmPrecompile<Runtime, C>(PhantomData<(Runtime, C)>);
@@ -80,9 +91,15 @@ where
         + GetDispatchInfo,
     C: MaybeEquivalence<Location, <Runtime as pallet_assets::Config>::AssetId>,
     <Runtime as pallet_evm::Config>::AddressMapping: AddressMapping<Runtime::AccountId>,
+    Runtime::AccountId: Into<[u8; 32]>,
 {
-    /// Reserve-transfer a list of XC20 assets to an `AccountId32` beneficiary on the relay chain
-    /// or on a sibling parachain.
+    // ------------------------------------------------------------------------------------------
+    // Asset transfers. Every selector below funnels into `do_transfer`, which dispatches
+    // `pallet_xcm::transfer_assets_using_type_and_then` - the reserve is derived per asset rather
+    // than chosen by the caller, as `orml-xtokens` used to do.
+    // ------------------------------------------------------------------------------------------
+
+    /// Transfer XC20 assets to an `AccountId32` beneficiary on the relay chain or a sibling.
     #[precompile::public("assets_withdraw(address[],uint256[],bytes32,bool,uint256,uint256)")]
     fn assets_withdraw_native_v1(
         handle: &mut impl PrecompileHandle,
@@ -93,166 +110,20 @@ where
         parachain_id: U256,
         fee_index: U256,
     ) -> EvmResult<bool> {
-        let beneficiary: Location = Junction::AccountId32 {
-            network: None,
-            id: recipient_account_id.into(),
-        }
-        .into();
-
-        // Read arguments and check them
-        let assets: Vec<Address> = assets.into();
-        let assets = assets
-            .iter()
-            .cloned()
-            .filter_map(|address| {
-                Runtime::address_to_asset_id(address.into()).and_then(|x| C::convert_back(&x))
-            })
-            .collect::<Vec<Location>>();
-
-        let amounts: Vec<U256> = amounts.into();
-        let amounts = amounts
-            .into_iter()
-            .map(|x| x.try_into())
-            .collect::<Result<Vec<u128>, _>>()
-            .map_err(|_| revert("error converting amounts, maybe value too large"))?;
-
-        // Check that assets list is valid:
-        // * all assets resolved to multi-location
-        // * all assets has corresponded amount
-        if assets.len() != amounts.len() || assets.is_empty() {
-            return Err(revert("Assets resolution failure."));
-        }
-
-        let parachain_id: u32 = parachain_id
-            .try_into()
-            .map_err(|_| revert("error converting parachain_id, maybe value too large"))?;
-
-        let fee_asset_item: u32 = fee_index
-            .try_into()
-            .map_err(|_| revert("error converting fee_index, maybe value too large"))?;
-
-        let destination = if is_relay {
-            Location::parent()
-        } else {
-            Junctions::from(Junction::Parachain(parachain_id)).into_exterior(1)
-        };
-
-        // `Assets` sorts and deduplicates on construction, so `fee_asset_item` has to be resolved
-        // against the sorted list - same as `orml-xtokens` did.
-        let assets: Assets = assets
-            .into_iter()
-            .zip(amounts)
-            .map(Into::into)
-            .collect::<Vec<Asset>>()
-            .into();
-
-        Self::ensure_dot_transfer_policy(assets.inner(), &destination)?;
-
-        let (assets_transfer_type, fees_transfer_type, fee_asset_id) =
-            Self::resolve_transfer_types(&assets, fee_asset_item, &destination)?;
-
-        log::trace!(target: "xcm-precompile:assets_withdraw", "Processed arguments: assets {:?}, destination: {:?}, beneficiary: {:?}, transfer types: {:?}/{:?}", assets, destination, beneficiary, assets_transfer_type, fees_transfer_type);
-
-        // Build call with origin.
-        let origin = Some(Runtime::AddressMapping::into_account_id(
-            handle.context().caller,
-        ))
-        .into();
-
-        let call = pallet_xcm::Call::<Runtime>::transfer_assets_using_type_and_then {
-            dest: Box::new(VersionedLocation::V5(destination)),
-            assets: Box::new(VersionedAssets::V5(assets.clone())),
-            assets_transfer_type: Box::new(assets_transfer_type),
-            remote_fees_id: Box::new(VersionedAssetId::V5(fee_asset_id)),
-            fees_transfer_type: Box::new(fees_transfer_type),
-            custom_xcm_on_dest: Box::new(VersionedXcm::V5(Self::deposit_to_beneficiary(
-                assets.len() as u32,
-                beneficiary,
-            ))),
-            weight_limit: WeightLimit::Unlimited,
-        };
-
-        // Dispatch a call.
-        RuntimeHelper::<Runtime>::try_dispatch(handle, origin, call, 0)?;
-        Ok(true)
+        Self::assets_transfer_v1(
+            handle,
+            assets,
+            amounts,
+            Self::beneficiary_32(recipient_account_id),
+            is_relay,
+            parachain_id,
+            fee_index,
+            false,
+        )
     }
 
-    /// Transfer a single token - native currency (zero address) or an XC20 - to a combined
-    /// destination location that embeds the beneficiary.
-    #[precompile::public("transfer(address,uint256,(uint8,bytes[]),(uint64,uint64))")]
-    fn transfer(
-        handle: &mut impl PrecompileHandle,
-        currency_address: Address,
-        amount_of_tokens: U256,
-        destination: Location,
-        weight: WeightV2,
-    ) -> EvmResult<bool> {
-        // Read call arguments
-        let amount_of_tokens: u128 = amount_of_tokens
-            .try_into()
-            .map_err(|_| revert("error converting amount_of_tokens, maybe value too large"))?;
-
-        let weight_limit = if weight.is_zero() {
-            WeightLimit::Unlimited
-        } else {
-            WeightLimit::Limited(weight.get_weight())
-        };
-
-        // Special case where zero address maps to native token by convention.
-        let asset_location = if currency_address == Address::from(NATIVE_ADDRESS) {
-            Location::here()
-        } else {
-            let asset_id = Runtime::address_to_asset_id(currency_address.into())
-                .ok_or(revert("Failed to resolve asset id from address"))?;
-            C::convert_back(&asset_id).ok_or(revert(
-                "Failed to resolve asset multilocation from local id",
-            ))?
-        };
-        let asset: Asset = (asset_location, amount_of_tokens).into();
-
-        let (dest, beneficiary) = split_location_into_chain_part_and_beneficiary(destination)
-            .ok_or(revert(
-                "error splitting destination into chain and beneficiary",
-            ))?;
-
-        let assets: Assets = asset.into();
-        Self::ensure_dot_transfer_policy(assets.inner(), &dest)?;
-
-        let (assets_transfer_type, fees_transfer_type, fee_asset_id) =
-            Self::resolve_transfer_types(&assets, 0, &dest)?;
-
-        log::trace!(target: "xcm-precompile::transfer", "Processed arguments: currency_address: {:?}, assets: {:?}, dest: {:?}, beneficiary: {:?}, weight_limit: {:?}, transfer type: {:?}",
-        currency_address, assets, dest, beneficiary, weight_limit, assets_transfer_type);
-
-        let call = pallet_xcm::Call::<Runtime>::transfer_assets_using_type_and_then {
-            dest: Box::new(VersionedLocation::V5(dest)),
-            assets: Box::new(VersionedAssets::V5(assets.clone())),
-            assets_transfer_type: Box::new(assets_transfer_type),
-            remote_fees_id: Box::new(VersionedAssetId::V5(fee_asset_id)),
-            fees_transfer_type: Box::new(fees_transfer_type),
-            custom_xcm_on_dest: Box::new(VersionedXcm::V5(Self::deposit_to_beneficiary(
-                assets.len() as u32,
-                beneficiary,
-            ))),
-            weight_limit,
-        };
-
-        let origin = Some(Runtime::AddressMapping::into_account_id(
-            handle.context().caller,
-        ))
-        .into();
-
-        // Dispatch a call.
-        RuntimeHelper::<Runtime>::try_dispatch(handle, origin, call, 0)?;
-
-        Ok(true)
-    }
-
-    // ------------------------------------------------------------------------------------------
-    // Deprecated methods.
-    // ------------------------------------------------------------------------------------------
-
-    /// Deprecated. Use the `bytes32` overload of `assets_withdraw` instead.
+    /// As above, with an `AccountKey20` beneficiary. Substrate-native destinations generally
+    /// cannot resolve one - prefer the `bytes32` overload unless the destination accepts it.
     #[precompile::public("assets_withdraw(address[],uint256[],address,bool,uint256,uint256)")]
     fn assets_withdraw_evm_v1(
         handle: &mut impl PrecompileHandle,
@@ -263,42 +134,23 @@ where
         parachain_id: U256,
         fee_index: U256,
     ) -> EvmResult<bool> {
-        let _ = (
+        Self::assets_transfer_v1(
             handle,
             assets,
             amounts,
-            recipient_account_id,
+            Self::beneficiary_key_20(recipient_account_id),
             is_relay,
             parachain_id,
             fee_index,
-        );
-        Err(revert(DEPRECATED))
+            false,
+        )
     }
 
-    /// Deprecated. Was already unreachable: `SendXcmOrigin` rejects signed origins.
-    #[precompile::public("remote_transact(uint256,bool,address,uint256,bytes,uint64)")]
-    fn remote_transact_v1(
-        handle: &mut impl PrecompileHandle,
-        para_id: U256,
-        is_relay: bool,
-        fee_asset_addr: Address,
-        fee_amount: U256,
-        remote_call: UnboundedBytes,
-        transact_weight: u64,
-    ) -> EvmResult<bool> {
-        let _ = (
-            handle,
-            para_id,
-            is_relay,
-            fee_asset_addr,
-            fee_amount,
-            remote_call,
-            transact_weight,
-        );
-        Err(revert(DEPRECATED))
-    }
-
-    /// Deprecated. Use the `bytes32` overload of `assets_withdraw` instead.
+    /// As `assets_withdraw`, except the zero address is read as the native token.
+    ///
+    /// That is the only difference between the two names, and it has always been so: widening
+    /// `assets_withdraw` instead would turn a caller's uninitialised address from a revert into a
+    /// native-balance transfer.
     #[precompile::public(
         "assets_reserve_transfer(address[],uint256[],bytes32,bool,uint256,uint256)"
     )]
@@ -311,19 +163,19 @@ where
         parachain_id: U256,
         fee_index: U256,
     ) -> EvmResult<bool> {
-        let _ = (
+        Self::assets_transfer_v1(
             handle,
             assets,
             amounts,
-            recipient_account_id,
+            Self::beneficiary_32(recipient_account_id),
             is_relay,
             parachain_id,
             fee_index,
-        );
-        Err(revert(DEPRECATED))
+            true,
+        )
     }
 
-    /// Deprecated. Use the `bytes32` overload of `assets_withdraw` instead.
+    /// As `assets_reserve_transfer` above, with an `AccountKey20` beneficiary.
     #[precompile::public(
         "assets_reserve_transfer(address[],uint256[],address,bool,uint256,uint256)"
     )]
@@ -336,19 +188,201 @@ where
         parachain_id: U256,
         fee_index: U256,
     ) -> EvmResult<bool> {
-        let _ = (
+        Self::assets_transfer_v1(
             handle,
             assets,
             amounts,
-            recipient_account_id,
+            Self::beneficiary_key_20(recipient_account_id),
             is_relay,
             parachain_id,
             fee_index,
-        );
-        Err(revert(DEPRECATED))
+            true,
+        )
     }
 
-    /// Deprecated. Was already unreachable: `SendXcmOrigin` rejects signed origins.
+    /// Transfer a single token - native currency (zero address) or an XC20 - to a combined
+    /// destination location that embeds the beneficiary.
+    #[precompile::public("transfer(address,uint256,(uint8,bytes[]),(uint64,uint64))")]
+    fn transfer(
+        handle: &mut impl PrecompileHandle,
+        currency_address: Address,
+        amount_of_tokens: U256,
+        destination: Location,
+        weight: WeightV2,
+    ) -> EvmResult<bool> {
+        let currency_address: H160 = currency_address.into();
+        // Special case where zero address maps to native token by convention.
+        let asset_location = if currency_address == NATIVE_ADDRESS {
+            Location::here()
+        } else {
+            let asset_id = Runtime::address_to_asset_id(currency_address)
+                .ok_or(revert("Failed to resolve asset id from address"))?;
+            C::convert_back(&asset_id).ok_or(revert(
+                "Failed to resolve asset multilocation from local id",
+            ))?
+        };
+        let asset: Asset = (asset_location, Self::amount(amount_of_tokens)?).into();
+
+        Self::transfer_to_combined_destination(handle, asset.into(), 0, destination, weight)
+    }
+
+    /// As `transfer`, with the asset named by its location instead of its XC20 address.
+    #[precompile::public(
+        "transfer_multiasset((uint8,bytes[]),uint256,(uint8,bytes[]),(uint64,uint64))"
+    )]
+    fn transfer_multiasset(
+        handle: &mut impl PrecompileHandle,
+        asset_location: Location,
+        amount_of_tokens: U256,
+        destination: Location,
+        weight: WeightV2,
+    ) -> EvmResult<bool> {
+        let asset: Asset = (asset_location, Self::amount(amount_of_tokens)?).into();
+
+        Self::transfer_to_combined_destination(handle, asset.into(), 0, destination, weight)
+    }
+
+    /// Transfer several XC20 assets to a combined destination location, `fee_item` naming the one
+    /// that pays for execution there.
+    #[precompile::public(
+        "transfer_multi_currencies((address,uint256)[],uint32,(uint8,bytes[]),(uint64,uint64))"
+    )]
+    fn transfer_multi_currencies(
+        handle: &mut impl PrecompileHandle,
+        currencies: BoundedVec<Currency, GetMaxAssets>,
+        fee_item: u32,
+        destination: Location,
+        weight: WeightV2,
+    ) -> EvmResult<bool> {
+        let currencies: Vec<Currency> = currencies.into();
+        let assets = currencies
+            .into_iter()
+            .map(|currency| {
+                Ok((
+                    Self::asset_location(currency.get_address().into(), false)
+                        .ok_or(revert("can't convert into currency id"))?,
+                    Self::amount(currency.get_amount())?,
+                )
+                    .into())
+            })
+            .collect::<EvmResult<Vec<Asset>>>()?;
+
+        Self::transfer_to_combined_destination(handle, assets.into(), fee_item, destination, weight)
+    }
+
+    /// As `transfer_multi_currencies`, with the assets named by their locations.
+    ///
+    /// The list must already be sorted and deduplicated, since `fee_item` indexes it.
+    #[precompile::public(
+        "transfer_multi_assets(((uint8,bytes[]),uint256)[],uint32,(uint8,bytes[]),(uint64,uint64))"
+    )]
+    fn transfer_multi_assets(
+        handle: &mut impl PrecompileHandle,
+        assets: BoundedVec<EvmMultiAsset, GetMaxAssets>,
+        fee_item: u32,
+        destination: Location,
+        weight: WeightV2,
+    ) -> EvmResult<bool> {
+        let assets: Vec<EvmMultiAsset> = assets.into();
+        let assets = assets
+            .into_iter()
+            .map(|asset| Ok((asset.get_location(), Self::amount(asset.get_amount())?).into()))
+            .collect::<EvmResult<Vec<Asset>>>()?;
+
+        let assets = Assets::from_sorted_and_deduplicated(assets).map_err(|_| {
+            revert("In field Assets, Provided assets either not sorted nor deduplicated")
+        })?;
+
+        Self::transfer_to_combined_destination(handle, assets, fee_item, destination, weight)
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Remote execution.
+    // ------------------------------------------------------------------------------------------
+
+    /// Send a `Transact` to a sibling parachain, buying its execution with `fee_asset_addr`.
+    ///
+    /// `pallet_xcm::send` is `Root`-only, so the message goes to the router directly with the
+    /// caller descended into the origin - byte for byte what the extrinsic built for a signed
+    /// origin, so the account the destination derives does not move.
+    #[precompile::public("remote_transact(uint256,bool,address,uint256,bytes,uint64)")]
+    fn remote_transact_v1(
+        handle: &mut impl PrecompileHandle,
+        para_id: U256,
+        is_relay: bool,
+        fee_asset_addr: Address,
+        fee_amount: U256,
+        remote_call: UnboundedBytes,
+        transact_weight: u64,
+    ) -> EvmResult<bool> {
+        if is_relay {
+            return Err(revert(
+                "remote_transact to the relay chain is not supported, use a sibling parachain",
+            ));
+        }
+
+        let dest = Self::chain_part(false, para_id)?;
+
+        let fee_asset_addr: H160 = fee_asset_addr.into();
+        // Special case where zero address maps to native token by convention.
+        let fee_asset = if fee_asset_addr == NATIVE_ADDRESS {
+            Location::here()
+        } else {
+            let fee_asset_id = Runtime::address_to_asset_id(fee_asset_addr)
+                .ok_or(revert("Failed to resolve fee asset id from address"))?;
+            C::convert_back(&fee_asset_id).ok_or(revert(
+                "Failed to resolve fee asset multilocation from local id",
+            ))?
+        };
+        let fee: Asset = (fee_asset, Self::amount(fee_amount)?).into();
+
+        let context = <Runtime as pallet_xcm::Config>::UniversalLocation::get();
+        let fee = fee
+            .reanchored(&dest, &context)
+            .map_err(|_| revert("Failed to reanchor fee asset"))?;
+
+        let message = Xcm(vec![
+            WithdrawAsset(fee.clone().into()),
+            BuyExecution {
+                fees: fee,
+                weight_limit: WeightLimit::Unlimited,
+            },
+            Transact {
+                origin_kind: OriginKind::SovereignAccount,
+                fallback_max_weight: Some(Weight::from_parts(transact_weight, DEFAULT_PROOF_SIZE)),
+                call: Vec::<u8>::from(remote_call).into(),
+            },
+        ]);
+
+        // The interior `pallet_xcm::send` derived for a signed origin: `SignedToAccountId32` with
+        // the network this chain lives in, which `UniversalLocation` already carries.
+        let interior = Junction::AccountId32 {
+            network: context.global_consensus().ok(),
+            id: Runtime::AddressMapping::into_account_id(handle.context().caller).into(),
+        };
+
+        log::trace!(target: "xcm-precompile:remote_transact", "dest: {:?}, interior: {:?}, message: {:?}", dest, interior, message);
+
+        let weight = <Runtime as pallet_xcm::Config>::WeightInfo::send();
+        RuntimeHelper::<Runtime>::record_external_cost(handle, weight, 0)?;
+        handle.record_cost(
+            <Runtime as pallet_evm::Config>::GasWeightMapping::weight_to_gas(weight),
+        )?;
+
+        pallet_xcm::Pallet::<Runtime>::send_xcm(interior, dest, message).map_err(|error| {
+            log::trace!(target: "xcm-precompile:remote_transact", "send_xcm failed: {:?}", error);
+            revert("Failed to send xcm")
+        })?;
+
+        Ok(true)
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Deprecated selectors.
+    // ------------------------------------------------------------------------------------------
+
+    /// An arbitrary XCM to an arbitrary destination from a signed origin is what
+    /// `SendXcmOrigin` was locked down to `Root` to prevent.
     #[precompile::public("send_xcm((uint8,bytes[]),bytes)")]
     fn send_xcm(
         handle: &mut impl PrecompileHandle,
@@ -356,10 +390,9 @@ where
         xcm_call: BoundedBytes<GetXcmSizeLimit>,
     ) -> EvmResult<bool> {
         let _ = (handle, dest, xcm_call);
-        Err(revert(DEPRECATED))
+        Err(revert(SEND_XCM_UNSUPPORTED))
     }
 
-    /// Deprecated. Use `transfer` and let the destination charge fees from the transferred asset.
     #[precompile::public(
         "transfer_with_fee(address,uint256,uint256,(uint8,bytes[]),(uint64,uint64))"
     )]
@@ -379,31 +412,9 @@ where
             destination,
             weight,
         );
-        Err(revert(DEPRECATED))
+        Err(revert(SEPARATE_FEE_UNSUPPORTED))
     }
 
-    /// Deprecated. Use `transfer` with the asset's XC20 address.
-    #[precompile::public(
-        "transfer_multiasset((uint8,bytes[]),uint256,(uint8,bytes[]),(uint64,uint64))"
-    )]
-    fn transfer_multiasset(
-        handle: &mut impl PrecompileHandle,
-        asset_location: Location,
-        amount_of_tokens: U256,
-        destination: Location,
-        weight: WeightV2,
-    ) -> EvmResult<bool> {
-        let _ = (
-            handle,
-            asset_location,
-            amount_of_tokens,
-            destination,
-            weight,
-        );
-        Err(revert(DEPRECATED))
-    }
-
-    /// Deprecated. Use `transfer` with the asset's XC20 address.
     #[precompile::public(
         "transfer_multiasset_with_fee((uint8,bytes[]),uint256,uint256,(uint8,bytes[]),(uint64,uint64))"
     )]
@@ -423,37 +434,196 @@ where
             destination,
             weight,
         );
-        Err(revert(DEPRECATED))
+        Err(revert(SEPARATE_FEE_UNSUPPORTED))
     }
 
-    /// Deprecated. Use `assets_withdraw` for multi-asset transfers.
-    #[precompile::public(
-        "transfer_multi_currencies((address,uint256)[],uint32,(uint8,bytes[]),(uint64,uint64))"
-    )]
-    fn transfer_multi_currencies(
+    // ------------------------------------------------------------------------------------------
+    // Internals.
+    // ------------------------------------------------------------------------------------------
+
+    /// Shared body of the four `assets_*` selectors, which name the destination chain with the
+    /// `is_relay` / `parachain_id` pair and carry the beneficiary separately.
+    ///
+    /// `native_address` is the one behavioural difference between the two names: only
+    /// `assets_reserve_transfer` has ever read the zero address as the native token.
+    fn assets_transfer_v1(
         handle: &mut impl PrecompileHandle,
-        currencies: BoundedVec<Currency, GetMaxAssets>,
-        fee_item: u32,
+        assets: BoundedVec<Address, GetMaxAssets>,
+        amounts: BoundedVec<U256, GetMaxAssets>,
+        beneficiary: Location,
+        is_relay: bool,
+        parachain_id: U256,
+        fee_index: U256,
+        native_address: bool,
+    ) -> EvmResult<bool> {
+        let addresses: Vec<Address> = assets.into();
+        let locations = addresses
+            .into_iter()
+            .filter_map(|address| Self::asset_location(address.into(), native_address))
+            .collect::<Vec<Location>>();
+
+        let amounts: Vec<U256> = amounts.into();
+        let amounts = amounts
+            .into_iter()
+            .map(Self::amount)
+            .collect::<EvmResult<Vec<u128>>>()?;
+
+        // Check that assets list is valid:
+        // * all assets resolved to multi-location
+        // * all assets has corresponded amount
+        if locations.len() != amounts.len() || locations.is_empty() {
+            return Err(revert("Assets resolution failure."));
+        }
+
+        let assets = locations
+            .into_iter()
+            .zip(amounts)
+            .map(Into::into)
+            .collect::<Vec<Asset>>();
+
+        let fee_index: u32 = fee_index
+            .try_into()
+            .map_err(|_| revert("error converting fee_index, maybe value too large"))?;
+
+        Self::do_transfer(
+            handle,
+            assets.into(),
+            fee_index,
+            Self::chain_part(is_relay, parachain_id)?,
+            beneficiary,
+            WeightLimit::Unlimited,
+        )
+    }
+
+    /// Shared body of the selectors that take one location holding both the destination chain and
+    /// the beneficiary.
+    fn transfer_to_combined_destination(
+        handle: &mut impl PrecompileHandle,
+        assets: Assets,
+        fee_index: u32,
         destination: Location,
         weight: WeightV2,
     ) -> EvmResult<bool> {
-        let _ = (handle, currencies, fee_item, destination, weight);
-        Err(revert(DEPRECATED))
+        let (dest, beneficiary) = split_location_into_chain_part_and_beneficiary(destination)
+            .ok_or(revert(
+                "error splitting destination into chain and beneficiary",
+            ))?;
+
+        let weight_limit = if weight.is_zero() {
+            WeightLimit::Unlimited
+        } else {
+            WeightLimit::Limited(weight.get_weight())
+        };
+
+        Self::do_transfer(handle, assets, fee_index, dest, beneficiary, weight_limit)
     }
 
-    /// Deprecated. Use `assets_withdraw` for multi-asset transfers.
-    #[precompile::public(
-        "transfer_multi_assets(((uint8,bytes[]),uint256)[],uint32,(uint8,bytes[]),(uint64,uint64))"
-    )]
-    fn transfer_multi_assets(
+    /// Resolve the reserves and hand the transfer to pallet-xcm.
+    fn do_transfer(
         handle: &mut impl PrecompileHandle,
-        assets: BoundedVec<EvmMultiAsset, GetMaxAssets>,
-        fee_item: u32,
-        destination: Location,
-        weight: WeightV2,
+        assets: Assets,
+        fee_index: u32,
+        dest: Location,
+        beneficiary: Location,
+        weight_limit: WeightLimit,
     ) -> EvmResult<bool> {
-        let _ = (handle, assets, fee_item, destination, weight);
-        Err(revert(DEPRECATED))
+        if assets.len() == 0 {
+            return Err(revert("Assets resolution failure."));
+        }
+
+        let dest = Self::redirect_relay_to_asset_hub(&assets, dest);
+        Self::ensure_dot_transfer_policy(assets.inner(), &dest)?;
+
+        let (assets_transfer_type, fees_transfer_type, fee_asset_id) =
+            Self::resolve_transfer_types(&assets, fee_index, &dest)?;
+
+        log::trace!(target: "xcm-precompile:transfer", "assets: {:?}, dest: {:?}, beneficiary: {:?}, transfer types: {:?}/{:?}", assets, dest, beneficiary, assets_transfer_type, fees_transfer_type);
+
+        let call = pallet_xcm::Call::<Runtime>::transfer_assets_using_type_and_then {
+            dest: Box::new(VersionedLocation::V5(dest)),
+            assets: Box::new(VersionedAssets::V5(assets.clone())),
+            assets_transfer_type: Box::new(assets_transfer_type),
+            remote_fees_id: Box::new(VersionedAssetId::V5(fee_asset_id)),
+            fees_transfer_type: Box::new(fees_transfer_type),
+            custom_xcm_on_dest: Box::new(VersionedXcm::V5(Self::deposit_to_beneficiary(
+                assets.len() as u32,
+                beneficiary,
+            ))),
+            weight_limit,
+        };
+
+        let origin = Some(Runtime::AddressMapping::into_account_id(
+            handle.context().caller,
+        ))
+        .into();
+
+        RuntimeHelper::<Runtime>::try_dispatch(handle, origin, call, 0)?;
+
+        Ok(true)
+    }
+
+    /// The relay chain holds no reserve for this chain's own token - Asset Hub does. Substitute
+    /// the destination rather than depositing assets on a chain that cannot account for them
+    fn redirect_relay_to_asset_hub(assets: &Assets, dest: Location) -> Location {
+        let local_asset_present = assets
+            .inner()
+            .iter()
+            .any(|asset| asset.id.0 == Location::here());
+
+        if dest == Location::parent() && local_asset_present {
+            Location::new(1, [Junction::Parachain(ASSET_HUB_PARA_ID)])
+        } else {
+            dest
+        }
+    }
+
+    /// The destination chain named by the legacy `is_relay` / `parachain_id` pair.
+    fn chain_part(is_relay: bool, parachain_id: U256) -> EvmResult<Location> {
+        if is_relay {
+            return Ok(Location::parent());
+        }
+
+        let parachain_id: u32 = parachain_id
+            .try_into()
+            .map_err(|_| revert("error converting parachain_id, maybe value too large"))?;
+
+        Ok(Junctions::from(Junction::Parachain(parachain_id)).into_exterior(1))
+    }
+
+    /// XC20 address to asset location. `native_address` allows the zero address to stand for the
+    /// native token, which only some selectors have ever accepted.
+    ///
+    /// Returns `None` rather than reverting: each selector keeps the wording it has always used.
+    fn asset_location(address: H160, native_address: bool) -> Option<Location> {
+        if native_address && address == NATIVE_ADDRESS {
+            return Some(Location::here());
+        }
+
+        Runtime::address_to_asset_id(address).and_then(|id| C::convert_back(&id))
+    }
+
+    fn amount(amount: U256) -> EvmResult<u128> {
+        amount
+            .try_into()
+            .map_err(|_| revert("error converting amount, maybe value too large"))
+    }
+
+    /// `AccountId32` beneficiary, as the `bytes32` overloads take it.
+    fn beneficiary_32(recipient_account_id: H256) -> Location {
+        Junction::AccountId32 {
+            network: None,
+            id: recipient_account_id.into(),
+        }
+        .into()
+    }
+
+    /// `AccountKey20` beneficiary, as the `address` overloads take it.
+    fn beneficiary_key_20(recipient_account_id: Address) -> Location {
+        Junction::AccountKey20 {
+            network: None,
+            key: recipient_account_id.0.to_fixed_bytes(),
+        }
+        .into()
     }
 
     /// Picks the reserve model for `assets` and, separately, for the fee asset at

--- a/precompiles/xcm/src/mock.rs
+++ b/precompiles/xcm/src/mock.rs
@@ -443,10 +443,10 @@ impl SendXcm for StoringRouter {
 
 impl pallet_xcm::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
-    type SendXcmOrigin = xcm_builder::EnsureXcmOrigin<RuntimeOrigin, LocalOriginToLocation>;
+    type SendXcmOrigin = xcm_builder::EnsureXcmOrigin<RuntimeOrigin, ()>;
     type XcmRouter = StoringRouter;
     type ExecuteXcmOrigin = xcm_builder::EnsureXcmOrigin<RuntimeOrigin, LocalOriginToLocation>;
-    type XcmExecuteFilter = Everything;
+    type XcmExecuteFilter = Nothing;
     type XcmExecutor = XcmExecutor<XcmConfig>;
     type XcmTeleportFilter = Everything;
     type XcmReserveTransferFilter = Everything;

--- a/precompiles/xcm/src/mock.rs
+++ b/precompiles/xcm/src/mock.rs
@@ -40,10 +40,11 @@ use sp_core::{ConstU32, DecodeWithMemTracking, H160};
 use sp_runtime::{traits::IdentityLookup, BuildStorage};
 use sp_std::cell::RefCell;
 
-use xcm::prelude::XcmVersion;
+use xcm::VersionedXcm;
 use xcm_builder::{
     test_utils::TransactAsset, AllowKnownQueryResponses, AllowSubscriptionsFrom,
     AllowTopLevelPaidExecutionFrom, FixedWeightBounds, SignedToAccountId32, TakeWeightCredit,
+    WithComputedOrigin,
 };
 use xcm_executor::XcmExecutor;
 
@@ -330,8 +331,10 @@ impl pallet_evm::Config for Runtime {
 
 parameter_types! {
     pub RelayNetwork: Option<NetworkId> = Some(NetworkId::Polkadot);
-    pub const AnyNetwork: Option<NetworkId> = None;
     pub UniversalLocation: InteriorLocation = [GlobalConsensus(RelayNetwork::get().unwrap()), Parachain(123)].into();
+    /// Mirrors `min(HRMP max_message_size, cumulus_pallet_xcmp_queue::Config::MaxPageSize)`: the
+    /// transport refuses anything larger, and it does so after the caller has paid for it.
+    pub const MaxOutboundMessageSize: u32 = 100 * 1024;
     pub Ancestry: Location = Here.into();
     pub UnitWeightCost: u64 = 1_000;
     pub const MaxAssetsIntoHolding: u32 = 64;
@@ -344,9 +347,15 @@ parameter_types! {
 
 pub type Barrier = (
     TakeWeightCredit,
-    AllowTopLevelPaidExecutionFrom<Everything>,
     AllowKnownQueryResponses<XcmPallet>,
-    AllowSubscriptionsFrom<Everything>,
+    WithComputedOrigin<
+        (
+            AllowTopLevelPaidExecutionFrom<Everything>,
+            AllowSubscriptionsFrom<Everything>,
+        ),
+        UniversalLocation,
+        ConstU32<8>,
+    >,
 );
 
 pub struct LocalAssetTransactor;
@@ -398,11 +407,16 @@ impl xcm_executor::Config for XcmConfig {
     type XcmEventEmitter = ();
 }
 
-parameter_types! {
-    pub static AdvertisedXcmVersion: XcmVersion = 3;
+pub type LocalOriginToLocation = SignedToAccountId32<RuntimeOrigin, AccountId, RelayNetwork>;
+
+thread_local! {
+    /// Sibling parachains with no open HRMP channel, for which `send_fragment` returns `NoChannel`.
+    pub static CLOSED_HRMP_CHANNELS: RefCell<Vec<u32>> = RefCell::new(Vec::new());
 }
 
-pub type LocalOriginToLocation = SignedToAccountId32<RuntimeOrigin, AccountId, AnyNetwork>;
+pub(crate) fn close_hrmp_channel(para_id: u32) {
+    CLOSED_HRMP_CHANNELS.with(|c| c.borrow_mut().push(para_id));
+}
 
 thread_local! {
     pub static SENT_XCM: RefCell<Vec<(Location, Xcm<()>)>> = RefCell::new(Vec::new());
@@ -428,10 +442,27 @@ impl SendXcm for StoringRouter {
         destination: &mut Option<Location>,
         message: &mut Option<Xcm<()>>,
     ) -> SendResult<(Location, Xcm<()>)> {
-        Ok((
-            (destination.take().unwrap(), message.take().unwrap()),
-            Assets::new().into(),
-        ))
+        let dest = destination.take().ok_or(SendError::MissingArgument)?;
+
+        match dest.unpack() {
+            (1, []) => {}
+            (1, [Parachain(para_id)]) => {
+                if CLOSED_HRMP_CHANNELS.with(|c| c.borrow().contains(para_id)) {
+                    return Err(SendError::Transport("NoChannel"));
+                }
+            }
+            _ => {
+                *destination = Some(dest);
+                return Err(SendError::NotApplicable);
+            }
+        }
+
+        let msg = message.take().ok_or(SendError::MissingArgument)?;
+        if VersionedXcm::V5(msg.clone()).encode().len() > MaxOutboundMessageSize::get() as usize {
+            return Err(SendError::ExceedsMaxMessageSize);
+        }
+
+        Ok(((dest, msg), Assets::new().into()))
     }
 
     fn deliver(pair: Self::Ticket) -> Result<XcmHash, SendError> {
@@ -448,7 +479,7 @@ impl pallet_xcm::Config for Runtime {
     type ExecuteXcmOrigin = xcm_builder::EnsureXcmOrigin<RuntimeOrigin, LocalOriginToLocation>;
     type XcmExecuteFilter = Nothing;
     type XcmExecutor = XcmExecutor<XcmConfig>;
-    type XcmTeleportFilter = Everything;
+    type XcmTeleportFilter = Nothing;
     type XcmReserveTransferFilter = Everything;
     type Weigher = FixedWeightBounds<BaseXcmWeight, RuntimeCall, MaxInstructions>;
     type UniversalLocation = UniversalLocation;
@@ -456,12 +487,12 @@ impl pallet_xcm::Config for Runtime {
     type RuntimeCall = RuntimeCall;
     const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
 
-    type AdvertisedXcmVersion = AdvertisedXcmVersion;
+    type AdvertisedXcmVersion = pallet_xcm::CurrentXcmVersion;
     type TrustedLockers = ();
     type SovereignAccountOf = ();
     type Currency = Balances;
     type CurrencyMatcher = ();
-    type MaxLockers = frame_support::traits::ConstU32<8>;
+    type MaxLockers = ConstU32<0>;
     type MaxRemoteLockConsumers = ConstU32<0>;
     type RemoteLockConsumerIdentifier = ();
     type WeightInfo = pallet_xcm::TestWeightInfo;

--- a/precompiles/xcm/src/tests.rs
+++ b/precompiles/xcm/src/tests.rs
@@ -23,6 +23,7 @@ use astar_primitives::xcm::ASSET_HUB_PARA_ID;
 use parity_scale_codec::Encode;
 use precompile_utils::testing::*;
 use sp_core::{H160, H256};
+use sp_runtime::traits::TryConvert;
 
 fn precompiles() -> TestPrecompileSet<Runtime> {
     PrecompilesValue::get()
@@ -330,6 +331,19 @@ mod transfer {
         WeightV2::from(3_000_000_000u64, 1024)
     }
 
+    fn destination() -> Location {
+        Location::new(
+            1,
+            [
+                Parachain(10),
+                AccountId32 {
+                    network: None,
+                    id: [1u8; 32],
+                },
+            ],
+        )
+    }
+
     #[test]
     fn sibling_parachain_asset_works() {
         ExtBuilder.build().execute_with(|| {
@@ -522,6 +536,126 @@ mod transfer {
                 .execute_reverts(|output| {
                     output == b"error splitting destination into chain and beneficiary"
                 });
+        });
+    }
+
+    /// A chain and nothing else. The destination would deposit to itself and trap the assets.
+    #[test]
+    fn destination_without_beneficiary_reverts() {
+        ExtBuilder.build().execute_with(|| {
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::transfer {
+                        currency_address: Address::from(NATIVE_ADDRESS),
+                        amount_of_tokens: 42000u64.into(),
+                        destination: Location::new(1, [Parachain(10)]),
+                        weight: weight(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_reverts(|output| {
+                    String::from_utf8_lossy(output).contains("destination carries no beneficiary")
+                });
+
+            assert!(take_sent_xcm().is_empty());
+        });
+    }
+
+    /// Nothing moves, yet the message is still built, sent and paid for on both sides.
+    #[test]
+    fn zero_amount_reverts() {
+        ExtBuilder.build().execute_with(|| {
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::transfer {
+                        currency_address: Address::from(NATIVE_ADDRESS),
+                        amount_of_tokens: 0u64.into(),
+                        destination: destination(),
+                        weight: weight(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_reverts(|output| {
+                    String::from_utf8_lossy(output).contains("amount must be greater than zero")
+                });
+
+            assert!(take_sent_xcm().is_empty());
+        });
+    }
+
+    /// `(0, 0)` is the documented spelling of `Unlimited`. Neither mixed form is reinterpreted:
+    /// one would drop the caller's proof-size limit, the other is overweight on every destination.
+    #[test]
+    fn mixed_zero_weight_reverts() {
+        ExtBuilder.build().execute_with(|| {
+            for (weight, reason) in [
+                (WeightV2::from(0u64, 1024u64), "weight.ref_time is zero"),
+                (
+                    WeightV2::from(3_000_000_000u64, 0u64),
+                    "weight.proof_size is zero",
+                ),
+            ] {
+                let reason = reason.to_string();
+                precompiles()
+                    .prepare_test(
+                        TestAccount::Alice,
+                        PRECOMPILE_ADDRESS,
+                        PrecompileCall::transfer {
+                            currency_address: Address::from(NATIVE_ADDRESS),
+                            amount_of_tokens: 42000u64.into(),
+                            destination: destination(),
+                            weight,
+                        },
+                    )
+                    .expect_no_logs()
+                    .execute_reverts(move |output| {
+                        String::from_utf8_lossy(output).contains(&reason)
+                    });
+            }
+
+            assert!(take_sent_xcm().is_empty());
+        });
+    }
+
+    /// `transfer_with_fee` folds the fee back into the amount
+    #[test]
+    fn with_fee_matches_a_transfer_of_the_total() {
+        ExtBuilder.build().execute_with(|| {
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::transfer {
+                        currency_address: Address::from(Runtime::asset_id_to_address(2u128)),
+                        amount_of_tokens: 42050u64.into(),
+                        destination: destination(),
+                        weight: weight(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_returns(true);
+            let folded = only_sent_xcm();
+
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::transfer_with_fee {
+                        currency_address: Address::from(Runtime::asset_id_to_address(2u128)),
+                        amount_of_tokens: 42000u64.into(),
+                        fee: 50u64.into(),
+                        destination: destination(),
+                        weight: weight(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_returns(true);
+
+            assert_eq!(folded, only_sent_xcm());
         });
     }
 }
@@ -855,6 +989,55 @@ mod multi_asset_selectors {
         });
     }
 
+    /// `Assets` sorts what it is built from, so `fee_item` has to be mapped onto the sorted list
+    /// rather than applied to it. Naming the same currency as the fee must mean the same thing either way round.
+    #[test]
+    fn fee_item_follows_the_callers_order() {
+        ExtBuilder.build().execute_with(|| {
+            // Asset 3 lives one junction deeper than asset 2, so it always sorts second.
+            let currency = |id: u128| -> Currency {
+                (
+                    Address::from(Runtime::asset_id_to_address(id)),
+                    U256::from(42000u64),
+                )
+                    .into()
+            };
+            let call = |currencies: Vec<Currency>, fee_item: u32| {
+                PrecompileCall::transfer_multi_currencies {
+                    currencies: currencies.into(),
+                    fee_item,
+                    destination: destination(),
+                    weight: weight(),
+                }
+            };
+
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    call(vec![currency(3), currency(2)], 0),
+                )
+                .expect_no_logs()
+                .execute_returns(true);
+            let named_first = only_sent_xcm();
+
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    call(vec![currency(2), currency(3)], 1),
+                )
+                .expect_no_logs()
+                .execute_returns(true);
+
+            assert_eq!(
+                named_first,
+                only_sent_xcm(),
+                "asset 3 pays the destination's fees in both, so both must build the same message"
+            );
+        });
+    }
+
     /// The list is still capped at `MAX_ASSETS_FOR_TRANSFER`
     #[test]
     fn cannot_insert_more_than_max() {
@@ -938,16 +1121,16 @@ mod remote_transact {
             let (dest, message) = only_sent_xcm();
             assert_eq!(dest, Location::new(1, [Parachain(10)]));
 
+            let expected =
+                <LocalOriginToLocation as TryConvert<RuntimeOrigin, Location>>::try_convert(
+                    RuntimeOrigin::signed(TestAccount::Alice),
+                )
+                .expect("a signed origin converts");
+
             assert_eq!(
                 message.0.first(),
-                Some(&DescendOrigin(
-                    AccountId32 {
-                        network: Some(NetworkId::Polkadot),
-                        id: [0xAA; 32],
-                    }
-                    .into()
-                )),
-                "the message must open with the caller's `AccountId32`, network included"
+                Some(&DescendOrigin(expected.interior)),
+                "the message must open with the origin `pallet_xcm::send` would have descended"
             );
             assert!(matches!(message.0.get(1), Some(WithdrawAsset(_))));
             assert!(matches!(message.0.get(2), Some(BuyExecution { .. })));
@@ -998,16 +1181,55 @@ mod remote_transact {
             );
         });
     }
+
+    /// The blob is capped here, inside the limit the transport enforces: the outbound page it
+    /// lands in is read and written whole, for a weight benchmarked on a fixed-size message.
+    #[test]
+    fn oversized_call_reverts() {
+        ExtBuilder.build().execute_with(|| {
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::remote_transact_v1 {
+                        para_id: 10u64.into(),
+                        is_relay: false,
+                        fee_asset_addr: Address::from(Runtime::asset_id_to_address(2u128)),
+                        fee_amount: 367.into(),
+                        remote_call: vec![0x11u8; REMOTE_CALL_SIZE_LIMIT as usize + 1].into(),
+                        transact_weight: TRANSACT_WEIGHT,
+                    },
+                )
+                .expect_no_logs()
+                .execute_reverts(|output| {
+                    let error = String::from_utf8_lossy(output);
+                    error.contains("remoteCall") && error.contains("Value is too large for length")
+                });
+
+            assert!(take_sent_xcm().is_empty());
+        });
+    }
+
+    /// The XCMP router opens no channel on demand, so an unreachable sibling fails closed.
+    #[test]
+    fn unopened_channel_reverts() {
+        ExtBuilder.build().execute_with(|| {
+            close_hrmp_channel(11);
+
+            precompiles()
+                .prepare_test(TestAccount::Alice, PRECOMPILE_ADDRESS, call(false, 11))
+                .expect_no_logs()
+                .execute_reverts(|output| output == b"Failed to send xcm");
+
+            assert!(take_sent_xcm().is_empty());
+        });
+    }
 }
 
-/// The three selectors deprecated. They stay registered so the ABI is
-/// unchanged, but every one of them reverts with a reason naming the replacement.
+/// `send_xcm` stays registered so the ABI is unchanged, but an arbitrary XCM to an arbitrary
+/// destination from a signed origin is exactly what `SendXcmOrigin` was locked to `Root` to stop.
 mod unsupported {
     use super::*;
-
-    fn weight() -> WeightV2 {
-        WeightV2::from(3_000_000_000u64, 1024)
-    }
 
     fn parachain_destination() -> Location {
         Location::new(
@@ -1045,38 +1267,6 @@ mod unsupported {
                     xcm_call: message.encode().into(),
                 },
                 "send_xcm is not supported",
-            );
-        });
-    }
-
-    #[test]
-    fn transfer_with_fee_reverts() {
-        ExtBuilder.build().execute_with(|| {
-            assert_reverts(
-                PrecompileCall::transfer_with_fee {
-                    currency_address: Address::from(Runtime::asset_id_to_address(2u128)),
-                    amount_of_tokens: 42000u64.into(),
-                    fee: 50u64.into(),
-                    destination: parachain_destination(),
-                    weight: weight(),
-                },
-                "a separate fee amount of the same asset is not supported",
-            );
-        });
-    }
-
-    #[test]
-    fn transfer_multiasset_with_fee_reverts() {
-        ExtBuilder.build().execute_with(|| {
-            assert_reverts(
-                PrecompileCall::transfer_multiasset_with_fee {
-                    asset_location: Location::new(1, [Parachain(10)]),
-                    amount_of_tokens: 42000u64.into(),
-                    fee: 50u64.into(),
-                    destination: parachain_destination(),
-                    weight: weight(),
-                },
-                "a separate fee amount of the same asset is not supported",
             );
         });
     }

--- a/precompiles/xcm/src/tests.rs
+++ b/precompiles/xcm/src/tests.rs
@@ -39,6 +39,17 @@ fn beneficiary_32(byte: u8) -> Location {
     )
 }
 
+/// `AccountKey20` beneficiary, as the precompile builds it from a raw `address`.
+fn beneficiary_key_20(byte: u8) -> Location {
+    Location::new(
+        0,
+        [AccountKey20 {
+            network: None,
+            key: [byte; 20],
+        }],
+    )
+}
+
 /// The single XCM the mock router recorded, panicking if there isn't exactly one.
 fn only_sent_xcm() -> (Location, Xcm<()>) {
     let mut sent = take_sent_xcm();
@@ -515,11 +526,483 @@ mod transfer {
     }
 }
 
-/// The ten selectors that were backed by `orml-xtokens` and saw no traffic on any network.
-///
-/// They stay registered so the precompile's ABI is unchanged, but every one of them must revert
-/// with the shared deprecation notice rather than silently doing something unexpected.
-mod deprecated {
+mod assets_reserve_transfer {
+    use super::*;
+
+    /// The native token, addressed by the zero address, to an `AccountId32` on Bifrost.
+    #[test]
+    fn native_asset_to_sibling_works() {
+        ExtBuilder.build().execute_with(|| {
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::assets_reserve_transfer_native_v1 {
+                        assets: vec![Address::from(NATIVE_ADDRESS)].into(),
+                        amounts: vec![42000u64.into()].into(),
+                        recipient_account_id: H256::repeat_byte(0xF1),
+                        is_relay: false,
+                        parachain_id: 2030.into(),
+                        fee_index: 0.into(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_returns(true);
+
+            let (dest, message) = only_sent_xcm();
+            assert_eq!(dest, Location::new(1, [Parachain(2030)]));
+            assert_deposits_to(&message, &beneficiary_32(0xF1));
+        });
+    }
+
+    /// On XC20 assets the two names agree
+    #[test]
+    fn matches_assets_withdraw_for_xc20() {
+        ExtBuilder.build().execute_with(|| {
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::assets_withdraw_native_v1 {
+                        assets: vec![Address::from(Runtime::asset_id_to_address(2u128))].into(),
+                        amounts: vec![42000u64.into()].into(),
+                        recipient_account_id: H256::repeat_byte(0xF1),
+                        is_relay: false,
+                        parachain_id: 10.into(),
+                        fee_index: 0.into(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_returns(true);
+            let withdrawn = only_sent_xcm();
+
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::assets_reserve_transfer_native_v1 {
+                        assets: vec![Address::from(Runtime::asset_id_to_address(2u128))].into(),
+                        amounts: vec![42000u64.into()].into(),
+                        recipient_account_id: H256::repeat_byte(0xF1),
+                        is_relay: false,
+                        parachain_id: 10.into(),
+                        fee_index: 0.into(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_returns(true);
+
+            assert_eq!(withdrawn, only_sent_xcm());
+        });
+    }
+
+    /// ...and differ on exactly one thing, as they always have: `assets_withdraw` does not read
+    /// the zero address as the native token, so an uninitialised address stays a revert there.
+    #[test]
+    fn zero_address_is_native_here_but_not_in_assets_withdraw() {
+        ExtBuilder.build().execute_with(|| {
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::assets_withdraw_native_v1 {
+                        assets: vec![Address::from(NATIVE_ADDRESS)].into(),
+                        amounts: vec![42000u64.into()].into(),
+                        recipient_account_id: H256::repeat_byte(0xF1),
+                        is_relay: false,
+                        parachain_id: 2030.into(),
+                        fee_index: 0.into(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_reverts(|output| {
+                    String::from_utf8_lossy(output).contains("Assets resolution failure.")
+                });
+
+            assert!(take_sent_xcm().is_empty());
+        });
+    }
+
+    /// The `address` overloads deposit to an `AccountKey20` on the destination.
+    #[test]
+    fn evm_beneficiary_works() {
+        ExtBuilder.build().execute_with(|| {
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::assets_reserve_transfer_evm_v1 {
+                        assets: vec![Address::from(Runtime::asset_id_to_address(2u128))].into(),
+                        amounts: vec![42000u64.into()].into(),
+                        recipient_account_id: Address(H160::repeat_byte(0xDE)),
+                        is_relay: false,
+                        parachain_id: 10.into(),
+                        fee_index: 0.into(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_returns(true);
+
+            let (dest, message) = only_sent_xcm();
+            assert_eq!(dest, Location::new(1, [Parachain(10)]));
+            assert_deposits_to(&message, &beneficiary_key_20(0xDE));
+
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::assets_withdraw_evm_v1 {
+                        assets: vec![Address::from(Runtime::asset_id_to_address(2u128))].into(),
+                        amounts: vec![42000u64.into()].into(),
+                        recipient_account_id: Address(H160::repeat_byte(0xDE)),
+                        is_relay: false,
+                        parachain_id: 10.into(),
+                        fee_index: 0.into(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_returns(true);
+
+            let (_, withdrawn) = only_sent_xcm();
+            assert_deposits_to(&withdrawn, &beneficiary_key_20(0xDE));
+        });
+    }
+
+    /// The native token asked to the relay is delivered to Asset Hub instead, on both overloads
+    /// The relay holds no reserve for it, so sending it there directly would strand the assets.
+    #[test]
+    fn native_asset_to_relay_goes_through_asset_hub() {
+        ExtBuilder.build().execute_with(|| {
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::assets_reserve_transfer_native_v1 {
+                        assets: vec![Address::from(NATIVE_ADDRESS)].into(),
+                        amounts: vec![42000u64.into()].into(),
+                        recipient_account_id: H256::repeat_byte(0xF1),
+                        is_relay: true,
+                        parachain_id: 0.into(),
+                        fee_index: 0.into(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_returns(true);
+
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::assets_reserve_transfer_evm_v1 {
+                        assets: vec![Address::from(NATIVE_ADDRESS)].into(),
+                        amounts: vec![42000u64.into()].into(),
+                        recipient_account_id: Address(H160::repeat_byte(0xDE)),
+                        is_relay: true,
+                        parachain_id: 0.into(),
+                        fee_index: 0.into(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_returns(true);
+
+            let sent = take_sent_xcm();
+            assert_eq!(sent.len(), 2);
+            for (dest, _) in sent {
+                assert_eq!(dest, Location::new(1, [Parachain(ASSET_HUB_PARA_ID)]));
+            }
+        });
+    }
+}
+
+mod multi_asset_selectors {
+    use super::*;
+
+    fn weight() -> WeightV2 {
+        WeightV2::from(3_000_000_000u64, 1024)
+    }
+
+    fn destination() -> Location {
+        Location::new(
+            1,
+            [
+                Parachain(10),
+                AccountId32 {
+                    network: None,
+                    id: [1u8; 32],
+                },
+            ],
+        )
+    }
+
+    /// `transfer_multiasset` is `transfer` with the asset named by location.
+    #[test]
+    fn transfer_multiasset_matches_transfer() {
+        ExtBuilder.build().execute_with(|| {
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::transfer {
+                        currency_address: Address::from(Runtime::asset_id_to_address(2u128)),
+                        amount_of_tokens: 42000u64.into(),
+                        destination: destination(),
+                        weight: weight(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_returns(true);
+            let by_address = only_sent_xcm();
+
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::transfer_multiasset {
+                        // asset 2 is registered at `(1, Parachain(10))`
+                        asset_location: Location::new(1, [Parachain(10)]),
+                        amount_of_tokens: 42000u64.into(),
+                        destination: destination(),
+                        weight: weight(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_returns(true);
+
+            assert_eq!(by_address, only_sent_xcm());
+        });
+    }
+
+    #[test]
+    fn transfer_multi_currencies_works() {
+        ExtBuilder.build().execute_with(|| {
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::transfer_multi_currencies {
+                        currencies: vec![(
+                            Address::from(Runtime::asset_id_to_address(2u128)),
+                            U256::from(42000u64),
+                        )
+                            .into()]
+                        .into(),
+                        fee_item: 0,
+                        destination: destination(),
+                        weight: weight(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_returns(true);
+
+            let (dest, message) = only_sent_xcm();
+            assert_eq!(dest, Location::new(1, [Parachain(10)]));
+            assert_deposits_to(&message, &beneficiary_32(1));
+        });
+    }
+
+    #[test]
+    fn transfer_multi_assets_works() {
+        ExtBuilder.build().execute_with(|| {
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::transfer_multi_assets {
+                        assets: vec![
+                            (Location::new(1, [Parachain(10)]), U256::from(42000u64)).into()
+                        ]
+                        .into(),
+                        fee_item: 0,
+                        destination: destination(),
+                        weight: weight(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_returns(true);
+
+            let (dest, message) = only_sent_xcm();
+            assert_eq!(dest, Location::new(1, [Parachain(10)]));
+            assert_deposits_to(&message, &beneficiary_32(1));
+        });
+    }
+
+    /// `fee_item` indexes the sorted list, so an unsorted one is rejected rather than silently
+    /// charging fees to the wrong asset.
+    #[test]
+    fn transfer_multi_assets_rejects_unsorted() {
+        ExtBuilder.build().execute_with(|| {
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::transfer_multi_assets {
+                        assets: vec![
+                            (Location::new(1, [Parachain(20)]), U256::from(1u64)).into(),
+                            (Location::new(1, [Parachain(10)]), U256::from(1u64)).into(),
+                        ]
+                        .into(),
+                        fee_item: 0,
+                        destination: destination(),
+                        weight: weight(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_reverts(|output| {
+                    String::from_utf8_lossy(output).contains("not sorted nor deduplicated")
+                });
+
+            assert!(take_sent_xcm().is_empty());
+        });
+    }
+
+    /// The list is still capped at `MAX_ASSETS_FOR_TRANSFER`
+    #[test]
+    fn cannot_insert_more_than_max() {
+        ExtBuilder.build().execute_with(|| {
+            let currency = |id: u128| -> Currency {
+                (
+                    Address::from(Runtime::asset_id_to_address(id)),
+                    U256::from(1u64),
+                )
+                    .into()
+            };
+
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::transfer_multi_currencies {
+                        currencies: vec![currency(1), currency(2), currency(3)].into(),
+                        fee_item: 0,
+                        destination: destination(),
+                        weight: weight(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_reverts(|output| {
+                    String::from_utf8_lossy(output).contains("Value is too large for length")
+                });
+
+            let asset = |para: u32| -> EvmMultiAsset {
+                (Location::new(1, [Parachain(para)]), U256::from(1u64)).into()
+            };
+
+            precompiles()
+                .prepare_test(
+                    TestAccount::Alice,
+                    PRECOMPILE_ADDRESS,
+                    PrecompileCall::transfer_multi_assets {
+                        assets: vec![asset(10), asset(20), asset(30)].into(),
+                        fee_item: 0,
+                        destination: destination(),
+                        weight: weight(),
+                    },
+                )
+                .expect_no_logs()
+                .execute_reverts(|output| {
+                    String::from_utf8_lossy(output).contains("Value is too large for length")
+                });
+
+            assert!(take_sent_xcm().is_empty());
+        });
+    }
+}
+
+mod remote_transact {
+    use super::*;
+
+    const CALL: [u8; 4] = [0xff, 0xaa, 0x77, 0x00];
+    const TRANSACT_WEIGHT: u64 = 3_000_000_000;
+
+    fn call(is_relay: bool, para_id: u64) -> PrecompileCall {
+        PrecompileCall::remote_transact_v1 {
+            para_id: para_id.into(),
+            is_relay,
+            fee_asset_addr: Address::from(Runtime::asset_id_to_address(2u128)),
+            fee_amount: 367.into(),
+            remote_call: CALL.to_vec().into(),
+            transact_weight: TRANSACT_WEIGHT,
+        }
+    }
+
+    /// The caller is descended into the origin exactly as `pallet_xcm::send` did for a signed
+    /// origin, so the account the destination derives does not move.
+    #[test]
+    fn sibling_transact_descends_the_caller() {
+        ExtBuilder.build().execute_with(|| {
+            precompiles()
+                .prepare_test(TestAccount::Alice, PRECOMPILE_ADDRESS, call(false, 10))
+                .expect_no_logs()
+                .execute_returns(true);
+
+            let (dest, message) = only_sent_xcm();
+            assert_eq!(dest, Location::new(1, [Parachain(10)]));
+
+            assert_eq!(
+                message.0.first(),
+                Some(&DescendOrigin(
+                    AccountId32 {
+                        network: Some(NetworkId::Polkadot),
+                        id: [0xAA; 32],
+                    }
+                    .into()
+                )),
+                "the message must open with the caller's `AccountId32`, network included"
+            );
+            assert!(matches!(message.0.get(1), Some(WithdrawAsset(_))));
+            assert!(matches!(message.0.get(2), Some(BuyExecution { .. })));
+            assert_eq!(
+                message.0.get(3),
+                Some(&Transact {
+                    origin_kind: OriginKind::SovereignAccount,
+                    fallback_max_weight: Some(Weight::from_parts(
+                        TRANSACT_WEIGHT,
+                        DEFAULT_PROOF_SIZE
+                    )),
+                    call: CALL.to_vec().into(),
+                })
+            );
+        });
+    }
+
+    /// The mock mirrors the runtimes: `pallet_xcm::send` is `Root`-only.
+    #[test]
+    fn pallet_xcm_send_is_root_only_in_the_mock() {
+        ExtBuilder.build().execute_with(|| {
+            frame_support::assert_noop!(
+                pallet_xcm::Pallet::<Runtime>::send(
+                    RuntimeOrigin::signed(TestAccount::Alice),
+                    Box::new(Location::new(1, [Parachain(10)]).into_versioned()),
+                    Box::new(xcm::VersionedXcm::V5(Xcm(vec![ClearOrigin]))),
+                ),
+                sp_runtime::DispatchError::BadOrigin
+            );
+        });
+    }
+
+    /// UMP is `Root`-only for a reason - the EVM must not be able to reach it at all.
+    #[test]
+    fn relay_destination_reverts() {
+        ExtBuilder.build().execute_with(|| {
+            precompiles()
+                .prepare_test(TestAccount::Alice, PRECOMPILE_ADDRESS, call(true, 0))
+                .expect_no_logs()
+                .execute_reverts(|output| {
+                    String::from_utf8_lossy(output)
+                        .contains("remote_transact to the relay chain is not supported")
+                });
+
+            assert!(
+                take_sent_xcm().is_empty(),
+                "a relay-bound remote_transact must not send any XCM"
+            );
+        });
+    }
+}
+
+/// The three selectors deprecated. They stay registered so the ABI is
+/// unchanged, but every one of them reverts with a reason naming the replacement.
+mod unsupported {
     use super::*;
 
     fn weight() -> WeightV2 {
@@ -539,151 +1022,62 @@ mod deprecated {
         )
     }
 
-    fn assert_deprecated(call: PrecompileCall) {
+    fn assert_reverts(call: PrecompileCall, reason: &str) {
+        let reason = reason.to_string();
         precompiles()
             .prepare_test(TestAccount::Alice, PRECOMPILE_ADDRESS, call)
             .expect_no_logs()
-            .execute_reverts(|output| {
-                String::from_utf8_lossy(output).contains("deprecated: xtokens has been removed")
-            });
+            .execute_reverts(move |output| String::from_utf8_lossy(output).contains(&reason));
 
         assert!(
             take_sent_xcm().is_empty(),
-            "a deprecated method must not send any XCM"
+            "an unsupported method must not send any XCM"
         );
-    }
-
-    #[test]
-    fn assets_withdraw_evm_v1_reverts() {
-        ExtBuilder.build().execute_with(|| {
-            assert_deprecated(PrecompileCall::assets_withdraw_evm_v1 {
-                assets: vec![Address::from(Runtime::asset_id_to_address(2u128))].into(),
-                amounts: vec![42000u64.into()].into(),
-                recipient_account_id: Address(H160::repeat_byte(0xDE)),
-                is_relay: false,
-                parachain_id: 10.into(),
-                fee_index: 0.into(),
-            });
-        });
-    }
-
-    #[test]
-    fn remote_transact_v1_reverts() {
-        ExtBuilder.build().execute_with(|| {
-            assert_deprecated(PrecompileCall::remote_transact_v1 {
-                para_id: 0.into(),
-                is_relay: true,
-                fee_asset_addr: Address::from(Runtime::asset_id_to_address(1u128)),
-                fee_amount: 367.into(),
-                remote_call: vec![0xff_u8, 0xaa, 0x77, 0x00].into(),
-                transact_weight: 3_000_000_000u64,
-            });
-        });
-    }
-
-    #[test]
-    fn assets_reserve_transfer_native_v1_reverts() {
-        ExtBuilder.build().execute_with(|| {
-            assert_deprecated(PrecompileCall::assets_reserve_transfer_native_v1 {
-                assets: vec![Address::from(Runtime::asset_id_to_address(2u128))].into(),
-                amounts: vec![42000u64.into()].into(),
-                recipient_account_id: H256::repeat_byte(0xF1),
-                is_relay: false,
-                parachain_id: 10.into(),
-                fee_index: 0.into(),
-            });
-        });
-    }
-
-    #[test]
-    fn assets_reserve_transfer_evm_v1_reverts() {
-        ExtBuilder.build().execute_with(|| {
-            assert_deprecated(PrecompileCall::assets_reserve_transfer_evm_v1 {
-                assets: vec![Address::from(Runtime::asset_id_to_address(2u128))].into(),
-                amounts: vec![42000u64.into()].into(),
-                recipient_account_id: Address(H160::repeat_byte(0xDE)),
-                is_relay: false,
-                parachain_id: 10.into(),
-                fee_index: 0.into(),
-            });
-        });
     }
 
     #[test]
     fn send_xcm_reverts() {
         ExtBuilder.build().execute_with(|| {
             let message: Xcm<()> = Xcm(vec![ClearOrigin]);
-            assert_deprecated(PrecompileCall::send_xcm {
-                dest: Location::parent(),
-                xcm_call: xcm::VersionedXcm::V5(message).encode().into(),
-            });
+            assert_reverts(
+                PrecompileCall::send_xcm {
+                    dest: parachain_destination(),
+                    xcm_call: message.encode().into(),
+                },
+                "send_xcm is not supported",
+            );
         });
     }
 
     #[test]
     fn transfer_with_fee_reverts() {
         ExtBuilder.build().execute_with(|| {
-            assert_deprecated(PrecompileCall::transfer_with_fee {
-                currency_address: Address::from(Runtime::asset_id_to_address(2u128)),
-                amount_of_tokens: 42000u64.into(),
-                fee: 100u64.into(),
-                destination: parachain_destination(),
-                weight: weight(),
-            });
-        });
-    }
-
-    #[test]
-    fn transfer_multiasset_reverts() {
-        ExtBuilder.build().execute_with(|| {
-            assert_deprecated(PrecompileCall::transfer_multiasset {
-                asset_location: Location::new(1, [Parachain(10)]),
-                amount_of_tokens: 42000u64.into(),
-                destination: parachain_destination(),
-                weight: weight(),
-            });
+            assert_reverts(
+                PrecompileCall::transfer_with_fee {
+                    currency_address: Address::from(Runtime::asset_id_to_address(2u128)),
+                    amount_of_tokens: 42000u64.into(),
+                    fee: 50u64.into(),
+                    destination: parachain_destination(),
+                    weight: weight(),
+                },
+                "a separate fee amount of the same asset is not supported",
+            );
         });
     }
 
     #[test]
     fn transfer_multiasset_with_fee_reverts() {
         ExtBuilder.build().execute_with(|| {
-            assert_deprecated(PrecompileCall::transfer_multiasset_with_fee {
-                asset_location: Location::new(1, [Parachain(10)]),
-                amount_of_tokens: 42000u64.into(),
-                fee: 100u64.into(),
-                destination: parachain_destination(),
-                weight: weight(),
-            });
-        });
-    }
-
-    #[test]
-    fn transfer_multi_currencies_reverts() {
-        ExtBuilder.build().execute_with(|| {
-            assert_deprecated(PrecompileCall::transfer_multi_currencies {
-                currencies: vec![(
-                    Address::from(Runtime::asset_id_to_address(2u128)),
-                    42000.into(),
-                )
-                    .into()]
-                .into(),
-                fee_item: 0u32,
-                destination: parachain_destination(),
-                weight: weight(),
-            });
-        });
-    }
-
-    #[test]
-    fn transfer_multi_assets_reverts() {
-        ExtBuilder.build().execute_with(|| {
-            assert_deprecated(PrecompileCall::transfer_multi_assets {
-                assets: vec![(Location::new(1, [Parachain(10)]), 42000.into()).into()].into(),
-                fee_item: 0u32,
-                destination: parachain_destination(),
-                weight: weight(),
-            });
+            assert_reverts(
+                PrecompileCall::transfer_multiasset_with_fee {
+                    asset_location: Location::new(1, [Parachain(10)]),
+                    amount_of_tokens: 42000u64.into(),
+                    fee: 50u64.into(),
+                    destination: parachain_destination(),
+                    weight: weight(),
+                },
+                "a separate fee amount of the same asset is not supported",
+            );
         });
     }
 }

--- a/primitives/src/xcm/mod.rs
+++ b/primitives/src/xcm/mod.rs
@@ -300,9 +300,6 @@ pub fn split_location_into_chain_part_and_beneficiary(
 /// rather than the relay chain. For any destination other than Asset Hub itself the executor gives
 /// up, so we name Asset Hub as a remote reserve explicitly.
 ///
-/// This mirrors the routing that `orml-xtokens` derived from its `AbsoluteAndRelativeReserveProvider`,
-/// so EVM callers see the same behaviour after the pallet's removal.
-///
 /// Returns `None` when no reserve can be determined - the caller should reject the transfer.
 pub fn resolve_transfer_type<XcmExecutor: XcmAssetTransfers>(
     asset: &Asset,


### PR DESCRIPTION
# Pull Request Summary

This PR reimplements the XCM precompile on `pallet_xcm` without xtokens and ORML deps.
